### PR TITLE
sg-1015 - See more links

### DIFF
--- a/web/themes/custom/sfgovpl/dist/css/drupal.css
+++ b/web/themes/custom/sfgovpl/dist/css/drupal.css
@@ -5913,6 +5913,7 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
   float: left;
   padding: 0;
   margin: 0 6px 0 0;
+  white-space: nowrap;
 }
 
 .page-node-type-topic .view-topic-parents-block ul li a {

--- a/web/themes/custom/sfgovpl/src/sass/node/_node-topic.scss
+++ b/web/themes/custom/sfgovpl/src/sass/node/_node-topic.scss
@@ -93,6 +93,7 @@
         float: left;
         padding: 0;
         margin: 0 6px 0 0;
+        white-space: nowrap;
         a {
           display: inline-block;
         }


### PR DESCRIPTION
Fixes SG-1015: "See more" parent topic names break at short length on child topic pages