### PR TITLE
Fix spotlight image alignment on narrow-ish screens

### DIFF
--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--spotlight.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--spotlight.html.twig
@@ -8,7 +8,7 @@
       paragraph.get('field_spotlight_img').entity ?
         paragraph.get('field_spotlight_img').entity.field_media_image.alt : 'image'
   %}
-  {% set style = spotlight_img_url ? 'background-image:url(' ~ spotlight_img_url ~ ');' : '' %}
+  {% set spotlight_img_style = spotlight_img_url ? 'background-image: url(' ~ spotlight_img_url ~ ');background-size: cover;' : '' %}
   <div class="sfgov-spotlight">
     {% block content %}
     <div class="sfgov-spotlight-section content">
@@ -16,10 +16,7 @@
       <div class="sfgov-spotlight-description">{{ content.field_description }}</div>
       <div class="sfgov-spotlight-button">{{ content.field_spotlight_button }}</div>
     </div>
-    <div class="sfgov-spotlight-section image">
-      {% if spotlight_img_url %}
-        <img src="{{ spotlight_img_url }}" alt="{{ spotlight_img_alt }}" />
-      {% endif %}
+    <div class="sfgov-spotlight-section image" style="{{ spotlight_img_style }}" aria-label="{{ spotlight_img_alt }}">
     </div>
     {% endblock %}
   </div>


### PR DESCRIPTION
This is a proposed fix for SG-976, which you can see on pretty much any topic page with a browser window at about tablet-ish width:

| [Census 2020](https://sf.gov/topics/census-2020) | [Budget](https://sf.gov/topics/budget) |
| :--- | :--- |
| ![image](https://user-images.githubusercontent.com/113896/76124646-03bfb680-5fb0-11ea-9c22-7f159f37a702.png) | ![image](https://user-images.githubusercontent.com/113896/76125151-0b338f80-5fb1-11ea-99fa-e9c0ca6423f7.png) |

The problem is that if the aspect ratio of the image container is taller than that of the image, it shrinks vertically. This PR moves the image from the `<img>` element to a CSS background with [`background-size: cover`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-size#Values), which ensures that the background image covers the element's bounding box. Here's what that looks like:

| [Census 2020](https://sf.gov/topics/census-2020) | [Budget](https://sf.gov/topics/budget) |
| :--- | :--- |
| ![image](https://user-images.githubusercontent.com/113896/76125390-914fd600-5fb1-11ea-9620-6324a61e3c2a.png) | ![image](https://user-images.githubusercontent.com/113896/76125415-a0368880-5fb1-11ea-97d6-8fd88ffc134e.png) |

You can test this fix by pasting the following into your browser's JavaScript console:

```js
(() => {
  const el = document.querySelector('.sfgov-spotlight-section.image')
  const img = el.querySelector('img')
  el.setAttribute('style', `background-image: url('${img.src}'); background-size: cover;`)
  img.remove()
})()
```

I wasn't able to find any other pages that use this spotlight template, but as you can see with the Census 2020 image, it works better if the focal point of the image is centered. On smaller screens, the proposed fix crops the image awkwardly. For images with an off-center focal point, it would be nice to be able to adjust the `background-position` property as well. The default is `center`, but for the above image `background-position: top` looks better, and matches the `max-height` behavior of what we have now:

| no `background-position` | `background-position: top` |
| :--- | :--- |
| ![image](https://user-images.githubusercontent.com/113896/76125838-82b5ee80-5fb2-11ea-9ff1-ab7005c175c6.png) | ![image](https://user-images.githubusercontent.com/113896/76125939-babd3180-5fb2-11ea-99e3-03335baf9351.png) |