### PR TITLE
[SG-183] Add-drop widget

### DIFF
--- a/config/core.entity_form_display.node.transaction.default.yml
+++ b/config/core.entity_form_display.node.transaction.default.yml
@@ -30,6 +30,7 @@ dependencies:
     - maxlength
     - paragraphs
     - path
+    - sfgov_admin
     - text
 third_party_settings:
   field_group:
@@ -187,7 +188,7 @@ content:
     type: link_default
     region: content
   field_help:
-    type: paragraphs
+    type: sfgov_paragraphs
     weight: 16
     settings:
       title: Paragraph
@@ -195,13 +196,13 @@ content:
       edit_mode: closed
       closed_mode: preview
       autocollapse: all
-      add_mode: dropdown
+      add_mode: dropdown_custom
       form_display_mode: default
       default_paragraph_type: _none
       features:
         duplicate: duplicate
         collapse_edit_all: collapse_edit_all
-        add_above: '0'
+        add_above: 0
     third_party_settings: {  }
     region: content
   field_special_cases:
@@ -223,7 +224,7 @@ content:
     third_party_settings: {  }
     region: content
   field_step_email:
-    type: paragraphs
+    type: sfgov_paragraphs
     weight: 16
     settings:
       title: Paragraph
@@ -231,17 +232,17 @@ content:
       edit_mode: closed
       closed_mode: preview
       autocollapse: all
-      add_mode: dropdown
+      add_mode: dropdown_custom
       form_display_mode: default
       default_paragraph_type: _none
       features:
         duplicate: duplicate
         collapse_edit_all: collapse_edit_all
-        add_above: '0'
+        add_above: 0
     third_party_settings: {  }
     region: content
   field_step_fax:
-    type: paragraphs
+    type: sfgov_paragraphs
     weight: 19
     settings:
       title: Paragraph
@@ -249,17 +250,17 @@ content:
       edit_mode: closed
       closed_mode: preview
       autocollapse: all
-      add_mode: dropdown
+      add_mode: dropdown_custom
       form_display_mode: default
       default_paragraph_type: _none
       features:
         duplicate: duplicate
         collapse_edit_all: collapse_edit_all
-        add_above: '0'
+        add_above: 0
     third_party_settings: {  }
     region: content
   field_step_in_person:
-    type: paragraphs
+    type: sfgov_paragraphs
     weight: 17
     settings:
       title: Paragraph
@@ -267,17 +268,17 @@ content:
       edit_mode: closed
       closed_mode: preview
       autocollapse: all
-      add_mode: dropdown
+      add_mode: dropdown_custom
       form_display_mode: default
       default_paragraph_type: _none
       features:
         duplicate: duplicate
         collapse_edit_all: collapse_edit_all
-        add_above: '0'
+        add_above: 0
     third_party_settings: {  }
     region: content
   field_step_mail:
-    type: paragraphs
+    type: sfgov_paragraphs
     weight: 18
     settings:
       title: Paragraph
@@ -285,17 +286,17 @@ content:
       edit_mode: closed
       closed_mode: preview
       autocollapse: all
-      add_mode: dropdown
+      add_mode: dropdown_custom
       form_display_mode: default
       default_paragraph_type: _none
       features:
         duplicate: duplicate
         collapse_edit_all: collapse_edit_all
-        add_above: '0'
+        add_above: 0
     third_party_settings: {  }
     region: content
   field_step_online:
-    type: paragraphs
+    type: sfgov_paragraphs
     weight: 14
     settings:
       title: Paragraph
@@ -303,13 +304,13 @@ content:
       edit_mode: closed
       closed_mode: preview
       autocollapse: all
-      add_mode: dropdown
+      add_mode: dropdown_custom
       form_display_mode: default
       default_paragraph_type: _none
       features:
         duplicate: duplicate
         collapse_edit_all: collapse_edit_all
