### PR TITLE
Upgrade formiojs to 4.11.2, formio-sfds to 6.2.0

### DIFF
--- a/config/sfgov_formio.settings.yml
+++ b/config/sfgov_formio.settings.yml
@@ -1,2 +1,2 @@
 formio_version: 'https://unpkg.com/formiojs@4.11.2/dist/formio.full.min.js'
-formio_sfds_version: 'https://unpkg.com/formio-sfds@6.2.0-rc.aa6ad2f/dist/formio-sfds.standalone.js'
+formio_sfds_version: 'https://unpkg.com/formio-sfds@6.2.0/dist/formio-sfds.standalone.js'

--- a/config/sfgov_formio.settings.yml
+++ b/config/sfgov_formio.settings.yml
@@ -1,2 +1,2 @@
 formio_version: 'https://unpkg.com/formiojs@4.11.2/dist/formio.full.min.js'
-formio_sfds_version: 'https://unpkg.com/formio-sfds@6.2.0/dist/formio-sfds.standalone.js'
+formio_sfds_version: 'https://unpkg.com/formio-sfds@6.2.0-rc.aa6ad2f/dist/formio-sfds.standalone.js'

--- a/config/sfgov_formio.settings.yml
+++ b/config/sfgov_formio.settings.yml
@@ -1,2 +1,2 @@
-formio_version: 'https://unpkg.com/formiojs@4.10.4/dist/formio.full.min.js'
-formio_sfds_version: 'https://unpkg.com/formio-sfds@6.1.0/dist/formio-sfds.standalone.js'
+formio_version: 'https://unpkg.com/formiojs@4.11.2/dist/formio.full.min.js'
+formio_sfds_version: 'https://unpkg.com/formio-sfds@6.2.0/dist/formio-sfds.standalone.js'

--- a/config/sfgov_formio.settings.yml
+++ b/config/sfgov_formio.settings.yml
@@ -1,2 +1,2 @@
 formio_version: 'https://unpkg.com/formiojs@4.10.4/dist/formio.full.min.js'
-formio_sfds_version: 'https://unpkg.com/formio-sfds@6.0.2/dist/formio-sfds.standalone.js'
+formio_sfds_version: 'https://unpkg.com/formio-sfds@6.1.0/dist/formio-sfds.standalone.js'


### PR DESCRIPTION
This updates us to a more recent release of formio.js and bumps our theme to improve accessibility. See https://github.com/SFDigitalServices/formio-sfds/pull/83 for more info.