### PR TITLE
[SG-192] Adds the search form to the search page on the sfgov theme.

### DIFF
--- a/config/block.block.search_page_block_sfgov.yml
+++ b/config/block.block.search_page_block_sfgov.yml
@@ -1,0 +1,29 @@
+uuid: ab07f22d-0649-4b16-80cc-e87f61f1d9a4
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.search
+  module:
+    - system
+    - views
+  theme:
+    - sfgovpl
+id: search_page_block_sfgov
+theme: sfgovpl
+region: content_top
+weight: 0
+provider: null
+plugin: 'views_exposed_filter_block:search-page_1'
+settings:
+  id: 'views_exposed_filter_block:search-page_1'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: ''
+visibility:
+  request_path:
+    id: request_path
+    pages: '/search*'
+    negate: false
+    context_mapping: {  }


### PR DESCRIPTION
I added the search form on the search page but since it's not in config, it will be removed as soon as the next `drush cim` happens without this config file.