-        add_above: '0'
+        add_above: 0
     third_party_settings: {  }
     region: content
   field_step_other:
@@ -339,7 +340,7 @@ content:
     type: string_textfield
     region: content
   field_step_phone:
-    type: paragraphs
+    type: sfgov_paragraphs
     weight: 15
     settings:
       title: Paragraph
@@ -347,13 +348,13 @@ content:
       edit_mode: closed
       closed_mode: preview
       autocollapse: all
-      add_mode: dropdown
+      add_mode: dropdown_custom
       form_display_mode: default
       default_paragraph_type: _none
       features:
         duplicate: duplicate
         collapse_edit_all: collapse_edit_all
-        add_above: '0'
+        add_above: 0
     third_party_settings: {  }
     region: content
   field_things_to_know:

--- a/config/core.entity_form_display.paragraph.section.default.yml
+++ b/config/core.entity_form_display.paragraph.section.default.yml
@@ -9,7 +9,7 @@ dependencies:
     - paragraphs.paragraphs_type.section
   module:
     - link
-    - paragraphs
+    - sfgov_admin
 id: paragraph.section.default
 targetEntityType: paragraph
 bundle: section
@@ -23,15 +23,15 @@ content:
       edit_mode: closed
       closed_mode: preview
       autocollapse: all
-      add_mode: dropdown
+      add_mode: dropdown_custom
       form_display_mode: default
       default_paragraph_type: _none
       features:
         duplicate: duplicate
         collapse_edit_all: collapse_edit_all
-        add_above: '0'
+        add_above: 0
     third_party_settings: {  }
-    type: paragraphs
+    type: sfgov_paragraphs
     region: content
   field_link:
     weight: 3

--- a/tests/features/bootstrap/FeatureContext.php
+++ b/tests/features/bootstrap/FeatureContext.php
@@ -64,7 +64,7 @@ class FeatureContext extends RawDrupalContext implements Context, SnippetAccepti
    * @Then /^(?:|I )should see a button labeled "(?P<text>(?:[^"]|\\")*)"$/
    */
   public function assertPageContainsButtonLable($label) {
-    $this->assertSession()->responseMatches('/<input.*type="submit".*value=".*'.preg_quote($label, '/').'.*"/Uui');
+    $this->assertSession()->responseMatches('/<input[^>]*type="submit"[^>]*value="('. preg_quote($label, '/') .')"[^>]*>/i');
   }
 
   /**

--- a/tests/features/bootstrap/FeatureContext.php
+++ b/tests/features/bootstrap/FeatureContext.php
@@ -45,7 +45,29 @@ class FeatureContext extends RawDrupalContext implements Context, SnippetAccepti
 //  }
 //
 
-    /**
+  /**
+   * Checks whether last command output contains provided button label.
+   *
+   * Example: I should see a button link labeled "Go"
+   *
+   * @Then /^(?:|I )should see a button link labeled "(?P<text>(?:[^"]|\\")*)"$/
+   */
+  public function assertPageContainsLinkLable($label) {
+    $this->assertSession()->elementTextContains('css', 'ul.dropbutton li a', $this->fixStepArgument($label));
+  }
+
+  /**
+   * Checks whether last command output contains provided button label.
+   *
+   * Example: I should see a button labeled "Submit"
+   *
+   * @Then /^(?:|I )should see a button labeled "(?P<text>(?:[^"]|\\")*)"$/
+   */
+  public function assertPageContainsButtonLable($label) {
+    $this->assertSession()->responseMatches('/<input.*type="submit".*value=".*'.preg_quote($label, '/').'.*"/Uui');
+  }
+
+  /**
      * Fills in form field with specified id|name|label|value
      * Example: And I enter the value of the env var "TEST_PASSWORD" for "edit-account-pass-pass1"
      *
@@ -247,4 +269,16 @@ class FeatureContext extends RawDrupalContext implements Context, SnippetAccepti
         $html = preg_replace('#\</title\>.*\</head\>#sU', '</title></head>', $html);
         return $html;
     }
+
+  /**
+   * Returns fixed step argument (with \\" replaced back to ")
+   *
+   * @param string $argument
+   *
+   * @return string
+   */
+  protected function fixStepArgument($argument)
+  {
+    return str_replace('\\"', '"', $argument);
+  }
 }

