### PR TITLE
SG-719: Fix News Card image issues on homepage vs department homepage

### DIFF
--- a/config/block.block.views_block__news_block_2.yml
+++ b/config/block.block.views_block__news_block_2.yml
@@ -8,14 +8,14 @@ dependencies:
     - views
   theme:
     - sfgovpl
-id: views_block__news_block_1
+id: views_block__news_block_2
 theme: sfgovpl
 region: department_news
 weight: 0
 provider: null
-plugin: 'views_block:news-block_1'
+plugin: 'views_block:news-block_2'
 settings:
-  id: 'views_block:news-block_1'
+  id: 'views_block:news-block_2'
   label: ''
   provider: views
   label_display: '0'

--- a/config/core.entity_view_display.node.news.card_compact.yml
+++ b/config/core.entity_view_display.node.news.card_compact.yml
@@ -1,0 +1,45 @@
+uuid: 38ccaa1e-9192-4495-a3b3-0370d7d79c8e
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.card_compact
+    - field.field.node.news.body
+    - field.field.node.news.field_abstract
+    - field.field.node.news.field_date
+    - field.field.node.news.field_dept
+    - field.field.node.news.field_image
+    - field.field.node.news.field_news_type
+    - field.field.node.news.field_topics
+    - node.type.news
+  module:
+    - datetime
+    - user
+id: node.news.card_compact
+targetEntityType: node
+bundle: news
+mode: card_compact
+content:
+  content_moderation_control:
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_date:
+    weight: 1
+    label: hidden
+    settings:
+      timezone_override: ''
+      format_type: default
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
+hidden:
+  body: true
+  field_abstract: true
+  field_dept: true
+  field_image: true
+  field_news_type: true
+  field_topics: true
+  langcode: true
+  links: true

--- a/config/core.entity_view_mode.node.card_compact.yml
+++ b/config/core.entity_view_mode.node.card_compact.yml
@@ -1,0 +1,10 @@
+uuid: c2125f7a-aae6-40d4-985f-1fd6b4df14c1
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.card_compact
+label: 'Card compact (no image)'
+targetEntityType: node
+cache: true

--- a/config/field.field.paragraph.news.field_news.yml
+++ b/config/field.field.paragraph.news.field_news.yml
@@ -7,7 +7,11 @@ dependencies:
     - paragraphs.paragraphs_type.news
     - views.view.news
   module:
+    - tmgmt_content
     - viewfield
+third_party_settings:
+  tmgmt_content:
+    excluded: false
 id: paragraph.news.field_news
 field_name: field_news
 entity_type: paragraph
@@ -24,18 +28,23 @@ default_value:
     target_uuid: 92ff818a-a3bb-4cbf-b390-167a6779170b
 default_value_callback: ''
 settings:
-  force_default: 0
+  force_default: 1
   allowed_views:
     news: news
     content: 0
+    block_content: 0
     departments: 0
     entity_browser_file: 0
     entity_browser_image: 0
     entity_browser_location: 0
+    events: 0
     files: 0
     frontpage: 0
+    google_analytics_reports_page: 0
+    google_analytics_summary: 0
     group_members: 0
     group_nodes: 0
+    tmgmt_job_overview: 0
     locked_content: 0
     media: 0
     moderated_content: 0
@@ -45,9 +54,14 @@ settings:
     services: 0
     services_rest: 0
     taxonomy_term: 0
+    tmgmt_translation_all_job_items: 0
+    tmgmt_job_items: 0
+    tmgmt_job_messages: 0
     watchdog: 0
   allowed_display_types:
     block: block
+    attachment: 0
+    embed: 0
     entity_browser: 0
     feed: 0
     default: 0

--- a/config/views.view.news.yml
+++ b/config/views.view.news.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.card
+    - core.entity_view_mode.node.card_compact
     - core.entity_view_mode.node.teaser
     - node.type.department
     - node.type.news
@@ -182,7 +183,7 @@ display:
   block_1:
     display_plugin: block
     id: block_1
-    display_title: Block
+    display_title: 'News Block'
     position: 2
     display_options:
       display_extenders: {  }
@@ -214,6 +215,53 @@ display:
       use_more_always: false
       use_more_text: 'See more news'
       header: {  }
+      block_description: 'News block'
+      display_description: 'A list of News content rendered with "Card" view mode.'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  block_2:
+    display_plugin: block
+    id: block_2
+    display_title: 'News Block (compact)'
+    position: 2
+    display_options:
+      display_extenders: {  }
+      style:
+        type: default
+        options:
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      defaults:
+        style: false
+        row: false
+        pager: false
+        use_more: false
+        use_more_always: false
+        use_more_text: false
+        header: false
+      row:
+        type: 'entity:node'
+        options:
+          relationship: none
+          view_mode: card_compact
+      pager:
+        type: some
+        options:
+          items_per_page: 3
+          offset: 0
+      use_more: true
+      use_more_always: false
+      use_more_text: 'See more news'
+      header: {  }
+      block_description: 'News block (no image)'
+      display_description: 'A list of News content rendered with "Card compact" view mode.'
     cache_metadata:
       max-age: -1
       contexts:

--- a/web/themes/custom/sfgovpl/dist/css/drupal.css
+++ b/web/themes/custom/sfgovpl/dist/css/drupal.css
@@ -2761,13 +2761,6 @@ header[role="banner"] .sfgov-menu-btn.is-active::before {
   padding-left: 0;
 }
 
-.page-node-type-department .sfgov-dept-news .views-events--rows .news--teaser--body.w-image,
-.page-node-type-department .sfgov-dept-news .views-news--rows .news--teaser--body.w-image,
-.page-node-type-department .sfgov-dept-events .views-events--rows .news--teaser--body.w-image,
-.page-node-type-department .sfgov-dept-events .views-news--rows .news--teaser--body.w-image {
-  background-image: none !important;
-}
-
 @media (max-width: 768px) {
   .page-node-type-department .sfgov-dept-news .empty,
   .page-node-type-department .sfgov-dept-events .empty {

--- a/web/themes/custom/sfgovpl/package-lock.json
+++ b/web/themes/custom/sfgovpl/package-lock.json
@@ -628,7 +628,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
       "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "base64id": {
       "version": "1.0.0",
@@ -870,6 +871,7 @@
           "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
           "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "p-finally": "^1.0.0"
           }
@@ -911,6 +913,7 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
@@ -935,7 +938,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -1107,6 +1111,7 @@
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
       "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4"
@@ -1117,6 +1122,7 @@
       "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
       "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
       "dev": true,
+      "optional": true,
       "requires": {
         "buffer-alloc-unsafe": "^1.1.0",
         "buffer-fill": "^1.0.0"
@@ -1126,13 +1132,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
       "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "buffer-equal": {
       "version": "1.0.0",
@@ -1144,7 +1152,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
       "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -1268,6 +1277,7 @@
       "resolved": "https://registry.npmjs.org/caw/-/caw-2.0.1.tgz",
       "integrity": "sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "get-proxy": "^2.0.0",
         "isurl": "^1.0.0-alpha5",
@@ -1561,6 +1571,7 @@
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
       "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "ini": "^1.3.4",
         "proto-list": "~1.2.1"
@@ -1602,6 +1613,7 @@
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
       "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
       "dev": true,
+      "optional": true,
       "requires": {
         "safe-buffer": "5.1.2"
       }
@@ -1672,6 +1684,7 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
+      "optional": true,
       "requires": {
         "lru-cache": "^4.0.1",
         "shebang-command": "^1.2.0",
@@ -1855,6 +1868,7 @@
       "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
       "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
       "dev": true,
+      "optional": true,
       "requires": {
         "decompress-tar": "^4.0.0",
         "decompress-tarbz2": "^4.0.0",
@@ -1871,6 +1885,7 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "dev": true,
+      "optional": true,
       "requires": {
         "mimic-response": "^1.0.0"
       }
@@ -1880,6 +1895,7 @@
       "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
       "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "file-type": "^5.2.0",
         "is-stream": "^1.1.0",
@@ -1890,7 +1906,8 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
           "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -1899,6 +1916,7 @@
       "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
       "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
       "dev": true,
+      "optional": true,
       "requires": {
         "decompress-tar": "^4.1.0",
         "file-type": "^6.1.0",
@@ -1911,7 +1929,8 @@
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
           "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -1920,6 +1939,7 @@
       "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
       "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
       "dev": true,
+      "optional": true,
       "requires": {
         "decompress-tar": "^4.1.1",
         "file-type": "^5.2.0",
@@ -1930,7 +1950,8 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
           "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -1939,6 +1960,7 @@
       "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
       "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
       "dev": true,
+      "optional": true,
       "requires": {
         "file-type": "^3.8.0",
         "get-stream": "^2.2.0",
@@ -1950,13 +1972,15 @@
           "version": "3.9.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
           "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "get-stream": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "dev": true,
+          "optional": true,
           "requires": {
             "object-assign": "^4.0.1",
             "pinkie-promise": "^2.0.0"
@@ -2137,7 +2161,8 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
       "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "domutils": {
       "version": "1.7.0",
@@ -2190,7 +2215,8 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "duplexify": {
       "version": "3.7.1",
@@ -2375,6 +2401,7 @@
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
       "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "es-to-primitive": "^1.2.0",
         "function-bind": "^1.1.1",
@@ -2389,6 +2416,7 @@
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
       "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -2645,6 +2673,7 @@
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
+      "optional": true,
       "requires": {
         "cross-spawn": "^5.0.1",
         "get-stream": "^3.0.0",
@@ -2720,6 +2749,7 @@
       "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
       "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "mime-db": "^1.28.0"
       }
@@ -2729,6 +2759,7 @@
       "resolved": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
       "integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "ext-list": "^2.0.0",
         "sort-keys-length": "^1.0.0"
@@ -2881,6 +2912,7 @@
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "dev": true,
+      "optional": true,
       "requires": {
         "pend": "~1.2.0"
       }
@@ -2915,13 +2947,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
       "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "filenamify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-2.1.0.tgz",
       "integrity": "sha512-ICw7NTT6RsDp2rnYKVd8Fu4cr6ITzGy3+u4vUujPkabyaz+03F24NWEX7fs5fp+kBonlaqPH8fAO2NM+SXt/JA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "filename-reserved-regex": "^2.0.0",
         "strip-outer": "^1.0.0",
@@ -3140,7 +3174,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "fs-extra": {
       "version": "3.0.1",
@@ -3189,7 +3224,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3210,12 +3246,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3230,17 +3268,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3357,7 +3398,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3369,6 +3411,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3383,6 +3426,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3390,12 +3434,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3414,6 +3460,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3494,7 +3541,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3506,6 +3554,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3591,7 +3640,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3627,6 +3677,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3646,6 +3697,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3689,12 +3741,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3770,6 +3824,7 @@
       "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-2.1.0.tgz",
       "integrity": "sha512-zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "npm-conf": "^1.1.0"
       }
@@ -3784,7 +3839,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "get-value": {
       "version": "2.0.6",
@@ -4293,6 +4349,7 @@
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -4339,7 +4396,8 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
       "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "has-symbols": {
       "version": "1.0.0",
@@ -4352,6 +4410,7 @@
       "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
       "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "has-symbol-support-x": "^1.4.1"
       }
@@ -4478,7 +4537,8 @@
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
       "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "ignore": {
       "version": "3.3.10",
@@ -4767,7 +4827,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
       "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-data-descriptor": {
       "version": "0.1.4",
@@ -4793,7 +4854,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -4899,7 +4961,8 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
       "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-negated-glob": {
       "version": "1.0.0",
@@ -4940,13 +5003,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
       "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -4981,6 +5046,7 @@
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
+      "optional": true,
       "requires": {
         "has": "^1.0.1"
       }
@@ -5004,13 +5070,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
       "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-svg": {
       "version": "3.0.0",
@@ -5027,6 +5095,7 @@
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "has-symbols": "^1.0.0"
       }
@@ -5099,6 +5168,7 @@
       "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
       "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
       "dev": true,
+      "optional": true,
       "requires": {
         "has-to-string-tag-x": "^1.2.0",
         "is-object": "^1.0.1"
@@ -5448,7 +5518,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "lpad-align": {
       "version": "1.1.2",
@@ -5568,7 +5639,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
       "integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "memoizee": {
       "version": "0.4.14",
@@ -5662,7 +5734,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -5782,7 +5855,8 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node-gyp": {
       "version": "3.8.0",
@@ -5964,6 +6038,7 @@
       "resolved": "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.3.tgz",
       "integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "config-chain": "^1.1.11",
         "pify": "^3.0.0"
@@ -5973,7 +6048,8 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5982,6 +6058,7 @@
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
+      "optional": true,
       "requires": {
         "path-key": "^2.0.0"
       }
@@ -6303,7 +6380,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "p-is-promise": {
       "version": "1.1.0",
@@ -6340,6 +6418,7 @@
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
       "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
       "dev": true,
+      "optional": true,
       "requires": {
         "p-finally": "^1.0.0"
       }
@@ -6437,7 +6516,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "path-parse": {
       "version": "1.0.6",
@@ -6475,7 +6555,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "performance-now": {
       "version": "2.1.0",
@@ -6615,7 +6696,8 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -7132,6 +7214,7 @@
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
       "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
       "dev": true,
+      "optional": true,
       "requires": {
         "commander": "~2.8.1"
       }
@@ -7314,6 +7397,7 @@
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
+      "optional": true,
       "requires": {
         "shebang-regex": "^1.0.0"
       }
@@ -7322,7 +7406,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "shelljs": {
       "version": "0.6.1",
@@ -7645,6 +7730,7 @@
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-plain-obj": "^1.0.0"
       }
@@ -7654,6 +7740,7 @@
       "resolved": "https://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz",
       "integrity": "sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=",
       "dev": true,
+      "optional": true,
       "requires": {
         "sort-keys": "^1.0.0"
       }
@@ -7922,6 +8009,7 @@
       "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
       "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-natural-number": "^4.0.1"
       }
@@ -7930,7 +8018,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "strip-indent": {
       "version": "1.0.1",
@@ -7952,6 +8041,7 @@
       "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
       "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "escape-string-regexp": "^1.0.2"
       }
@@ -8104,6 +8194,7 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
       "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
       "dev": true,
+      "optional": true,
       "requires": {
         "bl": "^1.0.0",
         "buffer-alloc": "^1.2.0",
@@ -8118,13 +8209,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
       "integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "tempfile": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-2.0.0.tgz",
       "integrity": "sha1-awRGhWqbERTRhW/8vlCczLCXcmU=",
       "dev": true,
+      "optional": true,
       "requires": {
         "temp-dir": "^1.0.0",
         "uuid": "^3.0.1"
@@ -8218,7 +8311,8 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "timers-ext": {
       "version": "0.1.7",
@@ -8250,7 +8344,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
       "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -8338,6 +8433,7 @@
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
       "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
       "dev": true,
+      "optional": true,
       "requires": {
         "escape-string-regexp": "^1.0.2"
       }
@@ -8398,6 +8494,7 @@
       "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
       "integrity": "sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "buffer": "^5.2.1",
         "through": "^2.3.8"
@@ -8571,7 +8668,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
       "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "use": {
       "version": "3.1.1",
@@ -8862,6 +8960,7 @@
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "dev": true,
+      "optional": true,
       "requires": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"

--- a/web/themes/custom/sfgovpl/src/sass/node/_node-dept.scss
+++ b/web/themes/custom/sfgovpl/src/sass/node/_node-dept.scss
@@ -50,11 +50,6 @@
     .views-events--rows,
     .views-news--rows {
       padding-left: 0;
-      .news--teaser--body {
-        &.w-image {
-          background-image: none !important;
-        }
-      }
     }
     @include less-than('not-big') {
       .empty {
@@ -350,7 +345,7 @@
               @include antialiasing;
             }
           }
-        }      
+        }
       }
       .sfgov-dept-about-description {
         @include fs-big-description;

--- a/web/themes/custom/sfgovpl/templates/node/node--news--card-compact.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--news--card-compact.html.twig
@@ -1,0 +1,3 @@
+{% include 'node--news--card.html.twig' with {
+  classes: ['news--card']
+} %}

--- a/web/themes/custom/sfgovpl/templates/node/node--news--card.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--news--card.html.twig
@@ -1,15 +1,19 @@
-{% extends 'node--news--teaser.html.twig' %}
+{% extends 'node.html.twig' %}
+
+{% block title %}{% endblock %}
 
 {% block body %}
-
   {% if is_front and content.field_image|render|striptags %}
-    {% set thumbnail = file_url(node.field_image.entity.field_media_image.entity.uri.value | image_style('160x160')) %}
+    {% set thumbnail = file_url(node.field_image.entity.field_media_image.entity.uri.value|image_style('160x160')) %}
     <div class="news--teaser--body w-image" style="background-image: url('{{ thumbnail }}');">
+
   {% else %}
     <div class="news--teaser--body">
   {% endif %}
 
-    <h3{{ title_attributes.addClass(title_classes) }}><a href="{{ url }}" rel="bookmark">{{ label }}</a></h3>
+    <h3{{ title_attributes.addClass(title_classes) }}>
+      <a href="{{ url }}" rel="bookmark">{{ label }}</a>
+    </h3>
     {{ content|without('links', 'field_image') }}
   </div>
 {% endblock body %}

--- a/web/themes/custom/sfgovpl/templates/node/node.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node.html.twig
@@ -73,7 +73,7 @@
     node.isPromoted() ? bundle ~ '--promoted',
     node.isSticky() ? bundle ~ '--sticky',
     not node.isPublished() ? bundle ~ '--unpublished',
-  ]
+  ]|merge(classes|default([]))
 %}
 {%
   set title_classes = [

--- a/web/themes/custom/sfgovpl/templates/views/views-view--news--block-2.html.twig
+++ b/web/themes/custom/sfgovpl/templates/views/views-view--news--block-2.html.twig
@@ -1,0 +1,1 @@
+{% include 'views-view--news--block-1.html.twig' %}


### PR DESCRIPTION
This fixes the caching problem.  In short it:

- Creates a new view mode: `card_compact`.
- Creates a new Views display: `block_2` that renders with `card_compact` (no image).
- Ensures that the news Paragraph (used on the homepage) still/always uses the `block_1` instance, which renders `card` and contains the image.
- Adjusts the `node.html.twig` template to allow `classes` to be used from extending templates.
- Tweaks `node--news--card.html.twig` to stop extending the teaser template which was confusing.

See more details in the commit messages.
