### PR TITLE
sg-955 - Homepage refresh

### DIFF
--- a/config/block.block.sfgovsearchblock.yml
+++ b/config/block.block.sfgovsearchblock.yml
@@ -21,6 +21,6 @@ settings:
 visibility:
   request_path:
     id: request_path
-    pages: "<front>\r\n/search"
+    pages: /search
     negate: true
     context_mapping: {  }

--- a/config/field.field.paragraph.block.field_block.yml
+++ b/config/field.field.paragraph.block.field_block.yml
@@ -7,6 +7,10 @@ dependencies:
     - paragraphs.paragraphs_type.block
   module:
     - block_field
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
 id: paragraph.block.field_block
 field_name: field_block
 entity_type: paragraph
@@ -19,6 +23,7 @@ default_value: {  }
 default_value_callback: ''
 settings:
   plugin_ids:
+    'views_block:services-block_3': 'views_block:services-block_3'
     sfgov_search_form_block: sfgov_search_form_block
     'simple_block:new_website_san_francisco': 'simple_block:new_website_san_francisco'
     'views_exposed_filter_block:search-page_1': 'views_exposed_filter_block:search-page_1'

--- a/config/views.view.events.yml
+++ b/config/views.view.events.yml
@@ -591,6 +591,7 @@ display:
         link_url: false
         filters: false
         filter_groups: false
+        sorts: false
       row:
         type: 'entity:node'
         options:
@@ -669,10 +670,67 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           plugin_id: numeric
+        field_start_date_value:
+          id: field_start_date_value
+          table: node__field_start_date
+          field: field_start_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '>='
+          value:
+            min: ''
+            max: ''
+            value: '-1 day'
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+            min_placeholder: ''
+            max_placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: datetime
       filter_groups:
         operator: AND
         groups:
           1: AND
+      sorts:
+        field_start_date_value:
+          id: field_start_date_value
+          table: node__field_start_date
+          field: field_start_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: ASC
+          exposed: false
+          expose:
+            label: ''
+          granularity: second
+          plugin_id: datetime
     cache_metadata:
       max-age: -1
       contexts:

--- a/config/views.view.services.yml
+++ b/config/views.view.services.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.card
     - core.entity_view_mode.node.teaser
+    - field.storage.node.field_description
     - field.storage.node.field_direct_external_url
     - field.storage.node.field_sort_title
     - node.type.step_by_step
@@ -13,6 +14,7 @@ dependencies:
   module:
     - link
     - node
+    - text
     - user
     - views_conditional
 id: services
@@ -427,6 +429,355 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
+  block_3:
+    display_plugin: block
+    id: block_3
+    display_title: 'All top level'
+    position: 6
+    display_options:
+      display_extenders: {  }
+      style:
+        type: default
+        options:
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      defaults:
+        style: false
+        row: false
+        fields: false
+        filters: false
+        filter_groups: false
+        css_class: false
+        title: false
+      row:
+        type: fields
+        options:
+          default_field_elements: false
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+        field_description:
+          id: field_description
+          table: node__field_description
+          field: field_description
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: text_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        nothing:
+          id: nothing
+          table: views
+          field: nothing
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: "<div>\r\n  <h6>{{ title }}</h6>\r\n  {{ field_description }}\r\n</div>"
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: false
+          plugin_id: custom
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            topic: topic
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        field_top_level_topic_value:
+          id: field_top_level_topic_value
+          table: node__field_top_level_topic
+          field: field_top_level_topic_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: boolean
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            '***LANGUAGE_language_interface***': '***LANGUAGE_language_interface***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      display_description: ''
+      css_class: all-top-level-topics
+      title: ''
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_description'
   page_az:
     display_plugin: page
     id: page_az

--- a/web/themes/custom/sfgovpl/README.md
+++ b/web/themes/custom/sfgovpl/README.md
@@ -51,7 +51,7 @@ TODO: update the following.
 
 setup.sh to generate a symbolic link between the pattern library _patterns folder and the src folder.
 
-## TODO: 
+## TODO:
 
   - Implement Javascript.
   - remove `src/fonts` and `dist/fonts` if they are going to be served via CDN or Google Fonts.
@@ -80,19 +80,20 @@ the `sfgovpl.libraries.yml` defines the library that references the css and js f
 
 ## TODO:
   - review and revise all of the above, because some of it will be irrelevant soon
-  
+
 ## What is relevant and remains true:
   - this theme uses sass
   - this theme uses the gulp task runner (v4) to compile sass to css
   - there is no gulp task to concat and minify js
-  
+
 ### Minimum node and npm versions
 ```
 node: 10.3.0
 npm: 6.1.0
 ```
+
 ### Compile sass and watch for changes
 from this directory:
 ```
-$ gulp 
+$ gulp
 ```

--- a/web/themes/custom/sfgovpl/dist/css/drupal.css
+++ b/web/themes/custom/sfgovpl/dist/css/drupal.css
@@ -6541,9 +6541,15 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 950px) {
   .paragraph--type--campaign .__title {
-    margin-bottom: 40px;
     font-size: 40px;
-    line-height: 48px;
+    font-weight: 500;
+    line-height: 47px;
+    margin-bottom: 40px;
+  }
+  .paragraph--type--campaign .__title.sfgov-translate-lang-zh-TW {
+    font-size: 40px;
+    line-height: 59px;
+    letter-spacing: 2px;
   }
 }
 
@@ -6767,11 +6773,22 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 }
 
 .paragraph--type--people .__description p {
+  font-size: 17px;
+  font-weight: 500;
+  line-height: 24px;
   color: #1c3e57;
   margin: 0;
-  font-size: 17px;
-  line-height: 24px;
-  font-weight: 500;
+}
+
+.paragraph--type--people .__description p.sfgov-translate-lang-zh-TW {
+  font-size: 18px;
+  line-height: 26px;
+  letter-spacing: 1px;
+  font-weight: 700;
+  /* antialiased, none, subpixel-antialiased*/
+  -webkit-font-smoothing: antialiased;
+  font-smoothing: antialiased;
+  font-smooth: always;
 }
 
 .paragraph--type--people .__description p:last-child {
@@ -7354,9 +7371,20 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 }
 
 .sfgov-services.all-top-level-topics .sfgov-container-item h6 {
-  margin: 0;
   font-size: 20px;
   font-weight: 500;
+  line-height: 27px;
+  margin: 0;
+}
+
+.sfgov-services.all-top-level-topics .sfgov-container-item h6.sfgov-translate-lang-zh-TW {
+  font-weight: 700;
+  line-height: 30px;
+  letter-spacing: 2px;
+  /* antialiased, none, subpixel-antialiased*/
+  -webkit-font-smoothing: antialiased;
+  font-smoothing: antialiased;
+  font-smooth: always;
 }
 
 .sfgov-services.all-top-level-topics .sfgov-container-item a {

--- a/web/themes/custom/sfgovpl/dist/css/drupal.css
+++ b/web/themes/custom/sfgovpl/dist/css/drupal.css
@@ -6539,11 +6539,17 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 }
 
 .paragraph--type--people .__people-title {
-  font-size: 33px;
+  font-size: 24px;
   font-weight: 500;
-  letter-spacing: -.3px;
-  line-height: 43px;
+  line-height: 30px;
+  margin-top: 20px;
   margin-bottom: 50px;
+}
+
+.paragraph--type--people .__people-title.sfgov-translate-lang-zh-TW {
+  font-size: 24px;
+  line-height: 36px;
+  letter-spacing: 2px;
 }
 
 @media screen and (min-width: 768px) {
@@ -6551,6 +6557,7 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
     font-size: 30px;
     font-weight: 500;
     line-height: 42px;
+    margin-top: 0;
   }
   .paragraph--type--people .__people-title.sfgov-translate-lang-zh-TW {
     font-size: 30px;
@@ -6683,8 +6690,16 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 .paragraph--type--people .__description {
   border-radius: 8px;
-  padding: 30px;
+  padding: 20px;
+  margin: 40px 0 20px;
   background: #fff;
+}
+
+@media screen and (min-width: 768px) {
+  .paragraph--type--people .__description {
+    margin: 0;
+    padding: 40px;
+  }
 }
 
 @media screen and (min-width: 950px) {
@@ -6752,7 +6767,13 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
   font-smoothing: antialiased;
   font-smooth: always;
   padding-bottom: 60px;
-  padding-top: 60px;
+  padding-top: 80px;
+}
+
+@media screen and (min-width: 768px) {
+  .sfgov-title--elected-officials {
+    margin-bottom: 60px;
+  }
 }
 
 .sfgov-title--elected-officials .__people-title {
@@ -6771,10 +6792,6 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 .sfgov-title--elected-officials .sfgov-people--content {
   position: relative;
-}
-
-.sfgov-title--elected-officials .person-container {
-  margin-bottom: 20px;
 }
 
 @media screen and (min-width: 768px) {
@@ -6816,7 +6833,7 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
   width: 110px;
   height: 110px;
   margin-bottom: 30px;
-  margin-right: 28px;
+  margin-right: 20px;
   vertical-align: top;
 }
 
@@ -7000,7 +7017,13 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 950px) {
   .sfgov-title--board-of-supervisors .sfgov-people--content {
-    padding-bottom: 80px;
+    padding-bottom: 120px;
+  }
+}
+
+@media screen and (min-width: 1280px) {
+  .sfgov-title--board-of-supervisors .sfgov-people--content {
+    padding-bottom: 100px;
   }
 }
 

--- a/web/themes/custom/sfgovpl/dist/css/drupal.css
+++ b/web/themes/custom/sfgovpl/dist/css/drupal.css
@@ -6629,9 +6629,11 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 .paragraph--type--people .person-photo {
   display: inline-block;
-  height: 70px;
-  margin-right: 22px;
-  width: 70px;
+  height: 80px;
+  margin-right: 18px;
+  width: 80px;
+  margin-top: 0;
+  margin-bottom: 0;
 }
 
 .paragraph--type--people .person-bio {
@@ -6670,8 +6672,7 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 }
 
 .paragraph--type--people .__description {
-  border-radius: 8px 0 0 8px;
-  margin-left: 20px;
+  border-radius: 8px;
   padding: 30px;
   background: #fff;
 }
@@ -6680,7 +6681,7 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
   .paragraph--type--people .__description {
     margin-left: 0;
     position: absolute;
-    right: 0;
+    right: 40px;
     width: 33%;
   }
 }
