### PR TITLE
sg-369 bring back event subscriber for transaction redirects

### DIFF
--- a/web/modules/custom/sfgov_utilities/sfgov_utilities.module
+++ b/web/modules/custom/sfgov_utilities/sfgov_utilities.module
@@ -50,7 +50,7 @@ function sfgovGetTransactionSearchVariables($variables) {
   $options = ['absolute' => TRUE];
   $drupalUrl = \Drupal\Core\Url::fromRoute('entity.node.canonical', ['node' => $node->id()], $options);
   $drupalUrl = $drupalUrl->toString();
-  $theUrl = $hasExternalUrl ? $externalUrlValueArray[0]['uri'] : $drupalUrl;
+  $theUrl = $drupalUrl; // keep the drupal url because the redirect happens in web/modules/custom/sfgov_event_subscriber/src/EventSubscriber/RedirectEventSubscriber
 
   $templateVars['related_dept'] = $relatedDept;
   $templateVars['the_url'] = $theUrl;


### PR DESCRIPTION
use the redirect instead of directly using external url.  a test for this exists at /tests/features/sfgov.feature