### PR TITLE
[SG-1134] Fix People section has pixellated photos.

### DIFF
--- a/config/core.entity_view_display.node.person.card.yml
+++ b/config/core.entity_view_display.node.person.card.yml
@@ -58,7 +58,7 @@ content:
     weight: 5
     label: hidden
     settings:
-      image_style: medium
+      image_style: large
     third_party_settings: {  }
     type: image_url
     region: content

--- a/config/core.entity_view_display.node.person.card_with_image_small.yml
+++ b/config/core.entity_view_display.node.person.card_with_image_small.yml
@@ -58,7 +58,7 @@ content:
     weight: 4
     label: hidden
     settings:
-      image_style: thumbnail
+      image_style: medium
     third_party_settings: {  }
     type: image_url
     region: content


### PR DESCRIPTION
1. I changed image style from Thumbnail to Medium for the people grid on home page. The size of the square is the same but the image inside it is a bit larger it is scaled down via CSS which makes it appear as it is on live but with much higher quality.

2. For the Card display (People) node I changed image style from Medium to Large also the same result as in item above.