### PR TITLE
Sg 605 get help sidebar

### DIFF
--- a/web/themes/custom/sfgovpl/dist/css/drupal.css
+++ b/web/themes/custom/sfgovpl/dist/css/drupal.css
@@ -2309,7 +2309,6 @@ header[role="banner"] .sfgov-menu-btn.is-active::before {
 
 .sidebar-card {
   padding: 0;
-  margin-bottom: 40px;
 }
 
 .sidebar-card .sidebar-card--link {
@@ -4808,8 +4807,8 @@ header[role="banner"] .sfgov-menu-btn.is-active::before {
 }
 
 .transaction--right-content .transaction--right-para {
-  margin-bottom: 60px;
-  padding: 30px;
+  margin-bottom: 40px;
+  padding: 40px;
 }
 
 .transaction--help {
@@ -4857,19 +4856,25 @@ header[role="banner"] .sfgov-menu-btn.is-active::before {
 
 .transaction--help .paragraph--type--in-person-location .__location .field--type-office-hours {
   white-space: normal;
+  margin-bottom: 30px;
+}
+
+.transaction--help .paragraph--type--in-person-location .__location .eck-entity-address-field {
+  margin-bottom: 20px;
+}
+
+.transaction--help .paragraph--type--in-person-location .simple-gmap-static-map {
+  padding: 0;
+  margin-bottom: 10px;
 }
 
 .transaction--help .paragraph--type--in-person-location .simple-gmap-static-map img {
   border: 1px solid #a9d6ea;
 }
 
-.transaction--help .paragraph--type--document,
-.transaction--help .paragraph--type--email,
-.transaction--help .paragraph--type--help,
-.transaction--help .paragraph--type--in-person-location,
-.transaction--help .paragraph--type--mailing-address,
-.transaction--help .paragraph--type--phone {
-  margin-bottom: 40px;
+.transaction--help .paragraph--type--in-person-location .simple-gmap-link {
+  margin-bottom: 30px;
+  padding-bottom: 0;
 }
 
 .transaction--help .paragraph > .__title,
@@ -4882,8 +4887,28 @@ header[role="banner"] .sfgov-menu-btn.is-active::before {
   margin-bottom: 10px;
 }
 
+.transaction--help > .transaction--help-item {
+  margin-bottom: 40px;
+}
+
+.transaction--help > .transaction--help-item.last {
+  margin-bottom: 0;
+}
+
+.transaction--help > .transaction--help-item.last .simple-gmap-link {
+  margin-bottom: 0;
+}
+
 .transaction--related-services > h2 {
   margin-bottom: 30px;
+}
+
+.transaction--related-services .transaction--related-services-item {
+  margin-bottom: 40px;
+}
+
+.transaction--related-services .transaction--related-services-item.last {
+  margin-bottom: 0;
 }
 
 .region-fourofour {

--- a/web/themes/custom/sfgovpl/dist/css/drupal.css
+++ b/web/themes/custom/sfgovpl/dist/css/drupal.css
@@ -4863,6 +4863,10 @@ header[role="banner"] .sfgov-menu-btn.is-active::before {
   margin-bottom: 20px;
 }
 
+.transaction--help .paragraph--type--in-person-location .__location .field--type-text-long {
+  margin-top: 30px;
+}
+
 .transaction--help .paragraph--type--in-person-location .simple-gmap-static-map {
   padding: 0;
   margin-bottom: 10px;
@@ -4892,10 +4896,6 @@ header[role="banner"] .sfgov-menu-btn.is-active::before {
 }
 
 .transaction--help > .transaction--help-item.last {
-  margin-bottom: 0;
-}
-
-.transaction--help > .transaction--help-item.last .simple-gmap-link {
   margin-bottom: 0;
 }
 

--- a/web/themes/custom/sfgovpl/dist/css/drupal.css
+++ b/web/themes/custom/sfgovpl/dist/css/drupal.css
@@ -2307,6 +2307,25 @@ header[role="banner"] .sfgov-menu-btn.is-active::before {
   display: none;
 }
 
+.sidebar-card {
+  padding: 0;
+  margin-bottom: 40px;
+}
+
+.sidebar-card .sidebar-card--link {
+  font-size: 20px;
+  font-weight: 500;
+  line-height: 24px;
+  display: block;
+  margin: 0 0 10px 0;
+}
+
+.sidebar-card .sidebar-card__body {
+  font-size: 17px;
+  font-weight: 400;
+  line-height: 24px;
+}
+
 .page-node-type-page .sfgov-new-website {
   margin-bottom: 0;
   margin-top: 30px;
@@ -4750,10 +4769,6 @@ header[role="banner"] .sfgov-menu-btn.is-active::before {
   }
 }
 
-.transaction--right .sidebar-card {
-  padding: 0 0 34px;
-}
-
 .transaction--right .eck-entity-address-field {
   margin-bottom: 23px;
 }
@@ -4797,12 +4812,12 @@ header[role="banner"] .sfgov-menu-btn.is-active::before {
   padding: 30px;
 }
 
-.transaction--right-content .sidebar-card--link {
-  font-size: 20px;
-  font-weight: 500;
-  line-height: 24px;
-  display: block;
-  margin-bottom: 18px;
+.transaction--help {
+  padding: 40px;
+}
+
+.transaction--help > h2 {
+  margin-bottom: 30px;
 }
 
 .transaction--help .field__label,
@@ -4836,12 +4851,38 @@ header[role="banner"] .sfgov-menu-btn.is-active::before {
   margin: 0;
 }
 
+.transaction--help .paragraph--type--help .__text {
+  font-style: normal;
+}
+
+.transaction--help .paragraph--type--in-person-location .__location .field--type-office-hours {
+  white-space: normal;
+}
+
+.transaction--help .paragraph--type--in-person-location .simple-gmap-static-map img {
+  border: 1px solid #a9d6ea;
+}
+
 .transaction--help .paragraph--type--document,
 .transaction--help .paragraph--type--email,
 .transaction--help .paragraph--type--help,
 .transaction--help .paragraph--type--in-person-location,
 .transaction--help .paragraph--type--mailing-address,
 .transaction--help .paragraph--type--phone {
+  margin-bottom: 40px;
+}
+
+.transaction--help .paragraph > .__title,
+.transaction--help .paragraph > .__location .field__label,
+.transaction--help .paragraph.paragraph--type--phone .field__label {
+  /* antialiased, none, subpixel-antialiased*/
+  -webkit-font-smoothing: antialiased;
+  font-smoothing: antialiased;
+  font-smooth: always;
+  margin-bottom: 10px;
+}
+
+.transaction--related-services > h2 {
   margin-bottom: 30px;
 }
 

--- a/web/themes/custom/sfgovpl/src/sass/components/_sidebar-card.scss
+++ b/web/themes/custom/sfgovpl/src/sass/components/_sidebar-card.scss
@@ -1,0 +1,12 @@
+.sidebar-card {
+  padding: 0;
+  margin-bottom: 40px;
+  .sidebar-card--link {
+    @include fs-title-right;
+    display: block;
+    margin: 0 0 10px 0;
+  }
+  .sidebar-card__body {
+    @include fs-body-short;  
+  }
+}

--- a/web/themes/custom/sfgovpl/src/sass/components/_sidebar-card.scss
+++ b/web/themes/custom/sfgovpl/src/sass/components/_sidebar-card.scss
@@ -1,6 +1,5 @@
 .sidebar-card {
   padding: 0;
-  margin-bottom: 40px;
   .sidebar-card--link {
     @include fs-title-right;
     display: block;

--- a/web/themes/custom/sfgovpl/src/sass/drupal.scss
+++ b/web/themes/custom/sfgovpl/src/sass/drupal.scss
@@ -25,6 +25,7 @@
 @import 'components/alpha-banner';
 @import 'components/person-card';
 @import 'components/service-card';
+@import 'components/sidebar-card';
 
 @import 'node/node-basic';
 @import 'node/node-dept';
@@ -42,6 +43,7 @@
 
 @import 'node/node-transaction';
 @import 'node/node-transaction-help';
+@import 'node/node-transaction-related-services';
 
 @import 'page/page-404';
 

--- a/web/themes/custom/sfgovpl/src/sass/node/_node-transaction-help.scss
+++ b/web/themes/custom/sfgovpl/src/sass/node/_node-transaction-help.scss
@@ -56,6 +56,9 @@
       .eck-entity-address-field {
         margin-bottom: 20px;
       }
+      .field--type-text-long {
+        margin-top: 30px;
+      }
     }
     .simple-gmap-static-map {
       padding: 0;
@@ -84,9 +87,6 @@
     margin-bottom: 40px;
     &.last {
       margin-bottom: 0;
-      .simple-gmap-link {
-        margin-bottom: 0;
-      }
     }
   }
 }

--- a/web/themes/custom/sfgovpl/src/sass/node/_node-transaction-help.scss
+++ b/web/themes/custom/sfgovpl/src/sass/node/_node-transaction-help.scss
@@ -1,5 +1,11 @@
 .transaction--help {
 
+  padding: 40px;
+
+  > h2 {
+    margin-bottom: 30px;
+  }
+
   .field__label,
   .__title {
     @include fs-title-5;
@@ -35,13 +41,41 @@
     }
   }
 
+  .paragraph--type--help {
+    .__text {
+      font-style: normal;
+    }
+  }
+
+  .paragraph--type--in-person-location {
+    .__location {
+      .field--type-office-hours {
+        white-space: normal;
+      }
+    }
+    .simple-gmap-static-map {
+      img {
+        border: 1px solid $c-blue-2;
+      }
+    }
+  }
+
   .paragraph--type--document,
   .paragraph--type--email,
   .paragraph--type--help,
   .paragraph--type--in-person-location,
   .paragraph--type--mailing-address,
   .paragraph--type--phone {
-    margin-bottom: 30px;
+    margin-bottom: 40px;
   }
-
+  
+  // subtitles (email address, name of way to get help, in person address organization, phone number owner, etc)
+  .paragraph {
+    > .__title,
+    > .__location .field__label,
+    &.paragraph--type--phone .field__label {
+      @include antialiasing;
+      margin-bottom: 10px;
+    }
+  }
 }

--- a/web/themes/custom/sfgovpl/src/sass/node/_node-transaction-help.scss
+++ b/web/themes/custom/sfgovpl/src/sass/node/_node-transaction-help.scss
@@ -51,22 +51,23 @@
     .__location {
       .field--type-office-hours {
         white-space: normal;
+        margin-bottom: 30px;
+      }
+      .eck-entity-address-field {
+        margin-bottom: 20px;
       }
     }
     .simple-gmap-static-map {
+      padding: 0;
+      margin-bottom: 10px;
       img {
         border: 1px solid $c-blue-2;
       }
     }
-  }
-
-  .paragraph--type--document,
-  .paragraph--type--email,
-  .paragraph--type--help,
-  .paragraph--type--in-person-location,
-  .paragraph--type--mailing-address,
-  .paragraph--type--phone {
-    margin-bottom: 40px;
+    .simple-gmap-link {
+      margin-bottom: 30px;
+      padding-bottom: 0;
+    }
   }
   
   // subtitles (email address, name of way to get help, in person address organization, phone number owner, etc)
@@ -76,6 +77,16 @@
     &.paragraph--type--phone .field__label {
       @include antialiasing;
       margin-bottom: 10px;
+    }
+  }
+
+  > .transaction--help-item {
+    margin-bottom: 40px;
+    &.last {
+      margin-bottom: 0;
+      .simple-gmap-link {
+        margin-bottom: 0;
+      }
     }
   }
 }

--- a/web/themes/custom/sfgovpl/src/sass/node/_node-transaction-related-services.scss
+++ b/web/themes/custom/sfgovpl/src/sass/node/_node-transaction-related-services.scss
@@ -2,4 +2,10 @@
   > h2 {
     margin-bottom: 30px;
   }
+  .transaction--related-services-item {
+    margin-bottom: 40px;
+    &.last {
+      margin-bottom: 0;
+    }
+  }
 }

--- a/web/themes/custom/sfgovpl/src/sass/node/_node-transaction-related-services.scss
+++ b/web/themes/custom/sfgovpl/src/sass/node/_node-transaction-related-services.scss
@@ -1,0 +1,5 @@
+.transaction--related-services {
+  > h2 {
+    margin-bottom: 30px;
+  }
+}

--- a/web/themes/custom/sfgovpl/src/sass/node/_node-transaction.scss
+++ b/web/themes/custom/sfgovpl/src/sass/node/_node-transaction.scss
@@ -155,10 +155,6 @@
 .transaction--right {
   @include columns-350(right);
 
-  .sidebar-card {
-    padding: 0 0 34px;
-  }
-
   .eck-entity-address-field {
     margin-bottom: 23px;
   }
@@ -194,11 +190,5 @@
   .transaction--right-para {
     margin-bottom: 60px;
     padding: 30px;
-  }
-
-  .sidebar-card--link {
-    @include fs-title-right;
-    display: block;
-    margin-bottom: 18px;
   }
 }

--- a/web/themes/custom/sfgovpl/src/sass/node/_node-transaction.scss
+++ b/web/themes/custom/sfgovpl/src/sass/node/_node-transaction.scss
@@ -188,7 +188,7 @@
   }
 
   .transaction--right-para {
-    margin-bottom: 60px;
-    padding: 30px;
+    margin-bottom: 40px;
+    padding: 40px;
   }
 }

--- a/web/themes/custom/sfgovpl/templates/components/atoms/sidebar-card.twig
+++ b/web/themes/custom/sfgovpl/templates/components/atoms/sidebar-card.twig
@@ -1,0 +1,6 @@
+<div class="sidebar-card">
+    <div class="sidebar-card-container">
+        <a href="{{ url }}" class="sidebar-card--link">{{ title }}</a>
+        <div class="sidebar-card__body">{{ description }}</div>
+    </div>
+</div>

--- a/web/themes/custom/sfgovpl/templates/field/field--node--field-help--transaction.html.twig
+++ b/web/themes/custom/sfgovpl/templates/field/field--node--field-help--transaction.html.twig
@@ -2,7 +2,13 @@
   <div class="transaction--right-para transaction--help">
     <h2>{{ 'Get help'|t }}</h2>
     {% for item in items %}
-      {{ item.content }}
+      {% if loop.last %}
+        <div class="transaction--help-item last">
+      {% else %}
+        <div class="transaction--help-item">
+      {% endif %}
+          {{ item.content }}
+        </div>
     {% endfor %}
   </div>
 </div>

--- a/web/themes/custom/sfgovpl/templates/field/field--node--field-transactions--transaction.html.twig
+++ b/web/themes/custom/sfgovpl/templates/field/field--node--field-transactions--transaction.html.twig
@@ -40,7 +40,13 @@
   <div class="transaction--right-para transaction--related-services">
     <h2>Related Services</h2>
     {% for item in items %}
-      {{ item.content }}
+      {% if loop.last %}
+        <div class="transaction--related-services-item last">
+      {% else %}
+        <div class="transaction--related-services-item">
+      {% endif %}
+          {{ item.content }}
+        </div>
     {% endfor %}
   </div>
 </div>

--- a/web/themes/custom/sfgovpl/templates/field/field--node--field-transactions--transaction.html.twig
+++ b/web/themes/custom/sfgovpl/templates/field/field--node--field-transactions--transaction.html.twig
@@ -37,7 +37,7 @@
  */
 #}
 <div class="transaction--right-content">
-  <div class="transaction--right-para">
+  <div class="transaction--right-para transaction--related-services">
     <h2>Related Services</h2>
     {% for item in items %}
       {{ item.content }}

--- a/web/themes/custom/sfgovpl/templates/node/node--transaction--teaser.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--transaction--teaser.html.twig
@@ -1,9 +1,8 @@
 {% set url = path('entity.node.canonical', {'node': elements['#node'].id()  }) %}
 {% set description = node.get('field_description').getValue()[0]['value'] %}
-{% include "@molecules/04-cards/02-sidebar-card.twig" with {
-  "sidebar_card": {
-    "url": url,
-    "title": elements['#node'].get('title').getString(),
-    "body": description
-  }
+
+{% include "@theme/atoms/sidebar-card.twig" with {
+  "url": url,
+  "title": elements['#node'].get('title').getString(),
+  "description": description
 } %}


### PR DESCRIPTION
Some details below, full context at https://sfgovdt.jira.com/browse/SG-605

The subtitles should be anti-aliased. They look a little heavy right now so this will help create better hierarchy with the “Get help”. If this will affect text in other places too, let me know. It’s probably OK/good.

The generic “way to get help” should not be italic. We should use italic only for special cases or notes.

Text is going past the edge of the box for hours (and maybe for other things??)

Maps should have a 1px blue L2 border 

Spacing between each component should be updated.

https://www.figma.com/file/bTWFLkGPHBnY20LvrPTKQjcW/Transactions?node-id=1%3A8