### PR TITLE
Fix bleeding white background on service accordions

### DIFF
--- a/web/themes/custom/sfgovpl/dist/css/drupal.css
+++ b/web/themes/custom/sfgovpl/dist/css/drupal.css
@@ -2070,6 +2070,10 @@ img {
   padding-left: 0;
 }
 
+details {
+  border-radius: 8px;
+}
+
 details summary {
   font-size: 20px;
   font-weight: 500;

--- a/web/themes/custom/sfgovpl/src/sass/components/_details.scss
+++ b/web/themes/custom/sfgovpl/src/sass/components/_details.scss
@@ -3,6 +3,7 @@ details {
   
   summary {
     @include fs-title-5;
+    background: $c-white;
     border: 3px solid $c-bright-blue;
     border-radius: 8px;
     color: $c-bright-blue;

--- a/web/themes/custom/sfgovpl/src/sass/components/_details.scss
+++ b/web/themes/custom/sfgovpl/src/sass/components/_details.scss
@@ -1,4 +1,6 @@
 details {
+  border-radius: 8px;
+  
   summary {
     @include fs-title-5;
     border: 3px solid $c-bright-blue;
@@ -42,7 +44,6 @@ details {
 .page-node-type-department {
   .sfgov-services details {
     background: $c-white;
-    border-radius: 8px;
     
     summary {
       padding-right: 20px;

--- a/web/themes/custom/sfgovpl/src/sass/components/_details.scss
+++ b/web/themes/custom/sfgovpl/src/sass/components/_details.scss
@@ -42,8 +42,6 @@ details {
 .page-node-type-topic,
 .page-node-type-department {
   .sfgov-services details {
-    background: $c-white;
-    
     summary {
       padding-right: 20px;
     }

--- a/web/themes/custom/sfgovpl/src/sass/components/_details.scss
+++ b/web/themes/custom/sfgovpl/src/sass/components/_details.scss
@@ -1,7 +1,6 @@
 details {
   summary {
     @include fs-title-5;
-    background: $c-white;
     border: 3px solid $c-bright-blue;
     border-radius: 8px;
     color: $c-bright-blue;

--- a/web/themes/custom/sfgovpl/src/sass/components/_details.scss
+++ b/web/themes/custom/sfgovpl/src/sass/components/_details.scss
@@ -42,6 +42,9 @@ details {
 .page-node-type-topic,
 .page-node-type-department {
   .sfgov-services details {
+    background: $c-white;
+    border-radius: 8px;
+    
     summary {
       padding-right: 20px;
     }


### PR DESCRIPTION
The new accordions look great! I noticed, though, that on smaller viewports the background of the `<details>` element bleeds out from behind the border-radius of the `<summary>`:

![image](https://user-images.githubusercontent.com/113896/77702228-4bb17800-6f75-11ea-8f1b-947cb5b6cb5b.png)

This PR removes the offending white background. My first attempt at fixing this was to just remove the background from `<details>`, since `<summary>` already has one:

https://github.com/SFDigitalServices/sfgov/blob/df34989d0f341657f1b880fe43b93b32094bf415/web/themes/custom/sfgovpl/src/sass/components/_details.scss#L4

But then the content didn't have one:

![image](https://user-images.githubusercontent.com/113896/77702505-e8741580-6f75-11ea-8c79-565b5d195549.png)

So I brought the background back and added a border-radius to the `<details>` element instead. This effectively crops the element, masking out the white background:

![image](https://user-images.githubusercontent.com/113896/77703230-8ddbb900-6f77-11ea-8100-2dce608b68d1.png)

Yes, it took me 5 commits to figure this out. Please squash this when merging. :joy: