### PR TITLE
Get form.io render options from template output

### DIFF
--- a/config/core.entity_form_display.paragraph.form_io.default.yml
+++ b/config/core.entity_form_display.paragraph.form_io.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.paragraph.form_io.field_formio_data_source
     - field.field.paragraph.form_io.field_formio_js_version
+    - field.field.paragraph.form_io.field_formio_render_options
     - field.field.paragraph.form_io.field_formio_sfds_version
     - paragraphs.paragraphs_type.form_io
 id: paragraph.form_io.default
@@ -27,6 +28,14 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: string_textfield
+    region: content
+  field_formio_render_options:
+    weight: 3
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textarea
     region: content
   field_formio_sfds_version:
     weight: 2

--- a/config/core.entity_view_display.paragraph.form_io.default.yml
+++ b/config/core.entity_view_display.paragraph.form_io.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.paragraph.form_io.field_formio_data_source
     - field.field.paragraph.form_io.field_formio_js_version
+    - field.field.paragraph.form_io.field_formio_render_options
     - field.field.paragraph.form_io.field_formio_sfds_version
     - paragraphs.paragraphs_type.form_io
 id: paragraph.form_io.default
@@ -27,6 +28,13 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     type: string
+    region: content
+  field_formio_render_options:
+    weight: 3
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
     region: content
   field_formio_sfds_version:
     weight: 2

--- a/config/field.field.paragraph.form_io.field_formio_render_options.yml
+++ b/config/field.field.paragraph.form_io.field_formio_render_options.yml
@@ -1,0 +1,24 @@
+uuid: 9234aeaa-1ef8-44bd-bd42-a1aedf3657c2
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_formio_render_options
+    - paragraphs.paragraphs_type.form_io
+  module:
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: paragraph.form_io.field_formio_render_options
+field_name: field_formio_render_options
+entity_type: paragraph
+bundle: form_io
+label: 'Form.io Render Options'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/field.storage.paragraph.field_formio_render_options.yml
+++ b/config/field.storage.paragraph.field_formio_render_options.yml
@@ -1,0 +1,19 @@
+uuid: 54408a3a-5153-4554-98f0-b30d83a85569
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_formio_render_options
+field_name: field_formio_render_options
+entity_type: paragraph
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -49,7 +49,7 @@
 <div id="formio"
   data-source="{{ paragraph.field_formio_data_source.value }}"
   {% if paragraph.field_formio_render_options.value %}
-    data-options="{{ paragraph.field_formio_render_options.value|json_encode|escape }}"
+    data-options="{{ paragraph.field_formio_render_options.value|escape }}"
   {% endif %}
 ></div>
 <script src="https://unpkg.com/formiojs@{{ formio_js_version }}/dist/formio.full.min.js"></script>
@@ -59,7 +59,7 @@
     var el = document.getElementById('formio')
     var options = safeJSONParse(el.getAttribute('data-options'))
     Formio.createForm(el, el.getAttribute('data-source'), options)
-    
+
     function safeJSONParse(str) {
       var parsed = {}
       try {

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -50,8 +50,19 @@
 <script src="https://unpkg.com/formiojs@{{ formio_js_version }}/dist/formio.full.min.js"></script>
 <script src="https://unpkg.com/formio-sfds@{{ formio_sfds_version }}/dist/formio-sfds.standalone.js"></script>
 <script>
-  window.addEventListener('load', () => {
-    const el = document.getElementById('formio')
-    Formio.createForm(el, el.getAttribute('data-source'))
+  window.addEventListener('load', function() {
+    var el = document.getElementById('formio')
+    var options = safeJSONParse(el.getAttribute('data-options'))
+    Formio.createForm(el, el.getAttribute('data-source'), options)
+    
+    function safeJSONParse(str) {
+      var parsed = {}
+      try {
+        parsed = JSON.parse(str)
+      } catch (error) {
+        console.warn('Unable to parse form options:', str)
+      }
+      return parsed
+    }
   })
 </script>

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -46,7 +46,12 @@
 {% if paragraph.field_formio_sfds_version.value %}
   {% set formio_sfds_version = paragraph.field_formio_sfds_version.value %}
 {% endif %}
-<div id="formio" data-source="{{ paragraph.field_formio_data_source.value }}"></div>
+<div id="formio"
+  data-source="{{ paragraph.field_formio_data_source.value }}"
+  {% if paragraph.field_formio_render_options.value %}
+    data-options="{{ paragraph.field_formio_render_options.value|json_encode|escape }}"
+  {% endif %}
+></div>
 <script src="https://unpkg.com/formiojs@{{ formio_js_version }}/dist/formio.full.min.js"></script>
 <script src="https://unpkg.com/formio-sfds@{{ formio_sfds_version }}/dist/formio-sfds.standalone.js"></script>
 <script>


### PR DESCRIPTION
@hshaosf We'd like to be able to pass options to `Formio.createForm()` at runtime, on a per-form basis. (Stuff like being able to show or hide certain buttons in the [wizard](https://formio.github.io/formio.js/app/examples/wizard.html) nav, for instance.) This is an attempt to stub out the template changes that would:

1. Output the `data-options="..."` attribute as a JSON-encoded string, then
2. Parse the value as JSON and pass that to the `Formio.createForm()` function

I realize that if we encode as JSON on the template side we might have a double encoding issue — unless there's some snazzy way for Drupal to expose a JSON editor that outputs template data in object form. But in lieu of that, maybe we just take a JSON string as input (`{"foo":"bar"}`) and skip the `json_encode` filter?