### PR TITLE
Set up Lighthouse CI

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -11,7 +11,7 @@ jobs:
         uses: SFDigitalServices/wait-for-deployment-action@v2
         with:
           github-token: ${{ github.token }}
-          interval: 300
+          interval: 30
           timeout: 600
 
       - uses: treosh/lighthouse-ci-action@v3

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,23 +1,22 @@
 name: Lighthouse
-on: [push]
+on:
+  deployment_status:
+    types: [success]
 
 jobs:
   lighthouse:
+    if: github.event.deployment_status.state == 'success'
     runs-on: ubuntu-latest
     steps:
+      - name: event JSON
+        run: echo '${{ toJson(github.event) }}'
       - uses: actions/checkout@v2
-
-      - id: deployment
-        uses: SFDigitalServices/wait-for-deployment-action@v2
         with:
-          github-token: ${{ github.token }}
-          interval: 60
-          timeout: 600
-
+          ref: ${{ github.event.deployment.sha }}
       - uses: treosh/lighthouse-ci-action@v3
         with:
           serverToken: ${{ secrets.LHCI_BUILD_TOKEN }}
           serverBaseUrl: https://lighthouse-ci-sfgov.herokuapp.com
         env:
           LHCI_GITHUB_TOKEN: ${{ github.token }}
-          LHCI_COLLECT_BASE_URL: ${{ steps.deployment.outputs.url }}
+          LHCI_COLLECT_BASE_URL: ${{ github.event.deployment_status.target_url }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,22 +1,21 @@
 name: Lighthouse
-on:
-  deployment_status:
-    types: [success]
+on: [deployment_status]
 
 jobs:
   lighthouse:
     if: github.event.deployment_status.state == 'success'
     runs-on: ubuntu-latest
     steps:
-      - name: event JSON
-        run: echo '${{ toJson(github.event) }}'
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.deployment.sha }}
+
+      - name: determine branch
+        uses: SFDigitalServices/git-the-branch@v1
+
       - uses: treosh/lighthouse-ci-action@v3
         with:
           serverToken: ${{ secrets.LHCI_BUILD_TOKEN }}
           serverBaseUrl: https://lighthouse-ci-sfgov.herokuapp.com
         env:
+          LHCI_BUILD_CONTEXT__CURRENT_BRANCH: ${{ env.GIT_BRANCH }}
           LHCI_GITHUB_TOKEN: ${{ github.token }}
           LHCI_COLLECT_BASE_URL: ${{ github.event.deployment_status.target_url }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,23 @@
+name: Lighthouse
+on: [push]
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - id: deployment
+        uses: SFDigitalServices/wait-for-deployment-action@v2
+        with:
+          github-token: ${{ github.token }}
+          interval: 300
+          timeout: 600
+
+      - uses: treosh/lighthouse-ci-action@v3
+        with:
+          serverToken: ${{ secrets.LHCI_BUILD_TOKEN }}
+          serverBaseUrl: https://lighthouse-ci-sfgov.herokuapp.com
+        env:
+          LHCI_GITHUB_TOKEN: ${{ github.token }}
+          LHCI_COLLECT_BASE_URL: ${{ steps.deployment.outputs.url }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -11,7 +11,7 @@ jobs:
         uses: SFDigitalServices/wait-for-deployment-action@v2
         with:
           github-token: ${{ github.token }}
-          interval: 30
+          interval: 60
           timeout: 600
 
       - uses: treosh/lighthouse-ci-action@v3

--- a/.lighthouserc.js
+++ b/.lighthouserc.js
@@ -1,0 +1,29 @@
+try {
+  require('dotenv').config()
+} catch (error) {
+  // this can fail in CI, where there is no .env
+}
+
+const {
+  LHCI_BUILD_TOKEN: token,
+  LHCI_COLLECT_BASE_URL: baseUrl = 'http://sfgov.lndo.site',
+} = process.env
+
+module.exports = {
+  ci: {
+    collect: {
+      url: baseUrl,
+      staticDistDir: false
+    },
+    assert: {
+    },
+    upload: {
+      target: 'lhci',
+      token,
+      ignoreDuplicateBuildFailure: true,
+      urlReplacementPatterns: [
+        `s#^${baseUrl}##`
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Okay, so I'd love to test this out on the develop branch and see if it works, because the whole poll-the-deployments-API approach is clearly not working. Here's what _should_ happen after this merges:

Every time a successful `deployment_status` event is triggered, Actions will checkout the repo at the same git SHA/ref as the deployment and run LHCI. I've had to make [another action](/sfdigitalservices/git-the-branch) to determine the right git branch from these events, since (unlike `push` events) they're not associated with a branch/ref. But it seems to work, and now instead of having a Lighthouse action run tied to every push, they only run on deployments, and the commit still gets the status:

![image](https://user-images.githubusercontent.com/113896/94171523-9b063180-fe4e-11ea-86d9-abe0050ce73f.png)
