### PR TITLE
sg-965 - accessibility changes to topics

### DIFF
--- a/web/themes/custom/sfgovpl/README.md
+++ b/web/themes/custom/sfgovpl/README.md
@@ -51,7 +51,7 @@ TODO: update the following.
 
 setup.sh to generate a symbolic link between the pattern library _patterns folder and the src folder.
 
-## TODO: 
+## TODO:
 
   - Implement Javascript.
   - remove `src/fonts` and `dist/fonts` if they are going to be served via CDN or Google Fonts.
@@ -80,12 +80,12 @@ the `sfgovpl.libraries.yml` defines the library that references the css and js f
 
 ## TODO:
   - review and revise all of the above, because some of it will be irrelevant soon
-  
+
 ## What is relevant and remains true:
   - this theme uses sass
   - this theme uses the gulp task runner (v4) to compile sass to css
   - there is no gulp task to concat and minify js
-  
+
 ### Minimum node and npm versions
 ```
 node: 10.3.0
@@ -94,5 +94,5 @@ npm: 6.1.0
 ### Compile sass and watch for changes
 from this directory:
 ```
-$ gulp 
+$ gulp
 ```

--- a/web/themes/custom/sfgovpl/templates/node/node--step-by-step--card.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--step-by-step--card.html.twig
@@ -8,7 +8,7 @@
       "title": node.label,
       "description": content.field_description,
       "url": url,
-      "heading": 'h4'
+      "heading": 'p'
     } %}
   {% endblock body %}
 {% endblock node %}

--- a/web/themes/custom/sfgovpl/templates/node/node--transaction--card.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--transaction--card.html.twig
@@ -8,7 +8,7 @@
       "title": node.label,
       "description": content.field_description,
       "url": url,
-      "heading": 'h4'
+      "heading": 'p'
     } %}
   {% endblock body %}
 {% endblock node %}

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--department-service-section.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--department-service-section.html.twig
@@ -50,7 +50,7 @@
 {% block paragraph %}
   <div class="sfgov-services">
     {% block content %}
-      <h5 class="sfgov-dept-services-section-title">{{ content.field_dept_service_section_title }}</h5>
+      <h3 class="sfgov-dept-services-section-title">{{ content.field_dept_service_section_title }}</h3>
       <div class="sfgov-dept-services-section-content service-cards sfgov-container-three-column">
         {{ content.field_dept_service_sect_services }}
       </div>

--- a/web/themes/custom/sfgovpl/templates/views/views-view-unformatted--events--block-1.html.twig
+++ b/web/themes/custom/sfgovpl/templates/views/views-view-unformatted--events--block-1.html.twig
@@ -34,7 +34,7 @@
   <div class="view-events-block">
     {% block title %}
       {% if view.getTitle() %}
-        <h3 class="title">{{ view.getTitle() }}</h3>
+        <h2 class="title">{{ view.getTitle() }}</h2>
       {% endif %}
     {% endblock title %}
 

--- a/web/themes/custom/sfgovpl/templates/views/views-view-unformatted--news--block.html.twig
+++ b/web/themes/custom/sfgovpl/templates/views/views-view-unformatted--news--block.html.twig
@@ -5,7 +5,7 @@
 
 <div class="view-news-block">
   {% if view.getTitle() %}
-    <h3 class="title">{{ view.getTitle() }}</h3>
+    <h2 class="title">{{ view.getTitle() }}</h2>
   {% endif %}
   {% block rows %}
     {% include '@theme/molecules/news-cards.twig' %}


### PR DESCRIPTION
The view template in use for the **events section** is `views-view-unformatted--events-block-topics.html.twig`, which itself extends `views-view-unformatted--events--block-1.html.twig`. I made the change in the `block-1` template directly. 

If the `block-1` template shouldn't have been modified because its `h3.title` is desired, then the `events-block-topics` will need to be modified to either a) not extend the `block-1` template, or b) alter the twig `{% block title %}` from `events-block-topics` to use the requested `h2`.