### PR TITLE
Pin formiojs and theme versions

### DIFF
--- a/config/sfgov_formio.settings.yml
+++ b/config/sfgov_formio.settings.yml
@@ -1,2 +1,2 @@
 formio_version: 'https://unpkg.com/formiojs@4.10.4/dist/formio.full.min.js'
-formio_sfds_version: 'https://unpkg.com/formio-sfds@6.0.1/dist/formio-sfds.standalone.js'
+formio_sfds_version: 'https://unpkg.com/formio-sfds@6.0.2/dist/formio-sfds.standalone.js'

--- a/config/sfgov_formio.settings.yml
+++ b/config/sfgov_formio.settings.yml
@@ -1,2 +1,2 @@
-formio_version: ''
-formio_sfds_version: ''
+formio_version: 'https://unpkg.com/formiojs@4.10.4/dist/formio.full.min.js'
+formio_sfds_version: 'https://unpkg.com/formio-sfds@6.0.1/dist/formio-sfds.standalone.js'


### PR DESCRIPTION
This pins the versions of formiojs and the SFDS theme to specific versions so that the settings persist in other environments (test-sfgov and PR deployments). @jacine and I discussed this in Slack, and my thinking is that it's better to have these in git rather than in the Drupal UI.

As for the specific versions, I think it's important to note that:

1. We're "stuck" on formiojs v4.10.4 until I can identify whatever is causing the bizarre issue with date/time input icons rendering as `[Object HTMLElement]` (citation needed!).
2. I've upgraded us to the [6.0 release of formio-sfds](https://github.com/SFDigitalServices/formio-sfds/releases/tag/v6.0.0), which gives us Truss's design updates and more accessible form navigation.