### PR TITLE
sg-1203 - put back to top link in twig so amplitude js registers the …

### DIFF
--- a/web/themes/custom/sfgovpl/src/js/back-to-top.js
+++ b/web/themes/custom/sfgovpl/src/js/back-to-top.js
@@ -8,8 +8,6 @@
 (function ($, Drupal) {
   Drupal.behaviors.backToTop = {
     attach: function (context) {
-      var buttonText = Drupal.t('Back to top');
-      $('body', context).once('backToTop').append('<a id="back-to-top" class="back-to-top">' + buttonText + '<span /></a>');
       $('#back-to-top', context).on('click', function(e) {
         e.preventDefault();
         $('html, body', context).animate({scrollTop: 0}, '300');

--- a/web/themes/custom/sfgovpl/templates/layout/html.html.twig
+++ b/web/themes/custom/sfgovpl/templates/layout/html.html.twig
@@ -51,6 +51,7 @@
 {{ page_top }}
 {{ page }}
 {{ page_bottom }}
+<a id="back-to-top" class="back-to-top">{{ "Back to top" | t }}<span /></a>
 <js-bottom-placeholder token="{{ placeholder_token }}">
 </body>
 </html>


### PR DESCRIPTION
Amplitude js initializes tracking events before this link gets inserted into the dom.  This pr moves the markup for the back to top link from being created dynamically via javascript to the `html.html.twig` template.  