@@ -6704,12 +6705,11 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 }
 
 .paragraph--type--people .__description p {
-  font-size: 20px;
-  font-weight: 500;
-  line-height: 32px;
   color: #1c3e57;
-  font-style: italic;
   margin: 0;
+  font-size: 17px;
+  line-height: 24px;
+  font-weight: 500;
 }
 
 .paragraph--type--people .__description p:last-child {
@@ -6771,6 +6771,12 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
   }
 }
 
+@media screen and (min-width: 950px) {
+  .sfgov-title--elected-officials .person-container {
+    width: 70%;
+  }
+}
+
 .sfgov-title--elected-officials.sfgov-paragraph-people-single article,
 .sfgov-title--elected-officials .__person-2 {
   margin: 0 auto;
@@ -6795,11 +6801,21 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 .sfgov-title--elected-officials .person-photo {
   display: inline-block;
-  width: 140px;
-  height: 140px;
+  width: 110px;
+  height: 110px;
   margin-bottom: 30px;
   margin-right: 28px;
   vertical-align: top;
+}
+
+@media screen and (min-width: 768px) {
+  .sfgov-title--elected-officials .person-photo {
+    width: 200px;
+    height: 200px;
+    float: left;
+    margin-bottom: 50px;
+    margin-right: 40px;
+  }
 }
 
 .sfgov-title--elected-officials .person-photo img {
@@ -6850,22 +6866,15 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
   }
 }
 
-@media screen and (min-width: 768px) {
-  .sfgov-title--elected-officials .__people-title {
-    margin-bottom: 50px;
-  }
-}
-
 .sfgov-title--elected-officials .person-bio {
   display: inline-block;
   text-align: left;
-  width: calc(100% - 194px);
+  width: auto;
 }
 
 @media screen and (min-width: 768px) {
   .sfgov-title--elected-officials .person-bio {
     vertical-align: top;
-    width: calc(100% - 194px);
   }
 }
 
@@ -6925,7 +6934,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
   font-size: 24px;
   font-weight: 500;
   line-height: 34px;
-  color: #a9d6ea;
+  color: #fff;
+  opacity: .7;
   margin-bottom: 12px;
 }
 
@@ -6946,44 +6956,53 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
   }
 }
 
-@media screen and (min-width: 950px) {
-  .sfgov-title--elected-officials .person-subtitle {
-    margin-left: 173px;
-    margin-top: -75px;
-    max-width: 373px;
-  }
-}
-
 .sfgov-title--board-of-supervisors {
-  background: #0c1464;
-  color: #fff;
-  padding-bottom: 185px;
   position: relative;
-  /* antialiased, none, subpixel-antialiased*/
-  -webkit-font-smoothing: antialiased;
-  font-smoothing: antialiased;
-  font-smooth: always;
-}
-
-.sfgov-title--board-of-supervisors .sfgov-people--content .__person-2 {
   margin: 0 auto;
   max-width: 1090px;
   padding-left: 20px;
   padding-right: 20px;
   width: 100%;
+  margin-top: 40px;
+  margin-bottom: 40px;
 }
 
 @media screen and (min-width: 1280px) {
-  .sfgov-title--board-of-supervisors .sfgov-people--content .__person-2 {
+  .sfgov-title--board-of-supervisors {
     padding: 0;
+  }
+}
+
+.sfgov-title--board-of-supervisors .inner {
+  position: relative;
+  background: #edf4f7;
+  border-radius: 8px;
+  padding: 20px;
+}
+
+@media screen and (min-width: 768px) {
+  .sfgov-title--board-of-supervisors .inner {
+    padding: 40px;
+  }
+}
+
+@media screen and (min-width: 950px) {
+  .sfgov-title--board-of-supervisors .sfgov-people--content {
+    padding-bottom: 80px;
   }
 }
 
 .sfgov-title--board-of-supervisors .sfgov-people--content .__person-2 .field__item {
   vertical-align: top;
-  margin: 0 auto 35px;
+  margin: 0 auto 20px;
   width: auto;
   display: block;
+}
+
+@media screen and (min-width: 768px) {
+  .sfgov-title--board-of-supervisors .sfgov-people--content .__person-2 .field__item {
+    margin-bottom: 40px;
+  }
 }
 
 @media screen and (min-width: 700px) {
@@ -7000,72 +7019,64 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
   }
 }
 
-.sfgov-title--board-of-supervisors .person-name a:link {
-  color: #fff;
-}
-
-.sfgov-title--board-of-supervisors .person-name a:visited, .sfgov-title--board-of-supervisors .person-name a:link:visited {
-  color: #fff;
-}
-
-.sfgov-title--board-of-supervisors .person-name a:focus {
-  color: #fff;
-}
-
-.sfgov-title--board-of-supervisors .person-name a.active:hover, .sfgov-title--board-of-supervisors .person-name a.is-active:hover, .sfgov-title--board-of-supervisors .person-name a.active-trail:hover, .sfgov-title--board-of-supervisors .person-name a.visited:hover, .sfgov-title--board-of-supervisors .person-name a:hover {
-  color: #fff;
-}
-
-.sfgov-title--board-of-supervisors .person-name a.is-active, .sfgov-title--board-of-supervisors .person-name a:active, .sfgov-title--board-of-supervisors .person-name a.active-trail {
-  color: #fff;
-}
-
 .sfgov-title--board-of-supervisors .__people-title {
-  margin: 0 auto;
-  max-width: 1090px;
-  padding-left: 20px;
-  padding-right: 20px;
-  width: 100%;
   margin-bottom: 40px;
 }
 