--- a/tests/features/content.feature
+++ b/tests/features/content.feature
@@ -34,10 +34,11 @@ Feature: Content
     And  I am logged in as a user with the "administrator" role
     When I go to "node/add/landing"
     Then I should see a button link labeled "Add"
-    And  I should see a button labeled "Block"
-    And  I should see a button labeled "Button link"
-    And  I should see a button labeled "List"
-    And  I should see a button labeled "Text"
+    # The leading space in the following values is actualy UTF-8 `0xC2:0xA0` (non breaking space).
+    And  I should see a button labeled " Block"
+    And  I should see a button labeled " Button link"
+    And  I should see a button labeled " List"
+    And  I should see a button labeled " Text"
     And  I should not see "to Section Content"
 
 # Setting the body field contents does not seem to be effective

--- a/tests/features/content.feature
+++ b/tests/features/content.feature
@@ -29,6 +29,17 @@ Feature: Content
     And I should see "First article"
     And I should see "Second article"
 
+  @api
+  Scenario: Add widget
+    And  I am logged in as a user with the "administrator" role
+    When I go to "node/add/landing"
+    Then I should see a button link labeled "Add"
+    And  I should see a button labeled "Block"
+    And  I should see a button labeled "Button link"
+    And  I should see a button labeled "List"
+    And  I should see a button labeled "Text"
+    And  I should not see "to Section Content"
+
 # Setting the body field contents does not seem to be effective
 
 #  @api

--- a/web/modules/custom/sfgov_admin/js/dist/sfgov-admin.js
+++ b/web/modules/custom/sfgov_admin/js/dist/sfgov-admin.js
@@ -50,5 +50,13 @@
       });
     }
   };
+  Drupal.behaviors.sfgovParagraphAddDropbutton = {
+    attach: function (context) {
+      // The add button is just a placeholder for the add buttons. Clicking it should have no affect.
+      $('.sfgov-admin-paragraph-add-link', context)
+        .once()
+        .on('click', function (event) { event.preventDefault(); });
+    }
+  };
 })(jQuery, Drupal, document, window);
 //# sourceMappingURL=sfgov-admin.js.map

--- a/web/modules/custom/sfgov_admin/js/src/sfgov-admin.js
+++ b/web/modules/custom/sfgov_admin/js/src/sfgov-admin.js
@@ -54,5 +54,13 @@
 
     }
   };
+  Drupal.behaviors.sfgovParagraphAddDropbutton = {
+    attach: function (context) {
+      // The add button is just a placeholder for the add buttons. Clicking it should have no affect.
+      $('.sfgov-admin-paragraph-add-link', context)
+        .once()
+        .on('click', function (event) { event.preventDefault(); });
+    }
+  };
 
 }(jQuery, Drupal, document, window));

