### PR TITLE
SG-1097 Don't allow translation of document paragraphs.

### DIFF
--- a/web/themes/custom/sfgovpl/includes/paragraph.inc
+++ b/web/themes/custom/sfgovpl/includes/paragraph.inc
@@ -117,3 +117,13 @@ function sfgovpl_preprocess_paragraph__video(&$variables) {
   $link['#attributes']['target'] = '_blank';
   $variables['link_transcript'] = $link;
 }
+
+/**
+ * Preprocess paragraph document.
+ *
+ * @param $variables
+ */
+function sfgovpl_preprocess_paragraph__document(&$variables) {
+  // Don't translate document paragraphs by gtranslate.
+  $variables['attributes']['class'][] = 'notranslate';
+}


### PR DESCRIPTION
Fixes SG-1097 by excluding the document paragraphs from gtranslate.