-@media screen and (min-width: 1280px) {
-  .sfgov-title--board-of-supervisors .__people-title {
-    padding: 0;
-  }
+.sfgov-title--board-of-supervisors .person-title {
+  opacity: .7;
 }
 
 .sfgov-title--board-of-supervisors .__description {
-  bottom: 77px;
+  bottom: 40px;
 }
 
 .sfgov-title--elected-officers,
 .sfgov-title--city-officials {
-  background: #edf4f7;
-}
-
-.sfgov-title--elected-officers .sfgov-people--content .__person-2,
-.sfgov-title--city-officials .sfgov-people--content .__person-2 {
   margin: 0 auto;
   max-width: 1090px;
   padding-left: 20px;
   padding-right: 20px;
   width: 100%;
+  margin-top: 40px;
+  margin-bottom: 40px;
 }
 
 @media screen and (min-width: 1280px) {
-  .sfgov-title--elected-officers .sfgov-people--content .__person-2,
-  .sfgov-title--city-officials .sfgov-people--content .__person-2 {
+  .sfgov-title--elected-officers,
+  .sfgov-title--city-officials {
     padding: 0;
+  }
+}
+
+.sfgov-title--elected-officers .inner,
+.sfgov-title--city-officials .inner {
+  background: #edf4f7;
+  border-radius: 8px;
+  padding: 20px;
+}
+
+@media screen and (min-width: 768px) {
+  .sfgov-title--elected-officers .inner,
+  .sfgov-title--city-officials .inner {
+    padding: 40px;
+    padding-bottom: 20px;
   }
 }
 
 .sfgov-title--elected-officers .sfgov-people--content .__person-2 .field__item,
 .sfgov-title--city-officials .sfgov-people--content .__person-2 .field__item {
   vertical-align: top;
-  margin: 0 auto 35px;
+  margin: 0 auto 20px;
   width: auto;
   display: block;
+}
+
+@media screen and (min-width: 768px) {
+  .sfgov-title--elected-officers .sfgov-people--content .__person-2 .field__item,
+  .sfgov-title--city-officials .sfgov-people--content .__person-2 .field__item {
+    margin-bottom: 40px;
+  }
 }
 
 @media screen and (min-width: 700px) {
@@ -7086,19 +7097,7 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 .sfgov-title--elected-officers .__people-title,
 .sfgov-title--city-officials .__people-title {
-  margin: 0 auto;
-  max-width: 1090px;
-  padding-left: 20px;
-  padding-right: 20px;
-  width: 100%;
   margin-bottom: 40px;
-}
-
-@media screen and (min-width: 1280px) {
-  .sfgov-title--elected-officers .__people-title,
-  .sfgov-title--city-officials .__people-title {
-    padding: 0;
-  }
 }
 
 .sfgov-title--elected-officers .person-title,
@@ -7109,11 +7108,6 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 .sfgov-title--elected-officers .person-subtitle,
 .sfgov-title--city-officials .person-subtitle {
   opacity: .7;
-}
-
-.path-frontpage .sfgov-people > div:last-of-type .sfgov-title--city-officials,
-.path-frontpage .sfgov-people > div:last-of-type .sfgov-title--elected-officers {
-  margin-bottom: 50px;
 }
 
 .sfgov-title--city-officials {

--- a/web/themes/custom/sfgovpl/dist/css/drupal.css
+++ b/web/themes/custom/sfgovpl/dist/css/drupal.css
@@ -2205,17 +2205,16 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 }
 
 .sfgov-new-website h2 {
-  font-size: 30px;
+  font-size: 20px;
   font-weight: 500;
-  line-height: 42px;
+  line-height: 27px;
   color: #1c3e57;
 }
 
 .sfgov-new-website h2.sfgov-translate-lang-zh-TW {
-  font-size: 30px;
-  line-height: 42px;
-  letter-spacing: 2px;
   font-weight: 700;
+  line-height: 30px;
+  letter-spacing: 2px;
   /* antialiased, none, subpixel-antialiased*/
   -webkit-font-smoothing: antialiased;
   font-smoothing: antialiased;
@@ -2223,9 +2222,9 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 }
 
 .sfgov-new-website p:last-child {
-  font-size: 20px;
+  font-size: 17px;
   font-weight: 400;
-  line-height: 28px;
+  line-height: 24px;
   color: #1c3e57;
 }
 
@@ -6372,9 +6371,9 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 }
 
 .paragraph--type--additional-info p:last-child {
-  font-size: 20px;
+  font-size: 17px;
   font-weight: 400;
-  line-height: 28px;
+  line-height: 24px;
   color: #1c3e57;
 }
 

--- a/web/themes/custom/sfgovpl/dist/css/drupal.css
+++ b/web/themes/custom/sfgovpl/dist/css/drupal.css
@@ -966,9 +966,9 @@ img {
 
 @media screen and (min-width: 768px) {
   .sfgov-logo--seal {
-    height: 42px;
+    height: 56px;
     margin-right: 4px;
-    width: 42px;
+    width: 56px;
   }
 }
 
@@ -979,8 +979,8 @@ img {
 
 @media screen and (min-width: 768px) {
   .sfgov-logo--lockup {
-    width: 112px;
-    height: 23.39px;
+    width: 134px;
+    height: 29px;
   }
 }
 

--- a/web/themes/custom/sfgovpl/dist/css/drupal.css
+++ b/web/themes/custom/sfgovpl/dist/css/drupal.css
@@ -2202,7 +2202,13 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
   background: #a9d6ea;
   border-radius: 8px;
   margin-bottom: 80px;
-  padding: 40px;
+  padding: 20px;
+}
+
+@media screen and (min-width: 768px) {
+  .sfgov-new-website {
+    padding: 40px;
+  }
 }
 
 .sfgov-new-website h2 {
@@ -2243,6 +2249,14 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 .sfgov-new-website a.is-active, .sfgov-new-website a:active, .sfgov-new-website a.active-trail {
   color: #1c3e57;
+}
+
+.paragraph--title--new-website-disclaimer > h2 {
+  display: none;
+}
+
+.paragraph--title--new-website-disclaimer .sfgov-container {
+  padding: 0;
 }
 
 .path-frontpage .view-news {

--- a/web/themes/custom/sfgovpl/dist/css/drupal.css
+++ b/web/themes/custom/sfgovpl/dist/css/drupal.css
@@ -2202,6 +2202,7 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
   background: #a9d6ea;
   border-radius: 8px;
   margin-bottom: 80px;
+  padding: 40px;
 }
 
 .sfgov-new-website h2 {

--- a/web/themes/custom/sfgovpl/dist/css/drupal.css
+++ b/web/themes/custom/sfgovpl/dist/css/drupal.css
@@ -979,7 +979,7 @@ img {
 
 @media screen and (min-width: 768px) {
   .sfgov-logo--lockup {
-    width: 134px;
+    width: 150px;
     height: 29px;
   }
 }

--- a/web/themes/custom/sfgovpl/dist/css/drupal.css
+++ b/web/themes/custom/sfgovpl/dist/css/drupal.css
@@ -8792,6 +8792,7 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
   padding: 13px 20px 11px;
   text-align: center;
   text-decoration: none;
+  padding-top: 11px;
 }
 
 .paragraph--type--events .more-link a:hover {

--- a/web/themes/custom/sfgovpl/dist/css/drupal.css
+++ b/web/themes/custom/sfgovpl/dist/css/drupal.css
@@ -1888,17 +1888,18 @@ details[open] .details__content {
   padding-left: 0;
 }
 
-.path-frontpage .gtranslate_container,
-.path-search .gtranslate_container {
-  right: 55px;
-}
-
 .gtranslate_container {
   display: inline-block;
-  margin-right: 30px;
+  margin-right: 20px;
 }
 
-@media screen and (max-width: 768px) {
+@media screen and (min-width: 950px) {
+  .gtranslate_container {
+    margin-right: 30px;
+  }
+}
+
+@media screen and (max-width: 767px) {
   .gtranslate_container {
     position: absolute;
     right: 105px;
@@ -1961,12 +1962,10 @@ details[open] .details__content {
   display: none;
 }
 
-.path-frontpage header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search,
 .path-search header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
   display: none;
 }
 
-.path-frontpage header[role="banner"] .head-right--container,
 .path-search header[role="banner"] .head-right--container {
   margin-top: 9px;
 }
@@ -2074,7 +2073,7 @@ header[role="banner"] .sfgov-logo__container {
 
 header[role="banner"] .head-right--container {
   float: right;
-  margin-top: 2px;
+  margin-top: 10px;
   text-align: right;
   width: 54%;
 }
@@ -2097,7 +2096,7 @@ header[role="banner"] .head-right--container .sfgov-menu-btn {
 
 @media screen and (min-width: 768px) {
   header[role="banner"] .head-right--container {
-    width: 75%;
+    width: 70%;
   }
 }
 
@@ -2142,7 +2141,7 @@ header[role="banner"] nav[role="navigation"] .sfgov-main-navigation .menu > li a
   }
   header[role="banner"] nav[role="navigation"] .sfgov-main-navigation .menu > li {
     display: inline-block;
-    margin-right: 30px;
+    margin-right: 20px;
   }
   header[role="banner"] nav[role="navigation"] .sfgov-main-navigation .menu > li a {
     font-size: 17px;
@@ -2152,6 +2151,12 @@ header[role="banner"] nav[role="navigation"] .sfgov-main-navigation .menu > li a
     margin: 0;
     padding: 0;
     border: 0;
+  }
+}
+
+@media screen and (min-width: 950px) {
+  header[role="banner"] nav[role="navigation"] .sfgov-main-navigation .menu > li {
+    margin-right: 30px;
   }
 }
 

--- a/web/themes/custom/sfgovpl/dist/css/drupal.css
+++ b/web/themes/custom/sfgovpl/dist/css/drupal.css
@@ -6523,11 +6523,6 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
   color: #0c1464;
 }
 
-.paragraph--type--people {
-  padding-bottom: 60px;
-  padding-top: 60px;
-}
-
 .paragraph--type--people .__people-title {
   font-size: 33px;
   font-weight: 500;
@@ -6741,6 +6736,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
   -webkit-font-smoothing: antialiased;
   font-smoothing: antialiased;
   font-smooth: always;
+  padding-bottom: 60px;
+  padding-top: 60px;
 }
 
 .sfgov-title--elected-officials .__people-title {

--- a/web/themes/custom/sfgovpl/dist/css/drupal.css
+++ b/web/themes/custom/sfgovpl/dist/css/drupal.css
@@ -7081,7 +7081,6 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 .sfgov-services.paragraph {
   width: 100%;
-  background: #edf4f7;
   padding-top: 60px;
 }
 
@@ -7244,6 +7243,26 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
   .sfgov-services .sfgov-services-section {
     margin-bottom: 60px;
   }
+}
+
+.sfgov-services.all-top-level-topics .sfgov-container-item {
+  margin-bottom: 2.6rem;
+}
+
+.sfgov-services.all-top-level-topics .sfgov-container-item h6 {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 500;
+}
+
+.sfgov-services.all-top-level-topics .sfgov-container-item a {
+  text-decoration: none;
+}
+
+.sfgov-services.all-top-level-topics .sfgov-container-item p {
+  margin-top: 0;
+  color: #6b8292;
+  font-weight: 300;
 }
 
 .sfds-call-to-action h3 {

--- a/web/themes/custom/sfgovpl/dist/css/drupal.css
+++ b/web/themes/custom/sfgovpl/dist/css/drupal.css
@@ -8663,6 +8663,35 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
   background: #0c1464;
 }
 
+.sfgov-events.paragraph {
+  padding-top: 50px;
+  padding-bottom: 75px;
+  background-color: #f8f8f8;
+}
+
+.sfgov-events.paragraph > .sfgov-header-section {
+  display: none;
+}
+
+.sfgov-events.paragraph .view-events-block-container {
+  padding-top: 30px;
+  padding-bottom: 10px;
+}
+
+.sfgov-events.paragraph .paragraph--type--button {
+  margin: 0 auto;
+  max-width: 1090px;
+  padding-left: 20px;
+  padding-right: 20px;
+  width: 100%;
+}
+
+@media screen and (min-width: 1280px) {
+  .sfgov-events.paragraph .paragraph--type--button {
+    padding: 0;
+  }
+}
+
 .maintenance-page {
   padding: 30px 20px;
 }

--- a/web/themes/custom/sfgovpl/dist/css/drupal.css
+++ b/web/themes/custom/sfgovpl/dist/css/drupal.css
@@ -6395,24 +6395,41 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 }
 
 .paragraph-child--campaign {
-  background: #f4c435;
+  margin: 0 auto;
+  max-width: 1090px;
+  padding-left: 20px;
+  padding-right: 20px;
+  width: 100%;
+}
+
+@media screen and (min-width: 1280px) {
+  .paragraph-child--campaign {
+    padding: 0;
+  }
 }
 
 .paragraph--type--campaign {
-  margin: 0 auto;
-  max-width: 1280px;
-  width: 100%;
   background: #f4c435;
-  display: table;
+  border-radius: 10px;
+  overflow: hidden;
 }
 
-.paragraph--type--campaign .__media {
-  margin-bottom: 39px;
+@media screen and (min-width: 950px) {
+  .paragraph--type--campaign {
+    display: -webkit-box;
+    display: flex;
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: reverse;
+            flex-direction: row-reverse;
+  }
 }
 
 @media screen and (min-width: 950px) {
   .paragraph--type--campaign .__media {
-    margin-bottom: 0;
+    -webkit-box-flex: 0;
+            flex: 0 0 50%;
+    overflow: hidden;
+    position: relative;
   }
 }
 
@@ -6422,20 +6439,43 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 }
 
 @media screen and (min-width: 950px) {
-  .paragraph--type--campaign .paragraph-campaign--text {
-    background: #f4c435;
-    display: table-cell;
+  .paragraph--type--campaign img {
+    position: absolute;
+    width: auto;
     height: 100%;
-    max-width: 444px;
+    top: 50%;
+    left: 50%;
+    min-height: 100%;
+    min-width: 100%;
+    -webkit-transform: translate(-50%, -50%);
+            transform: translate(-50%, -50%);
+    max-width: unset;
+  }
+}
+
+.paragraph--type--campaign .paragraph-campaign--text {
+  padding: 20px;
+}
+
+@media screen and (min-width: 950px) {
+  .paragraph--type--campaign .paragraph-campaign--text {
+    -webkit-box-flex: 0;
+            flex: 0 0 50%;
+    height: 100%;
+    padding: 40px 60px 40px 40px;
     vertical-align: middle;
   }
+}
+
+.paragraph--type--campaign .paragraph-campaign--text p {
+  margin: 0 0 15px;
 }
 
 .paragraph--type--campaign .__title {
   font-size: 30px;
   font-weight: 500;
   line-height: 42px;
-  padding: 0 38px 39px;
+  margin-bottom: 28px;
 }
 
 .paragraph--type--campaign .__title.sfgov-translate-lang-zh-TW {
@@ -6449,14 +6489,16 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
   font-smooth: always;
 }
 
-.paragraph--type--campaign .__link {
-  padding: 0 38px 39px;
+@media screen and (min-width: 950px) {
+  .paragraph--type--campaign .__title {
+    margin-bottom: 40px;
+    font-size: 40px;
+    line-height: 48px;
+  }
 }
 
-@media screen and (min-width: 950px) {
-  .paragraph--type--campaign .__link {
-    padding-bottom: 0;
-  }
+.paragraph--type--campaign .__link {
+  margin-bottom: 20px;
 }
 
 .paragraph--type--campaign .__link a {

--- a/web/themes/custom/sfgovpl/dist/css/drupal.css
+++ b/web/themes/custom/sfgovpl/dist/css/drupal.css
@@ -925,7 +925,8 @@ img {
 
 @media screen and (min-width: 1280px) {
   .sfgov-full-bleed .sfgov-section-container {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -1023,7 +1024,8 @@ img {
 
 @media screen and (min-width: 1280px) {
   .sfgov-search-311-block {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -1316,7 +1318,8 @@ header[role="banner"] [data-drupal-selector="edit-actions"] input[data-drupal-se
 
 @media screen and (min-width: 1280px) {
   .alert .alert--container {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -1487,7 +1490,8 @@ header[role="banner"] [data-drupal-selector="edit-actions"] input[data-drupal-se
 
 @media screen and (min-width: 1280px) {
   .hero-banner.default {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -1578,7 +1582,8 @@ header[role="banner"] [data-drupal-selector="edit-actions"] input[data-drupal-se
 
 @media screen and (min-width: 1280px) {
   .hero-banner.color .hero-banner--container {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -1754,7 +1759,8 @@ details[open] .details__content {
 
 @media screen and (min-width: 1280px) {
   .sfgov-footer .sfgov-footer__container {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -2055,7 +2061,8 @@ header[role="banner"] .sfgov-nav-container {
 
 @media screen and (min-width: 1280px) {
   header[role="banner"] .sfgov-nav-container {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -2281,7 +2288,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .news-front {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -2462,7 +2470,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .sfgov-alpha-banner .sfgov-alpha-banner__content {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -2672,7 +2681,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .last-updated {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -2835,7 +2845,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .sfgov-featured-items {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -2887,7 +2898,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .sfgov-services-container .sfgov-services {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -2963,7 +2975,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .basic--content {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -3082,7 +3095,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 @media screen and (min-width: 1280px) {
   .page-node-type-department .dept-heading--section,
   .page-node-type-department .sfgov-dept-section-heading {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -3115,7 +3129,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .page-node-type-department .content-head--content {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -3175,7 +3190,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .page-node-type-department .sfgov-dept-section-content-container {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -3192,7 +3208,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .page-node-type-department .sfgov-dept-in-this-page {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -3321,7 +3338,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .page-node-type-department .sfgov-dept-spotlight .sfgov-spotlight {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -3458,7 +3476,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .page-node-type-department .sfgov-dept-resources .sfgov-dept-resources-container {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -3510,7 +3529,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .page-node-type-department .sfgov-dept-about .sfgov-dept-about-content {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -3962,7 +3982,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .page-node-type-department .sfgov-dept-public-records {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -4061,7 +4082,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .page-node-type-form-page .form-page {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -4079,7 +4101,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .form-confirmation-page__content {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -4121,7 +4144,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .page-node-type-information-page .__information-section .sfgov-section h2 {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -4169,7 +4193,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .page-node-type-information-page .__information-section .sfgov-section .sfgov-section__content {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -4196,7 +4221,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .page-node-type-information-page .info--last-updated {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -4215,7 +4241,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .page-node-type-information-page .info--departments-container .info--departments {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -4408,7 +4435,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .page-node-type-news .news--ankle .__dept {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -4781,7 +4809,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .page-node-type-event .event--meta .event--meta-inner {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -5323,7 +5352,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .page-node-type-topic .view--departments-block-2-topic-related-depts .container {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -5371,7 +5401,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .page-node-type-topic .view--departments-block-2-topic-related-depts h2 {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -5555,7 +5586,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .page-node-type-transaction .banner-subheader .banner-subheader__container {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -5704,7 +5736,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .page-node-type-transaction .transaction--ankle .__departments {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -6046,7 +6079,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .page-node-type-step-by-step .step-by-step-content {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -6332,7 +6366,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .region-fourofour-footer {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -6418,7 +6453,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .paragraph-child--campaign {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -6582,7 +6618,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .paragraph--type--people .__person.person-item-multiple {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -6786,7 +6823,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .sfgov-title--elected-officials .__people-title {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -6818,7 +6856,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 @media screen and (min-width: 1280px) {
   .sfgov-title--elected-officials.sfgov-paragraph-people-single article,
   .sfgov-title--elected-officials .__person-2 {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -6998,7 +7037,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .sfgov-title--board-of-supervisors {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -7080,7 +7120,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 @media screen and (min-width: 1280px) {
   .sfgov-title--elected-officers,
   .sfgov-title--city-officials {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -7161,22 +7202,11 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 }
 
 .sfgov-services.paragraph .sfgov-header-section {
-  margin: 0 auto;
-  max-width: 1090px;
-  padding-left: 20px;
-  padding-right: 20px;
-  width: 100%;
   font-size: 33px;
   font-weight: 500;
   letter-spacing: -.3px;
   line-height: 43px;
   margin-bottom: 19px;
-}
-
-@media screen and (min-width: 1280px) {
-  .sfgov-services.paragraph .sfgov-header-section {
-    padding: 0;
-  }
 }
 
 @media screen and (min-width: 768px) {
@@ -7211,12 +7241,6 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
   }
 }
 
-@media screen and (min-width: 768px) {
-  .sfgov-services.paragraph .sfgov-header-section {
-    margin-bottom: 70px;
-  }
-}
-
 .sfgov-services.paragraph .sfgov-cta-button__container {
   margin: 0 auto;
   max-width: 1130px;
@@ -7248,17 +7272,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 }
 
 .sfgov-services.paragraph .sfgov-container {
-  margin: 0 auto;
-  max-width: 1090px;
-  padding-left: 20px;
-  padding-right: 20px;
-  width: 100%;
-}
-
-@media screen and (min-width: 1280px) {
-  .sfgov-services.paragraph .sfgov-container {
-    padding: 0;
-  }
+  padding-left: 0;
+  padding-right: 0;
 }
 
 .sfgov-services > .title {
@@ -7316,7 +7331,26 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 }
 
 .sfgov-services.all-top-level-topics .sfgov-container-item {
-  margin-bottom: 2.6rem;
+  margin-bottom: 0;
+  padding: 20px 0;
+}
+
+@media screen and (min-width: 768px) {
+  .sfgov-services.all-top-level-topics .sfgov-container-item {
+    padding: 30px 0;
+  }
+}
+
+@media screen and (min-width: 768px) {
+  .sfgov-services.all-top-level-topics .sfgov-container-item > div {
+    margin-right: 60px;
+  }
+}
+
+@media screen and (min-width: 768px) {
+  .sfgov-services.all-top-level-topics .sfgov-container-item:nth-child(3n+3) > div {
+    margin-right: 0;
+  }
 }
 
 .sfgov-services.all-top-level-topics .sfgov-container-item h6 {
@@ -7329,10 +7363,13 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
   text-decoration: none;
 }
 
+.sfgov-services.all-top-level-topics .sfgov-container-item a:hover {
+  text-decoration: underline;
+}
+
 .sfgov-services.all-top-level-topics .sfgov-container-item p {
-  margin-top: 0;
+  margin: 0;
   color: #6b8292;
-  font-weight: 300;
 }
 
 .sfds-call-to-action h3 {
@@ -7661,7 +7698,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .path-services .sfgov-services {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -7803,7 +7841,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .path-departments .sfgov-departments {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -8237,7 +8276,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 @media screen and (min-width: 1280px) {
   .path-events .sfgov-events-pill-container .sfgov-events-pill-list-container,
   .path-past-events .sfgov-events-pill-container .sfgov-events-pill-list-container {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -8379,7 +8419,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 @media screen and (min-width: 1280px) {
   .path-events .views-element-container .view-events > div.sfgov-no-events,
   .path-past-events .views-element-container .view-events > div.sfgov-no-events {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -8482,7 +8523,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .path-frontpage .view-events-block-container {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -8658,7 +8700,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .paragraph--type--news .field h2 {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -8674,7 +8717,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .paragraph--type--news .views-news--rows {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -8694,7 +8738,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .paragraph--type--news .more-link {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -8733,7 +8778,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .paragraph--type--events .views-events--rows {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -8777,7 +8823,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .sfgov-events.paragraph .paragraph--type--button {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -8824,7 +8871,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .path-user .user-login-form {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -9088,7 +9136,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   #sfgov-search-results-container {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -9544,7 +9593,8 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 
 @media screen and (min-width: 1280px) {
   .path-frontpage .paragraph-child--block {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 

--- a/web/themes/custom/sfgovpl/src/sass/_mixins-fs.scss
+++ b/web/themes/custom/sfgovpl/src/sass/_mixins-fs.scss
@@ -240,9 +240,9 @@
 }
 
 @mixin fs-new-website-text {
-  font-size: 20px;
+  font-size: 17px;
   font-weight: $fw-regular;
-  line-height: 28px;
+  line-height: 24px;
 }
 
 @mixin fs-title-right {

--- a/web/themes/custom/sfgovpl/src/sass/_mixins.scss
+++ b/web/themes/custom/sfgovpl/src/sass/_mixins.scss
@@ -295,14 +295,13 @@
 }
 
 @mixin sidebar($child-element) {
-  border-radius: 8px 0 0 8px;
-  margin-left: 20px;
+  border-radius: 8px;
   padding: 30px;
 
   @include media($narrow-screen) {
     margin-left: 0;
     position: absolute;
-    right: 0;
+    right: 40px;
     width: 33%;
   }
 

--- a/web/themes/custom/sfgovpl/src/sass/_mixins.scss
+++ b/web/themes/custom/sfgovpl/src/sass/_mixins.scss
@@ -122,7 +122,8 @@
   width: 100%;
 
   @include media($wide-screen) {
-    padding: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 

--- a/web/themes/custom/sfgovpl/src/sass/_mixins.scss
+++ b/web/themes/custom/sfgovpl/src/sass/_mixins.scss
@@ -296,7 +296,13 @@
 
 @mixin sidebar($child-element) {
   border-radius: 8px;
-  padding: 30px;
+  padding: 20px;
+  margin: 40px 0 20px;
+
+  @include media($medium-screen) {
+    margin: 0;
+    padding: 40px;
+  }
 
   @include media($narrow-screen) {
     margin-left: 0;

--- a/web/themes/custom/sfgovpl/src/sass/_variables.scss
+++ b/web/themes/custom/sfgovpl/src/sass/_variables.scss
@@ -6,6 +6,7 @@ $c-bright-blue: #4f66ee;
 $c-blue-1: #edf4f7;
 $c-blue-2: #a9d6ea;
 $c-blue-3: #e1f3f8;
+$c-blue-4: #6b8292;
 
 $c-yellow-1: #f8f1df;
 $c-yellow-2: #f9e3a3;

--- a/web/themes/custom/sfgovpl/src/sass/block/_block-branding.scss
+++ b/web/themes/custom/sfgovpl/src/sass/block/_block-branding.scss
@@ -31,9 +31,9 @@
   height: 32px;
 
   @include media($medium-screen) {
-    height: 42px;
+    height: 56px;
     margin-right: 4px;
-    width: 42px;
+    width: 56px;
   }
 }
 
@@ -42,8 +42,7 @@
   height: 18px;
 
   @include media($medium-screen) {
-    width: 112px;
-    height: 23.39px;
+    width: 134px;
+    height: 29px;
   }
 }
-

--- a/web/themes/custom/sfgovpl/src/sass/block/_block-branding.scss
+++ b/web/themes/custom/sfgovpl/src/sass/block/_block-branding.scss
@@ -42,7 +42,7 @@
   height: 18px;
 
   @include media($medium-screen) {
-    width: 134px;
+    width: 150px;
     height: 29px;
   }
 }

--- a/web/themes/custom/sfgovpl/src/sass/components/_gtranslate.scss
+++ b/web/themes/custom/sfgovpl/src/sass/components/_gtranslate.scss
@@ -1,14 +1,12 @@
-.path-frontpage,
-.path-search {
-  .gtranslate_container {
-    right: 55px;
-  }
-}
 .gtranslate_container {
   display: inline-block;
-  margin-right: 30px;
+  margin-right: 20px;
 
-  @include media-max($medium-screen) {
+  @include media($narrow-screen) {
+    margin-right: 30px;
+  }
+
+  @include media-max($medium-screen - 1px) {
     position: absolute;
     right: 105px;
   }

--- a/web/themes/custom/sfgovpl/src/sass/components/_header.scss
+++ b/web/themes/custom/sfgovpl/src/sass/components/_header.scss
@@ -1,4 +1,3 @@
-.path-frontpage,
 .path-search {
   header[role="banner"] {
     .sfgov-mobile-nav-btn.sfgov-mobile-search {
@@ -103,7 +102,7 @@ header[role="banner"] {
   .head-right--container {
     @include clearfix;
     float: right;
-    margin-top: 2px;
+    margin-top: 10px;
     text-align: right;
     width: 54%;
     .sfgov-menu-btn {
@@ -116,7 +115,7 @@ header[role="banner"] {
       width: auto;
     }
     @include media($medium-screen) {
-      width: 75%;
+      width: 70%;
     }
   }
 
@@ -147,7 +146,7 @@ header[role="banner"] {
       .sfgov-main-navigation .menu {
         > li {
           display: inline-block;
-          margin-right: 30px;
+          margin-right: 20px;
           a {
             @include fs-nav-item;
             color: $c-bright-blue;
@@ -155,6 +154,13 @@ header[role="banner"] {
             padding: 0;
             border: 0;
           }
+        }
+      }
+    }
+    @include media($narrow-screen) {
+      .sfgov-main-navigation .menu {
+        > li {
+          margin-right: 30px;
         }
       }
     }

--- a/web/themes/custom/sfgovpl/src/sass/components/_new-website.scss
+++ b/web/themes/custom/sfgovpl/src/sass/components/_new-website.scss
@@ -3,7 +3,11 @@
   background: $c-blue-2;
   border-radius: 8px;
   margin-bottom: 80px;
-  padding: 40px;
+  padding: 20px;
+
+  @include media($medium-screen) {
+    padding: 40px;
+  }
 
   h2 {
     @include fs-title-5;
@@ -17,5 +21,15 @@
 
   a {
     @include link-colors($c-slate);
+  }
+}
+
+.paragraph--title--new-website-disclaimer {
+  > h2 {
+    display: none;
+  }
+
+  .sfgov-container {
+    padding: 0;
   }
 }

--- a/web/themes/custom/sfgovpl/src/sass/components/_new-website.scss
+++ b/web/themes/custom/sfgovpl/src/sass/components/_new-website.scss
@@ -3,6 +3,7 @@
   background: $c-blue-2;
   border-radius: 8px;
   margin-bottom: 80px;
+  padding: 40px;
 
   h2 {
     @include fs-title-5;

--- a/web/themes/custom/sfgovpl/src/sass/components/_new-website.scss
+++ b/web/themes/custom/sfgovpl/src/sass/components/_new-website.scss
@@ -5,7 +5,7 @@
   margin-bottom: 80px;
 
   h2 {
-    @include fs-title-3;
+    @include fs-title-5;
     color: $c-slate;
   }
 

--- a/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-campaign.scss
+++ b/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-campaign.scss
@@ -54,9 +54,8 @@
     @include fs-title-3;
     margin-bottom: 28px;
     @include media($narrow-screen) {
+      @include fs-title-2;
       margin-bottom: 40px;
-      font-size: 40px;
-      line-height: 48px;
     }
   }
 

--- a/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-campaign.scss
+++ b/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-campaign.scss
@@ -1,48 +1,67 @@
 .paragraph-child--campaign {
-  background: $c-yellow-3;
+  @include contain-1090;
 }
 
 .paragraph--type--campaign {
-  @include contain-1280;
   background: $c-yellow-3;
-  display: table;
+  border-radius: 10px;
+  overflow: hidden;
 
+  @include media($narrow-screen) {
+    display: flex;
+    flex-direction: row-reverse;
+  }
 
   .__media {
-    margin-bottom: 39px;
-
     @include media($narrow-screen) {
-      margin-bottom: 0;
+      flex: 0 0 50%;
+      overflow: hidden;
+      position: relative;
     }
   }
 
   img {
     display: block;
     width: 100%;
+
+    @include media($narrow-screen) {
+      position: absolute;
+      width: auto;
+      height: 100%;
+      top: 50%;
+      left: 50%;
+      min-height: 100%;
+      min-width: 100%;
+      transform: translate(-50%, -50%);
+      max-width: unset;
+    }
   }
 
   .paragraph-campaign--text {
+    padding: 20px;
     @include media($narrow-screen) {
-      background: $c-yellow-3;
-      display: table-cell;
+      flex: 0 0 50%;
       height: 100%;
-      max-width: 444px;
+      padding: 40px 60px 40px 40px;
       vertical-align: middle;
+    }
+    p {
+      margin: 0 0 15px;
     }
   }
 
   .__title {
     @include fs-title-3;
-    padding: 0 38px 39px;
+    margin-bottom: 28px;
+    @include media($narrow-screen) {
+      margin-bottom: 40px;
+      font-size: 40px;
+      line-height: 48px;
+    }
   }
 
   .__link {
-    padding: 0 38px 39px;
-
-    @include media($narrow-screen) {
-      padding-bottom: 0;
-    }
-
+    margin-bottom: 20px;
     a {
       @include button-clear;
       border: 0;

--- a/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-events.scss
+++ b/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-events.scss
@@ -26,6 +26,7 @@
 
   .more-link a {
     @include button;
+    padding-top: 11px;
   }
 }
 

--- a/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-events.scss
+++ b/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-events.scss
@@ -28,3 +28,22 @@
     @include button;
   }
 }
+
+.sfgov-events.paragraph {
+  padding-top: 50px;
+  padding-bottom: 75px;
+  background-color: #f8f8f8;
+
+  > .sfgov-header-section {
+    display: none;
+  }
+
+  .view-events-block-container {
+    padding-top: 30px;
+    padding-bottom: 10px;
+  }
+
+  .paragraph--type--button {
+    @include contain-1090;
+  }
+}

--- a/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-people-1mayor.scss
+++ b/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-people-1mayor.scss
@@ -19,8 +19,6 @@
   }
 
   .person-container {
-    // margin-bottom: 20px;
-
     @include media($medium-screen) {
       margin-bottom: 40px;
     }

--- a/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-people-1mayor.scss
+++ b/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-people-1mayor.scss
@@ -3,6 +3,8 @@
   background: $c-dark-blue;
   color: $c-white;
   @include antialiasing;
+  padding-bottom: 60px;
+  padding-top: 60px;
 
   .__people-title {
     @include contain-1090;

--- a/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-people-1mayor.scss
+++ b/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-people-1mayor.scss
@@ -4,7 +4,11 @@
   color: $c-white;
   @include antialiasing;
   padding-bottom: 60px;
-  padding-top: 60px;
+  padding-top: 80px;
+
+  @include media($medium-screen) {
+    margin-bottom: 60px;
+  }
 
   .__people-title {
     @include contain-1090;
@@ -15,7 +19,7 @@
   }
 
   .person-container {
-    margin-bottom: 20px;
+    // margin-bottom: 20px;
 
     @include media($medium-screen) {
       margin-bottom: 40px;
@@ -42,7 +46,7 @@
     width: 110px;
     height: 110px;
     margin-bottom: 30px;
-    margin-right: 28px;
+    margin-right: 20px;
     vertical-align: top;
 
     @include media($medium-screen) {

--- a/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-people-1mayor.scss
+++ b/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-people-1mayor.scss
@@ -18,6 +18,10 @@
     @include media($medium-screen) {
       margin-bottom: 40px;
     }
+
+    @include media($narrow-screen) {
+      width: 70%;
+    }
   }
 
   &.sfgov-paragraph-people-single article,
@@ -33,11 +37,19 @@
 
   .person-photo {
     display: inline-block;
-    width: 140px;
-    height: 140px;
+    width: 110px;
+    height: 110px;
     margin-bottom: 30px;
     margin-right: 28px;
     vertical-align: top;
+
+    @include media($medium-screen) {
+      width: 200px;
+      height: 200px;
+      float: left;
+      margin-bottom: 50px;
+      margin-right: 40px;
+    }
 
     img {
       max-width: 1px;
@@ -51,20 +63,15 @@
     @include fs-h1;
     color: white;
     margin-bottom: 34px;
-
-    @include media($medium-screen) {
-      margin-bottom: 50px;
-    }
   }
 
   .person-bio {
     display: inline-block;
     text-align: left;
-    width: calc(100% - 194px);
+    width: auto;
 
     @include media($medium-screen) {
       vertical-align: top;
-      width: calc(100% - 194px);
     }
 
     .person-name a {
@@ -84,20 +91,12 @@
 
   .person-title {
     @include fs-title-4;
-    color: $c-blue-2;
+    color: $c-white;
+    opacity: .7;
     margin-bottom: 12px;
 
     @include media($medium-screen) {
       margin-bottom: 12px;
-    }
-  }
-
-  .person-subtitle {
-
-    @include media($narrow-screen) {
-      margin-left: 173px;
-      margin-top: -75px;
-      max-width: 373px;
     }
   }
 }

--- a/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-people-2board.scss
+++ b/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-people-2board.scss
@@ -18,8 +18,13 @@
 
   .sfgov-people--content {
     @include media($narrow-screen) {
-      padding-bottom: 80px;
+      padding-bottom: 120px;
     }
+
+    @include media($wide-screen) {
+      padding-bottom: 100px;
+    }
+
     .__person-2 {
       .field__item {
         vertical-align: top;

--- a/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-people-2board.scss
+++ b/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-people-2board.scss
@@ -1,19 +1,35 @@
 // Board of Supervisors.
 .sfgov-title--board-of-supervisors {
-  background: $c-dark-blue;
-  color: $c-white;
-  padding-bottom: 185px;
   position: relative;
-  @include antialiasing;
+  @include contain-1090;
+  margin-top: 40px;
+  margin-bottom: 40px;
+
+  .inner {
+    position: relative;
+    background: $c-blue-1;
+    border-radius: 8px;
+    padding: 20px;
+
+    @include media($medium-screen) {
+      padding: 40px;
+    }
+  }
 
   .sfgov-people--content {
+    @include media($narrow-screen) {
+      padding-bottom: 80px;
+    }
     .__person-2 {
-      @include contain-1090;
       .field__item {
         vertical-align: top;
-        margin: 0 auto 35px;
+        margin: 0 auto 20px;
         width: auto;
         display: block;
+
+        @include media($medium-screen) {
+          margin-bottom: 40px;
+        }
       }
 
       @include media($mobile-screen) {
@@ -32,16 +48,15 @@
     }
   }
 
-  .person-name a {
-    @include link-colors($c-white, $c-white);
-  }
-
   .__people-title {
-    @include contain-1090;
     margin-bottom: 40px;
   }
 
+  .person-title {
+    opacity: .7;
+  }
+
   .__description {
-    bottom: 77px;
+    bottom: 40px;
   }
 }

--- a/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-people-3elected.scss
+++ b/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-people-3elected.scss
@@ -1,16 +1,32 @@
 // Elected Officers.
 .sfgov-title--elected-officers,
 .sfgov-title--city-officials {
-  background: $c-blue-1;
+  @include contain-1090;
+  margin-top: 40px;
+  margin-bottom: 40px;
+
+  .inner {
+    background: $c-blue-1;
+    border-radius: 8px;
+    padding: 20px;
+
+    @include media($medium-screen) {
+      padding: 40px;
+      padding-bottom: 20px;
+    }
+  }
 
   .sfgov-people--content {
     .__person-2 {
-      @include contain-1090;
       .field__item {
         vertical-align: top;
-        margin: 0 auto 35px;
+        margin: 0 auto 20px;
         width: auto;
         display: block;
+
+        @include media($medium-screen) {
+          margin-bottom: 40px;
+        }
       }
 
       @include media($mobile-screen) {
@@ -30,7 +46,6 @@
   }
 
   .__people-title {
-    @include contain-1090;
     margin-bottom: 40px;
   }
 
@@ -40,17 +55,6 @@
 
   .person-subtitle {
     opacity: .7;
-  }
-}
-
-.path-frontpage {
-  .sfgov-people {
-    > div:last-of-type {
-      .sfgov-title--city-officials,
-      .sfgov-title--elected-officers {
-        margin-bottom: 50px;
-      }
-    }
   }
 }
 

--- a/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-people.scss
+++ b/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-people.scss
@@ -71,11 +71,9 @@
     }
 
     p {
+      @include fs-body-bold;
       color: $c-slate;
       margin: 0;
-      font-size: 17px;
-      line-height: 24px;
-      font-weight: $fw-medium;
       &:last-child {
         margin-bottom: 0;
       }

--- a/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-people.scss
+++ b/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-people.scss
@@ -42,9 +42,11 @@
 
   .person-photo {
     display: inline-block;
-    height: 70px;
-    margin-right: 22px;
-    width: 70px;
+    height: 80px;
+    margin-right: 18px;
+    width: 80px;
+    margin-top: 0;
+    margin-bottom: 0;
   }
 
   .person-bio {
@@ -70,10 +72,11 @@
     }
 
     p {
-      @include fs-pull-large;
       color: $c-slate;
-      font-style: italic;
       margin: 0;
+      font-size: 17px;
+      line-height: 24px;
+      font-weight: $fw-medium;
       &:last-child {
         margin-bottom: 0;
       }

--- a/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-people.scss
+++ b/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-people.scss
@@ -1,10 +1,12 @@
 .paragraph--type--people {
   .__people-title {
-    @include fs-h1-small;
+    @include fs-title-3-mobile;
+    margin-top: 20px;
     margin-bottom: 50px;
 
     @include media($medium-screen) {
       @include fs-title-3;
+      margin-top: 0;
     }
   }
 

--- a/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-people.scss
+++ b/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-people.scss
@@ -1,7 +1,4 @@
 .paragraph--type--people {
-  padding-bottom: 60px;
-  padding-top: 60px;
-
   .__people-title {
     @include fs-h1-small;
     margin-bottom: 50px;

--- a/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-services.scss
+++ b/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-services.scss
@@ -2,7 +2,6 @@
 // See also _node-topic.scss.
 .sfgov-services.paragraph {
   @include sfgov-container--full-override;
-  background: $c-blue-1;
   padding-top: 60px;
 
   @include media($medium-screen) {
@@ -45,6 +44,26 @@
     margin-bottom: 40px;
     @include media($medium-screen) {
       margin-bottom: 60px;
+    }
+  }
+}
+
+.sfgov-services.all-top-level-topics {
+  .sfgov-container-item {
+    margin-bottom: 2.6rem;
+
+    h6 {
+      margin: 0;
+      font-size: 20px;
+      font-weight: 500;
+    }
+    a {
+      text-decoration: none;
+    }
+    p {
+      margin-top: 0;
+      color: $c-blue-4;
+      font-weight: 300;
     }
   }
 }

--- a/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-services.scss
+++ b/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-services.scss
@@ -9,13 +9,8 @@
   }
 
   .sfgov-header-section {
-    @include contain-1090;
     @include fs-h1;
     margin-bottom: 19px;
-
-    @include media($medium-screen) {
-      margin-bottom: 70px;
-    }
   }
 
   .sfgov-cta-button__container {
@@ -28,7 +23,8 @@
   }
 
   .sfgov-container {
-    @include contain-1090;
+   padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -50,7 +46,26 @@
 
 .sfgov-services.all-top-level-topics {
   .sfgov-container-item {
-    margin-bottom: 2.6rem;
+    margin-bottom: 0;
+    padding: 20px 0;
+
+    @include media($medium-screen) {
+      padding: 30px 0;
+    }
+
+    > div {
+      @include media($medium-screen) {
+        margin-right: 60px;
+      }
+    }
+
+    &:nth-child(3n+3) {
+      @include media($medium-screen) {
+        > div {
+          margin-right: 0;
+        }
+      }
+    }
 
     h6 {
       margin: 0;
@@ -59,11 +74,14 @@
     }
     a {
       text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+      }
     }
     p {
-      margin-top: 0;
+      margin: 0;
       color: $c-blue-4;
-      font-weight: 300;
     }
   }
 }

--- a/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-services.scss
+++ b/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-services.scss
@@ -68,9 +68,8 @@
     }
 
     h6 {
+      @include fs-title-5;
       margin: 0;
-      font-size: 20px;
-      font-weight: 500;
     }
     a {
       text-decoration: none;

--- a/web/themes/custom/sfgovpl/templates/node/node--landing--full.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--landing--full.html.twig
@@ -1,1 +1,3 @@
-{% include 'node--full.html.twig' %}
+{% extends 'node--full.html.twig' %}
+
+{% block header %}{% endblock %}

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--campaign.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--campaign.html.twig
@@ -1,8 +1,19 @@
-{% extends 'paragraph.html.twig' %}
-
-{% block content %}
-  {{ content.field_media }}
-  <div class="paragraph-campaign--text">
-    {{ content|without('field_media') }}
+{%
+  set classes = [
+    'paragraph',
+    'paragraph--type--' ~ paragraph.bundle|clean_class,
+    view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+    not paragraph.isPublished() ? 'paragraph--unpublished'
+  ]
+%}
+{% block paragraph %}
+  <div{{ attributes.addClass(classes) }}>
+    {% block content %}
+      {{ content.field_media }}
+      <div class="paragraph-campaign--text">
+        <p>{{ 'Latest'|t }}</p>
+        {{ content|without('field_media') }}
+      </div>
+    {% endblock %}
   </div>
-{% endblock %}
+{% endblock paragraph %}

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--people.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--people.html.twig
@@ -55,14 +55,16 @@
 {% block paragraph %}
   <div{{ attributes.addClass(classes) }}>
     {% block content %}
-      {{ content.field_people_title }}
-      <div class="sfgov-people--content">
-        {% if single %}
-          {{ drupal_entity('node', content.field_person_2.0['#node'].id(), 'card') }}
-        {% else %}
-          {{ content.field_person_2 }}
-        {% endif %}
-        {{ content.field_description }}
+      <div class="inner">
+        {{ content.field_people_title }}
+        <div class="sfgov-people--content">
+          {% if single %}
+            {{ drupal_entity('node', content.field_person_2.0['#node'].id(), 'card') }}
+          {% else %}
+            {{ content.field_person_2 }}
+          {% endif %}
+          {{ content.field_description }}
+        </div>
       </div>
     {% endblock %}
   </div>

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--section--default.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--section--default.html.twig
@@ -49,6 +49,7 @@
   (parent.bundle == 'landing') ? 'sfgov-container--full',
   "parent--bundle--" ~ parent.bundle,
   (paragraph.field_title.getString == 'Services') ? 'sfgov-services',
+  (paragraph.field_title.getString == 'Events') ? 'sfgov-events',
   'paragraph-child--' ~ child
 ] %}
 

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--section--default.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--section--default.html.twig
@@ -50,7 +50,8 @@
   "parent--bundle--" ~ parent.bundle,
   (paragraph.field_title.getString == 'Services') ? 'sfgov-services',
   (paragraph.field_title.getString == 'Events') ? 'sfgov-events',
-  'paragraph-child--' ~ child
+  'paragraph-child--' ~ child,
+  not paragraph.field_title.isEmpty ? 'paragraph--title--' ~ paragraph.field_title.getString|clean_class,
 ] %}
 
 {% block paragraph %}


### PR DESCRIPTION
This PR includes the following subtasks:
- SG-963 Update new website disclaimer styling
- SG-962 Update Mayor and Board of Supervisors sections on homepage
- SG-956 Increase size of SF.gov seal
- SG-957 Remove first two elements from SF.gov homepage
- SG-958 Update styling of SF.gov homepage campaign
- SG-959 Update services area on SF.gov homepage
- SG-955 Display events on SF.gov homepage