### PR TITLE
Sg 323 tx external urls

### DIFF
--- a/web/themes/custom/sfgovpl/sfgovpl.theme
+++ b/web/themes/custom/sfgovpl/sfgovpl.theme
@@ -9,8 +9,3 @@ $includes_path = dirname(__FILE__) . '/includes/*.inc';
 foreach (glob($includes_path) as $filename) {
   require_once dirname(__FILE__) . '/includes/' . basename($filename);
 }
-
-$module_handler = Drupal::service('module_handler');
-$devel_path = $module_handler->getModule('devel')->getPath();
-require_once($devel_path.'/kint/kint/Kint.class.php');
-Kint::$maxLevels = 4;

--- a/web/themes/custom/sfgovpl/sfgovpl.theme
+++ b/web/themes/custom/sfgovpl/sfgovpl.theme
@@ -9,3 +9,8 @@ $includes_path = dirname(__FILE__) . '/includes/*.inc';
 foreach (glob($includes_path) as $filename) {
   require_once dirname(__FILE__) . '/includes/' . basename($filename);
 }
+
+$module_handler = Drupal::service('module_handler');
+$devel_path = $module_handler->getModule('devel')->getPath();
+require_once($devel_path.'/kint/kint/Kint.class.php');
+Kint::$maxLevels = 4;

--- a/web/themes/custom/sfgovpl/templates/node/node--transaction--search-index.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--transaction--search-index.html.twig
@@ -16,8 +16,14 @@
 {% if view.id == 'services' %}
 {%  set relatedDept = null %}
 {% endif %}
+
+{# use internal drupal url if there is no external url or if user logged in, otherwise use the direct external url #}
+{% set externalUrlValueArray = node.get('field_direct_external_url').getValue() %}
+{% set hasExternalUrl = (externalUrlValueArray is not empty and not logged_in) ? true : false %}
+{% set theUrl = (externalUrlValueArray is empty or logged_in) ? url : externalUrlValueArray[0].uri %}
+
 {% include "@molecules/08-search-results/01-transaction-search.twig" with {
-  "url": url,
+  "url": {"url": theUrl, "external": hasExternalUrl},
   "title": elements['#node'].get('title').getString(),
   "body": description,
   "relatedDept": relatedDept


### PR DESCRIPTION
doing this in the theme/template layer

also requires an update to pattern library as the pattern library has to accommodate a hash now - the calling template passes in a url and boolean to determine if the link should open in a new window or not (based on logged in user)

open to suggestions on a better approach

this is the diff to review: https://github.com/SFDigitalServices/sfgov/pull/192/files#diff-e8b47a90240e6702bc9b47527544a322