### PR TITLE
571 mobile search b

### DIFF
--- a/web/modules/custom/sfgov_search/js/sfgov_search.js
+++ b/web/modules/custom/sfgov_search/js/sfgov_search.js
@@ -79,7 +79,7 @@ function Search311(collectionName) {
               $(_this.autocompleteContainerSelector).show();
               var autocompleteHtml = '';
               for(var i = 0; i<autocompletes.length; i++) {
-                autocompleteHtml += '<a href="/search?keyword=' + autocompletes[i].disp + '">' + autocompletes[i].disp.replace(searchKeyword, '<strong>' + searchKeyword + '</strong>') + '</a>';
+                autocompleteHtml += '<a href="/search?keyword=' + autocompletes[i].disp + '">' + autocompletes[i].disp.replace(searchKeyword.toLowerCase(), '<strong>' + searchKeyword + '</strong>') + '</a>';
               }
               $(_this.autocompleteContainerSelector).html(autocompleteHtml);
             } else {

--- a/web/themes/custom/sfgovpl/src/js/navigation.js
+++ b/web/themes/custom/sfgovpl/src/js/navigation.js
@@ -27,9 +27,10 @@
         }
 
         $('button.sfgov-mobile-search').click(function() {
-            $('header .sfgov-search-311-block').show();
-            $('body').removeClass('sfgov-mobile_nav-active');
-            $('.sf-gov-search-input-class').focus();
+          $('header .sfgov-search-311-block').show();
+          $('body').removeClass('sfgov-mobile_nav-active');
+          $('.sf-gov-search-input-class').focus();
+          $('button.sfgov-menu-btn').removeClass('is-active');
         });
 
         $('header .sfgov-search-311-block .sfgov-mobile-btn-close').click(function() {

--- a/web/themes/custom/sfgovpl/src/sass/_layout.scss
+++ b/web/themes/custom/sfgovpl/src/sass/_layout.scss
@@ -208,7 +208,7 @@ header[role="banner"] {
               text-align: left;
               padding-left: 60px;
               background-color: rgba(0,0,0,.7);
-              top: 81px;
+              top: 80px;
               z-index: $z-menu-mobile;
               .sfgov-nav-inner {
                 width: 100%;

--- a/web/themes/custom/sfgovpl/src/sass/block/_block-search-small.scss
+++ b/web/themes/custom/sfgovpl/src/sass/block/_block-search-small.scss
@@ -29,7 +29,7 @@
     }
 
     .is_typing .input-clear {
-      top: 26px;
+      top: 28px;
     }
 
     [data-drupal-selector="edit-submit"] {

--- a/web/themes/custom/sfgovpl/src/sass/components/_header.scss
+++ b/web/themes/custom/sfgovpl/src/sass/components/_header.scss
@@ -39,7 +39,7 @@ header[role="banner"] {
       @include background-image('x-close-white.svg', 50% 50%, $c-blue-button);
       content: '';
       display: block;
-      height: 78px;
+      height: 80px;
       position: absolute;
       right: 0;
       top: 0;


### PR DESCRIPTION
Resolves: 
1 - keyword should be bolded in autocomplete results
2 - small gap between the "X" and the colored banner.
3 - The small gray X inside the search bar is not vertically aligned.
4 - Once I opened the "Menu", then pressed on the "Search" icon things start breaking. The red highlighted "X" should remain as "Menu" on the header.