--- a/web/modules/custom/sfgov_admin/src/Plugin/Field/FieldWidget/SfgovParagraphsWidget.php
+++ b/web/modules/custom/sfgov_admin/src/Plugin/Field/FieldWidget/SfgovParagraphsWidget.php
@@ -10,7 +10,7 @@ use Drupal\paragraphs\Plugin\Field\FieldWidget\ParagraphsWidget;
  *
  * @FieldWidget(
  *   id = "sfgov_paragraphs",
- *   label = @Translation("Paragraphs EXPERIMENTAL (Custom)"),
+ *   label = @Translation("Paragraphs EXPERIMENTAL (SF.gov)"),
  *   description = @Translation("An custom experimental paragraphs inline form widget."),
  *   field_types = {
  *     "entity_reference_revisions"
@@ -75,6 +75,7 @@ class SfgovParagraphsWidget extends ParagraphsWidget {
         $elements[$button_key]['#value'] = $this->t('&nbsp;@type', ['@type' => $label]);
       }
       $elements = $this->buildDropbutton($elements);
+      // Adds an "Add" button to the top of the list.
       $elements["operations"]["#links"] = ['add_label' => [
         'title' => [
           '#type' => 'link',
@@ -92,7 +93,6 @@ class SfgovParagraphsWidget extends ParagraphsWidget {
           '#attached' => ['library' => ['sfgov_admin/paragraphs']],
           ],
         ]] + $elements["operations"]["#links"];
-      $elements['#suffix'] = $this->t('to %type', ['%type' => $this->fieldDefinition->getLabel()]);
     }
 
     return $elements;

--- a/web/modules/custom/sfgov_admin/src/Plugin/Field/FieldWidget/SfgovParagraphsWidget.php
+++ b/web/modules/custom/sfgov_admin/src/Plugin/Field/FieldWidget/SfgovParagraphsWidget.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Drupal\sfgov_admin\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Url;
+use Drupal\paragraphs\Plugin\Field\FieldWidget\ParagraphsWidget;
+
+/**
+ * Plugin implementation of the 'entity_reference_revisions paragraphs' widget.
+ *
+ * @FieldWidget(
+ *   id = "sfgov_paragraphs",
+ *   label = @Translation("Paragraphs EXPERIMENTAL (Custom)"),
+ *   description = @Translation("An custom experimental paragraphs inline form widget."),
+ *   field_types = {
+ *     "entity_reference_revisions"
+ *   }
+ * )
+ */
+class SfgovParagraphsWidget extends ParagraphsWidget {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getSettingOptions($setting_name) {
+    $options = parent::getSettingOptions($setting_name);
+
+    // Add our custom dropbutton options.
+    if ($setting_name == 'add_mode' && isset($options)) {
+      $options['dropdown_custom'] = $this->t('Add drop button');
+    }
+
+    return isset($options) ? $options : NULL;
+  }
+
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function buildAddActions() {
+    if ($this->getSetting('add_mode') !== 'dropdown_custom') {
+      return parent::buildAddActions();
+    }
+
+    if (count($this->getAccessibleOptions()) === 0) {
+      if (count($this->getAllowedTypes()) === 0) {
+        $add_more_elements['icons'] = $this->createMessage($this->t('You are not allowed to add any of the @title types.', ['@title' => $this->getSetting('title')]));
+      }
+      else {
+        $add_more_elements['icons'] = $this->createMessage($this->t('You did not add any @title types yet.', ['@title' => $this->getSetting('title')]));
+      }
+
+      return $add_more_elements;
+    }
+
+    return $this->buildButtonsAddMode();
+  }
+
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function buildButtonsAddMode() {
+    // Build the button list.
+    $elements = parent::buildButtonsAddMode();
+
+    // Check the add mode.
+    if ($this->getSetting('add_mode') == 'dropdown_custom') {
+      // Get the add button options.
+      $options = $this->getAccessibleOptions();
+
+      // Remove "Add" from all
+      foreach ($options as $machine_name => $label) {
+        $button_key = 'add_more_button_' . $machine_name;
+        $elements[$button_key]['#value'] = $this->t('&nbsp;@type', ['@type' => $label]);
+      }
+      $elements = $this->buildDropbutton($elements);
+      $elements["operations"]["#links"] = ['add_label' => [
+        'title' => [
+          '#type' => 'link',
+          '#url' => Url::fromRoute('<none>', [], [
+            'attributes' => [
+              'class' => [
+                'sfgov-admin-paragraph-add-link',
+              ],
+              'alt' => $this->t('Add'),
+              'title' => $this->t('Add'),
+              'disabled' => 'disabled',
+            ],
+          ]),
+          '#title' => $this->t('Add'),
+          '#attached' => ['library' => ['sfgov_admin/paragraphs']],
+          ],
+        ]] + $elements["operations"]["#links"];
+      $elements['#suffix'] = $this->t('to %type', ['%type' => $this->fieldDefinition->getLabel()]);
+    }
+
+    return $elements;
+  }
+
+}

--- a/web/modules/custom/sfgov_admin/tests/src/Unit/Plugin/Field/FieldWidget/SfgovParagraphsWidgetTest.php
+++ b/web/modules/custom/sfgov_admin/tests/src/Unit/Plugin/Field/FieldWidget/SfgovParagraphsWidgetTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Drupal\paragraphs\Plugin\Field\FieldWidget;
+
+/**
+ * Override t()
+ */
+function t($string, array $args = [], array $options = []) {
+  return $string;
+}
+
+namespace Drupal\Tests\sfgov_admin\Unit\Plugin\Field\FieldWidget;
+
+use Drupal\sfgov_admin\Plugin\Field\FieldWidget\SfgovParagraphsWidget;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * @coversDefaultClass \Drupal\sfgov_admin\Plugin\Field\FieldWidget\SfgovParagraphsWidget
+ * @group afgov_admin
+ */
+class SfgovParagraphsWidgetTest extends UnitTestCase {
+
+  /**
+   * @var \Drupal\sfgov_admin\Plugin\Field\FieldWidget\SfgovParagraphsWidget
+   */
+  protected $widget;
+
+
+  public function setUp() {
+    parent::setUp();
+
+    /** @var \Drupal\Core\Field\FieldDefinitionInterface $field_definition */
+    $field_definition = $this
+      ->getMockBuilder('\Drupal\Core\Field\FieldDefinitionInterface')
+      ->getMock();
+
+    // Mock the string translation service.
+    $string_translation = $this
+      ->getMockBuilder('\Drupal\Core\StringTranslation\TranslationManager')
+      ->disableOriginalConstructor()
+      ->setMethods(['translate'])
+      ->getMock();
+    $string_translation
+      ->expects($this->any())
+      ->method('translate')
+      // Always return the source value.
+      ->willReturn($this->callback(function ($val) { return $val; }));
+
+    // Mock the container.
+    $container = $this
+      ->getMockBuilder('\Symfony\Component\DependencyInjection\Container')
+      ->setMethods(['get'])
+      ->getMock();
+    $container
+      ->expects($this->any())
+      ->method('get')
+      ->with('string_translation')
+      ->willReturn($string_translation);
+
+    \Drupal::setContainer($container);
+
+    $this->widget = new SfgovParagraphsWidget('sfgov_paragraphs', [], $field_definition, [], []);
+  }
+
+  /**
+   * Test getting settings options.
+   *
+   * @test
+   *
+   * @throws \ReflectionException
+   */
+  public function getSettingOptions() {
+    $options = self::callMethod($this->widget, 'getSettingOptions', ['add_mode']);
+
+    self::assertArraySubset([
+      'dropdown_custom' => 'Add drop button',
+    ],  array_map('strval', $options));
+  }
+
+  /**
+   * @param $obj
+   * @param $name
+   * @param array $args
+   *
+   * @return mixed
+   * @throws \ReflectionException
+   */
+  public static function callMethod($obj, $name, array $args) {
+    $class = new \ReflectionClass($obj);
+    $method = $class->getMethod($name);
+    $method->setAccessible(true);
+    return $method->invokeArgs($obj, $args);
+  }
+}


### PR DESCRIPTION
For landing page sections, the button to add content to sections will use the new and improved widget. The initial add entry will appear as "Add" and subsequent entries will appear by their paragraph type name.

![add-section-content](https://user-images.githubusercontent.com/159693/41491667-788681e8-70af-11e8-8835-c995f2dcf7fc.gif)
