### PR TITLE
[SG-1209] Don't focus on fields after opening filters on mobile meeting list

### DIFF
--- a/web/themes/custom/sfgovpl/dist/css/drupal.css
+++ b/web/themes/custom/sfgovpl/dist/css/drupal.css
@@ -13267,7 +13267,7 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
   border-color: #0c1464;
 }
 
-.sfgov-filters button.filter-toggle, .sfgov-filters .field-m13 .filter-toggle.file-custom::before, .field-m13 .sfgov-filters .filter-toggle.file-custom::before {
+.sfgov-filters .filter-toggle {
   font-family: "Rubik", sans-serif;
   background: transparent;
   border: 0;
@@ -13284,15 +13284,15 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
   width: auto;
 }
 
-.sfgov-filters button.filter-toggle:focus, .sfgov-filters .field-m13 .filter-toggle.file-custom:focus::before, .field-m13 .sfgov-filters .filter-toggle.file-custom:focus::before {
+.sfgov-filters .filter-toggle:focus {
   outline: 2px dotted #aeb0b5;
 }
 
-.sfgov-filters button.filter-toggle:hover, .sfgov-filters .field-m13 .filter-toggle.file-custom:hover::before, .field-m13 .sfgov-filters .filter-toggle.file-custom:hover::before {
+.sfgov-filters .filter-toggle:hover {
   text-decoration: underline;
 }
 
-.sfgov-filters button.filter-toggle span, .sfgov-filters .field-m13 .filter-toggle.file-custom::before span, .field-m13 .sfgov-filters .filter-toggle.file-custom::before span {
+.sfgov-filters .filter-toggle span {
   -webkit-box-align: center;
       -ms-flex-align: center;
           align-items: center;
@@ -13306,7 +13306,7 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
   position: relative;
 }
 
-.sfgov-filters button.filter-toggle span::before, .sfgov-filters .field-m13 .filter-toggle.file-custom::before span::before, .field-m13 .sfgov-filters .filter-toggle.file-custom::before span::before {
+.sfgov-filters .filter-toggle span::before {
   content: '';
   background: transparent url(data:image/svg+xml;charset=utf-8;base64,PHN2ZyB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZD0iTTE3LjQ2IDE0Ljc1NWExLjI0NSAxLjI0NSAwIDAxLS44ODUtLjM2NUw5Ljk2IDcuNzc1IDMuMzQ1IDE0LjM5YTEuMjUyIDEuMjUyIDAgMDEtMS43Ny0xLjc3bDcuNS03LjVhMS4yNiAxLjI2IDAgMDExLjc3IDBsNy41IDcuNWExLjI2IDEuMjYgMCAwMTAgMS43NyAxLjI0NiAxLjI0NiAwIDAxLS44ODUuMzY1eiIgZmlsbD0iIzRGNjZFRSIvPjwvc3ZnPg==) no-repeat;
   display: -webkit-inline-box;
@@ -13317,11 +13317,11 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
   width: 20px;
 }
 
-.sfgov-filters button.filter-toggle--hide, .sfgov-filters .field-m13 .filter-toggle--hide.file-custom::before, .field-m13 .sfgov-filters .filter-toggle--hide.file-custom::before {
+.sfgov-filters .filter-toggle--hide {
   margin-top: 40px;
 }
 
-.sfgov-filters button.filter-toggle--show span::before, .sfgov-filters .field-m13 .filter-toggle--show.file-custom::before span::before, .field-m13 .sfgov-filters .filter-toggle--show.file-custom::before span::before {
+.sfgov-filters .filter-toggle--show span::before {
   -webkit-transform: rotate(180deg);
           transform: rotate(180deg);
 }

--- a/web/themes/custom/sfgovpl/src/js/meetings.js
+++ b/web/themes/custom/sfgovpl/src/js/meetings.js
@@ -31,8 +31,6 @@
         $buttonShow.on('click', function(e) {
           e.preventDefault();
           toggleFilters($content, 'show');
-          // Find the first focusable element and focus it.
-          $content.find('input, select, textarea, a, button').first().focus();
         });
 
         // Breakpoint at which sidebar becomes visible, and toggle functionality

--- a/web/themes/custom/sfgovpl/src/sass/view/_view-meetings-filters.scss
+++ b/web/themes/custom/sfgovpl/src/sass/view/_view-meetings-filters.scss
@@ -200,7 +200,7 @@
     }
   }
 
-  button.filter-toggle {
+  .filter-toggle {
     @include rubik;
     background: transparent;
     border: 0;


### PR DESCRIPTION
Also fixes an issue where sf-design-system [`@extends button`](https://github.com/SFDigitalServices/sf-design-system/blob/main/src/components/04-forms/field-types/_form-fields.scss#L286) with `::before`, which was breaking the show/hide icons.