### PR TITLE
Pin sfgov-pattern-lab to the master branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
         "oomphinc/composer-installers-extender": "^1.1",
         "pantheon-systems/quicksilver-pushback": "~1",
         "rvtraveller/qs-composer-installer": "^1.1",
-        "sf-digital-services/sfgov-pattern-lab": "dev-master#0.1",
+        "sf-digital-services/sfgov-pattern-lab": "dev-master",
         "webflo/drupal-core-strict": "^8"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e712ad2dd21ed5a54a34447f390dab9d",
+    "content-hash": "836ce550483f20dd3348a07eb025ef17",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -5484,7 +5484,7 @@
                 "reference": "master"
             },
             "type": "drupal-library",
-            "time": "2018-07-23T22:07:27+00:00"
+            "time": "2018-07-25T18:49:30+00:00"
         },
         {
             "name": "solarium/solarium",


### PR DESCRIPTION
My understanding is that we were continuously retagging `sfgov-pattern-lab` as `0.1` every time we updated master. This just points to the `master` branch.

I think this is preferable as:

* it simplifies the workflow during this initial rapid development push
* git tags are meant to be immutable

Eventually we will likely want to start tagging official releases of the pattern library using semantic versioning or similar, especially as more projects begin to depend on it, but this seems sensible for the time being.