### PR TITLE
Fix news item overflow with image present, use two columns if possibl…

### DIFF
--- a/web/themes/custom/sfgovpl/src/sass/node/_node-news-card.scss
+++ b/web/themes/custom/sfgovpl/src/sass/node/_node-news-card.scss
@@ -9,7 +9,7 @@
   text-decoration: none;
 
   &.has-image {
-    height: 160px;
+    min-height: 160px;
     padding: 20px 180px 20px 20px;
 
     @include media-max($medium-screen) {
@@ -20,7 +20,7 @@
   }
 
   &:hover {
-    background-color: #e7b22e;
+    background-color: $c-yellow-4;
   }
 
 

--- a/web/themes/custom/sfgovpl/templates/components/molecules/news-cards.twig
+++ b/web/themes/custom/sfgovpl/templates/components/molecules/news-cards.twig
@@ -1,4 +1,6 @@
-<div class="sfgov-container-three-column">
+{% set columns = columns or (rows | length) %}
+{% set column_modifier = columns >= 3 ? 'three' : 'two' %}
+<div class="sfgov-container-{{ column_modifier }}-column">
   {% for card in rows %}
     <div class="sfgov-container-item">
       {{ card.content }}


### PR DESCRIPTION
…e (#461)

* use min-height for .news--card.has-image

* replace literal #e7b22e with $c-yellow-4

* adapt news-cards molecule to two-column layout