### PR TITLE
sg-565 - use link help text for uri if available

### DIFF
--- a/config/field.field.paragraph.link.field_link.yml
+++ b/config/field.field.paragraph.link.field_link.yml
@@ -12,7 +12,7 @@ field_name: field_link
 entity_type: paragraph
 bundle: link
 label: Link
-description: ''
+description: 'Search for sf.gov content, or enter an external URL.'
 required: false
 translatable: true
 default_value: {  }

--- a/web/modules/custom/sfgov_utilities/sfgov_utilities.module
+++ b/web/modules/custom/sfgov_utilities/sfgov_utilities.module
@@ -134,3 +134,12 @@ function sfgov_utilities_preprocess_eck_entity(&$variables) {
     $variables['map_directions_url'] = $directionsUrl;
   }
 }
+
+function sfgov_utilities_field_widget_form_alter(&$element, FormStateInterface &$form_state, $context) {
+  if(array_key_exists('uri', $element)) {
+    if($element['#description']) {
+      $element['uri']['#description'] = $element['#description'];
+      $element['#description'] = '';
+    }
+  }
+}

--- a/web/modules/custom/sfgov_utilities/sfgov_utilities.module
+++ b/web/modules/custom/sfgov_utilities/sfgov_utilities.module
@@ -60,6 +60,9 @@ function sfgovGetTransactionSearchVariables($variables) {
   return $templateVars;
 }
 
+/**
+ * Implements hook_preprocess_node__transaction__search_index().
+ */
 function sfgov_utilities_preprocess_node__transaction__search_index(&$variables) {
   $templateVars = sfgovGetTransactionSearchVariables($variables);
   $variables['the_url'] = $templateVars['the_url'];
@@ -68,6 +71,9 @@ function sfgov_utilities_preprocess_node__transaction__search_index(&$variables)
   $variables['description'] = $templateVars['description'];
 }
 
+/**
+ * Implements hook_preprocess_node__transaction__transaction_search_result_related_dept().
+ */
 function sfgov_utilities_preprocess_node__transaction__transaction_search_result_related_dept(&$variables) {
   $templateVars = sfgovGetTransactionSearchVariables($variables);
   $variables['the_url'] = $templateVars['the_url'];
@@ -77,8 +83,9 @@ function sfgov_utilities_preprocess_node__transaction__transaction_search_result
   $variables['related_dept'] = $templateVars['related_dept'];
 }
 
-// paragraph people section 
-// override field_direct_external_url
+/**
+ * Implements hook_preprocess_paragraph__people().
+ */
 function sfgov_utilities_preprocess_paragraph__people(&$variables) {
 
   $userLoggedIn = \Drupal::currentUser()->isAnonymous() ? false : true;
@@ -100,6 +107,9 @@ function sfgov_utilities_preprocess_paragraph__people(&$variables) {
   }
 }
 
+/**
+ * Implements hook_preprocess_eck_entity().
+ */
 function sfgov_utilities_preprocess_eck_entity(&$variables) {
   $bundle = $variables['bundle'];
   if($bundle && $bundle == 'event_address') {
@@ -135,6 +145,9 @@ function sfgov_utilities_preprocess_eck_entity(&$variables) {
   }
 }
 
+/**
+ * Implements hook_field_widget_form_alter().
+ */
 function sfgov_utilities_field_widget_form_alter(&$element, FormStateInterface &$form_state, $context) {
   if(array_key_exists('uri', $element)) {
     if($element['#description']) {

--- a/web/modules/custom/sfgov_utilities/sfgov_utilities.module
+++ b/web/modules/custom/sfgov_utilities/sfgov_utilities.module
@@ -61,7 +61,7 @@ function sfgovGetTransactionSearchVariables($variables) {
 }
 
 /**
- * Implements hook_preprocess_node__transaction__search_index().
+ * Implements hook_preprocess_node__NODE_TYPE__VIEW_MODE().
  */
 function sfgov_utilities_preprocess_node__transaction__search_index(&$variables) {
   $templateVars = sfgovGetTransactionSearchVariables($variables);
@@ -72,7 +72,7 @@ function sfgov_utilities_preprocess_node__transaction__search_index(&$variables)
 }
 
 /**
- * Implements hook_preprocess_node__transaction__transaction_search_result_related_dept().
+ * Implements hook_preprocess_node__NODE_TYPE__VIEW_MODE().
  */
 function sfgov_utilities_preprocess_node__transaction__transaction_search_result_related_dept(&$variables) {
   $templateVars = sfgovGetTransactionSearchVariables($variables);
@@ -84,7 +84,7 @@ function sfgov_utilities_preprocess_node__transaction__transaction_search_result
 }
 
 /**
- * Implements hook_preprocess_paragraph__people().
+ * Implements hook_preprocess_paragraph__PARAGRAPH_TYPE().
  */
 function sfgov_utilities_preprocess_paragraph__people(&$variables) {
 


### PR DESCRIPTION
Use help text from “Link” field under uri input field, replacing “Start typing the title of a piece of content to select it...” default description