### PR TITLE
Fix news item overflow with image present, use two columns if possible

### DIFF
--- a/web/themes/custom/sfgovpl/src/sass/node/_node-news-card.scss
+++ b/web/themes/custom/sfgovpl/src/sass/node/_node-news-card.scss
@@ -9,7 +9,7 @@
   text-decoration: none;
 
   &.has-image {
-    height: 160px;
+    min-height: 160px;
     padding: 20px 180px 20px 20px;
 
     @include media-max($medium-screen) {

--- a/web/themes/custom/sfgovpl/src/sass/node/_node-news-card.scss
+++ b/web/themes/custom/sfgovpl/src/sass/node/_node-news-card.scss
@@ -20,7 +20,7 @@
   }
 
   &:hover {
-    background-color: #e7b22e;
+    background-color: $c-yellow-4;
   }
 
 

--- a/web/themes/custom/sfgovpl/templates/components/molecules/news-cards.twig
+++ b/web/themes/custom/sfgovpl/templates/components/molecules/news-cards.twig
@@ -1,4 +1,6 @@
-<div class="sfgov-container-three-column">
+{% set columns = columns or (rows | length) %}
+{% set column_modifier = columns >= 3 ? 'three' : 'two' %}
+<div class="sfgov-container-{{ column_modifier }}-column">
   {% for card in rows %}
     <div class="sfgov-container-item">
       {{ card.content }}


### PR DESCRIPTION
This is a proposed fix for SG-972. The source of the problem is the fixed [`height: 160px`]() causes the text to overflow when the title wraps to 4 lines or longer. We can solve that by switching `height` to `min-height`, which is _better_...

![image](https://user-images.githubusercontent.com/113896/76260957-2eab4400-6216-11ea-8146-d18ab8ff4ead.png)

But not great. You can test this out on any page with news cards using the following snippet in your browser's JavaScript console:

```js
(() => {
  const css = `.news--card.has-image { height: auto; min-height: 160px; }`
  const style = document.createElement('style')
  style.textContent = css
  document.head.appendChild(style)
})()
```

The second part of this fix is to have news card sections use a two-column layout if there are fewer than three news items:

![image](https://user-images.githubusercontent.com/113896/76261377-1556c780-6217-11ea-98be-715d7a1da070.png)

You can test this with the following snippet:

```js
$$('.news--card.has-image')
  .map(card => card.closest('.sfgov-container-three-column'))
  .filter((d, i, a) => a.indexOf(d) === i)
  .forEach(el => el.classList.replace('sfgov-container-three-column', 'sfgov-container-two-column'))
```

It's a good idea to test this on a dev environment before approving though!