### PR TITLE
Upgrade formio-sfds to 6.1.0

### DIFF
--- a/config/sfgov_formio.settings.yml
+++ b/config/sfgov_formio.settings.yml
@@ -1,2 +1,2 @@
 formio_version: 'https://unpkg.com/formiojs@4.10.4/dist/formio.full.min.js'
-formio_sfds_version: 'https://unpkg.com/formio-sfds@6.0.2/dist/formio-sfds.standalone.js'
+formio_sfds_version: 'https://unpkg.com/formio-sfds@6.1.0/dist/formio-sfds.standalone.js'


### PR DESCRIPTION
Here are links to the release notes for all of the versions since 6.0.2. I've noted the only release that includes a fix that's relevant to sf.gov; most of these are testing + DX improvements:

- [6.0.3](https://github.com/SFDigitalServices/formio-sfds/releases/tag/v6.0.3)
- [6.0.4](https://github.com/SFDigitalServices/formio-sfds/releases/tag/v6.0.4) includes an accessibility fix that properly associates most inputs with their labels
- [6.0.5](https://github.com/SFDigitalServices/formio-sfds/releases/tag/v6.0.5)
- [6.0.1](https://github.com/SFDigitalServices/formio-sfds/releases/tag/v6.1.0)