### PR TITLE
SG-1149: Fixes a js error when cookie is not used in form.io forms

### DIFF
--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -71,14 +71,14 @@
           customAddCssClassById(options.sfoptions.addClass)
         }
         // if cookies are defined, populate the form field with cookie value.
-        if(options.sfoptions["cookies"]){
+        if(options.sfoptions instanceof Object && options.sfoptions.cookies){
           manageFormCookies(options.sfoptions["cookies"], form, true)
         }
         // perform custom action on nextPage event
         form.on('nextPage', function(){
           // set form cookies, if there are any
-          if(options.sfoptions["cookies"]){
-            manageFormCookies(options.sfoptions["cookies"], form, false)
+          if(options.sfoptions instanceof Object && options.sfoptions.cookies){
+            manageFormCookies(options.sfoptions.cookies, form, false)
           }
         })
         // What to do when the submit begins.
@@ -88,7 +88,6 @@
               if (options.sfoptions && options.sfoptions.hide instanceof Object) {
                 customHideElements(options.sfoptions.hide)
               }
-              console.log(submission.data)
               for (var key in options.redirects) {
                 var value = options.redirects[key]
                 // only one "redirect" should be "yes", this is set in the form.io form


### PR DESCRIPTION
Problem as stated above, steps to reproduce: 

- Visit [https://test-sfgov.pantheonsite.io/apply-for-mini-grant](https://test-sfgov.pantheonsite.io/apply-for-mini-grant)
- Inspect the console to find the js error: `Uncaught (in promise) TypeError: Cannot read property 'cookies' of undefined`

Fixed in `paragraph--form-io.html.twig`
- Visit [http://pr-579-sfgov.pantheonsite.io/apply-for-mini-grant](http://pr-579-sfgov.pantheonsite.io/apply-for-mini-grant)
- Inspect the console to find no js error.
