### PR TITLE
Sg 766 frontpage meta

### DIFF
--- a/config/metatag.metatag_defaults.front.yml
+++ b/config/metatag.metatag_defaults.front.yml
@@ -10,4 +10,4 @@ tags:
   shortlink: '[site:url]'
   title: 'City and County of San Francisco'
   canonical_url: '[site:url]'
-  description: 'Get City services from the new official website for the City and County of San Francisco'
+  description: 'Find services and information from the City and County of San Francisco.'

--- a/config/metatag.metatag_defaults.front.yml
+++ b/config/metatag.metatag_defaults.front.yml
@@ -7,5 +7,7 @@ _core:
 id: front
 label: 'Front page'
 tags:
-  canonical_url: '[site:url]'
   shortlink: '[site:url]'
+  title: 'City and County of San Francisco'
+  canonical_url: '[site:url]'
+  description: 'Get City services from the new official website for the City and County of San Francisco'


### PR DESCRIPTION
add a meta description tag to the sf.gov homepage