### PR TITLE
[SG-1063] Allow news node to redirect to external URL

### DIFF
--- a/config/core.entity_form_display.node.news.default.yml
+++ b/config/core.entity_form_display.node.news.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.news.field_abstract
     - field.field.node.news.field_date
     - field.field.node.news.field_dept
+    - field.field.node.news.field_direct_external_url
     - field.field.node.news.field_image
     - field.field.node.news.field_news_type
     - field.field.node.news.field_topics
@@ -17,6 +18,7 @@ dependencies:
     - content_moderation
     - datetime
     - entity_browser
+    - link
     - path
     - text
 id: node.news.default
@@ -26,7 +28,7 @@ mode: default
 content:
   body:
     type: text_textarea_with_summary
-    weight: 4
+    weight: 5
     settings:
       rows: 9
       summary_rows: 3
@@ -34,7 +36,7 @@ content:
     third_party_settings: {  }
     region: content
   field_abstract:
-    weight: 3
+    weight: 4
     settings:
       rows: 5
       placeholder: ''
@@ -53,13 +55,21 @@ content:
     type: datetime_default
     region: content
   field_dept:
-    weight: 11
+    weight: 12
     settings:
       match_operator: CONTAINS
       size: 60
       placeholder: ''
     third_party_settings: {  }
     type: entity_reference_autocomplete
+    region: content
+  field_direct_external_url:
+    weight: 3
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
     region: content
   field_image:
     weight: 2
@@ -77,13 +87,13 @@ content:
     type: entity_browser_entity_reference
     region: content
   field_news_type:
-    weight: 9
+    weight: 10
     settings: {  }
     third_party_settings: {  }
     type: options_select
     region: content
   field_topics:
-    weight: 26
+    weight: 13
     settings:
       match_operator: CONTAINS
       size: 60
@@ -93,13 +103,13 @@ content:
     region: content
   moderation_state:
     type: moderation_state_default
-    weight: 7
+    weight: 8
     settings: {  }
     region: content
     third_party_settings: {  }
   path:
     type: path
-    weight: 5
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -107,7 +117,7 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 8
+    weight: 9
     region: content
     third_party_settings: {  }
   title:
@@ -119,12 +129,12 @@ content:
       placeholder: ''
     third_party_settings: {  }
   translation:
-    weight: 10
+    weight: 11
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   url_redirects:
-    weight: 6
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/core.entity_view_display.node.news.default.yml
+++ b/config/core.entity_view_display.node.news.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.news.field_abstract
     - field.field.node.news.field_date
     - field.field.node.news.field_dept
+    - field.field.node.news.field_direct_external_url
     - field.field.node.news.field_image
     - field.field.node.news.field_news_type
     - field.field.node.news.field_topics
@@ -76,6 +77,7 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_direct_external_url: true
   field_topics: true
   langcode: true
   links: true

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -81,6 +81,7 @@ module:
   sfgov_alerts: 0
   sfgov_departments: 0
   sfgov_event_subscriber: 0
+  sfgov_news: 0
   sfgov_search: 0
   sfgov_utilities: 0
   shortcut: 0

--- a/config/field.field.node.news.field_abstract.yml
+++ b/config/field.field.node.news.field_abstract.yml
@@ -5,13 +5,18 @@ dependencies:
   config:
     - field.storage.node.field_abstract
     - node.type.news
+  module:
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
 id: node.news.field_abstract
 field_name: field_abstract
 entity_type: node
 bundle: news
 label: Abstract
 description: ''
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/config/field.field.node.news.field_direct_external_url.yml
+++ b/config/field.field.node.news.field_direct_external_url.yml
@@ -1,0 +1,27 @@
+uuid: 540d90a6-31c2-4667-9ec8-06d4299b0bfe
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_direct_external_url
+    - node.type.news
+  module:
+    - link
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.news.field_direct_external_url
+field_name: field_direct_external_url
+entity_type: node
+bundle: news
+label: 'Direct External Link'
+description: 'Link to news on another City website (no external news).'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 16
+  title: 0
+field_type: link

--- a/web/modules/custom/sfgov_news/sfgov_news.info.yml
+++ b/web/modules/custom/sfgov_news/sfgov_news.info.yml
@@ -1,0 +1,9 @@
+name: 'SF Gov News'
+type: module
+description: 'Customizations related to the News content type.'
+core: 8.x
+package: 'SF Gov'
+
+dependencies:
+  - sfgov_event_subscriber:sfgov_event_subscriber
+  - node:node

--- a/web/modules/custom/sfgov_news/sfgov_news.module
+++ b/web/modules/custom/sfgov_news/sfgov_news.module
@@ -1,0 +1,19 @@
+<?php
+
+use \Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function sfgov_news_form_node_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  if (in_array($form_id, ['node_news_form', 'node_news_edit_form'])) {
+    // field_abstract is required unless field_direct_external_url is used.
+    $form['field_abstract']['widget'][0]['value']['#states'] = [
+      'required' => [
+        ':input[data-drupal-selector="edit-field-direct-external-url-0-uri"]' => [
+          'filled' => FALSE,
+        ]
+      ]
+    ];
+  }
+}


### PR DESCRIPTION
This PR does the following:

1.  Adds `field_direct_external_url` to the News content type. This field already contains the redirect functionality needed via `sfgov_event_subscriber` module.
2. Add a custom module named "SF Gov News" (for lack of a better place to put it), that uses States API to handle whether or not the Abstract field is required.  Prior to this PR, Abstract field was required globally.  Now, it's only required when `field_direct_external_url` is empty. 