### PR TITLE
[SG-1223] Compact version of Feedback for form pages

### DIFF
--- a/web/themes/custom/sfgovpl/dist/css/drupal.css
+++ b/web/themes/custom/sfgovpl/dist/css/drupal.css
@@ -13949,8 +13949,31 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 }
 
 .paragraph--formio--feedback a, .paragraph--formio--feedback label {
-  color: #fff;
   font-size: inherit;
+}
+
+.paragraph--formio--feedback label {
+  color: #fff;
+}
+
+.paragraph--formio--feedback a:link {
+  color: #fff;
+}
+
+.paragraph--formio--feedback a:visited, .paragraph--formio--feedback a:link:visited {
+  color: #fff;
+}
+
+.paragraph--formio--feedback a:focus {
+  color: #fff;
+}
+
+.paragraph--formio--feedback a.active:hover, .paragraph--formio--feedback a.is-active:hover, .paragraph--formio--feedback a.active-trail:hover, .paragraph--formio--feedback a.visited:hover, .paragraph--formio--feedback a:hover {
+  color: #fff;
+}
+
+.paragraph--formio--feedback a.is-active, .paragraph--formio--feedback a:active, .paragraph--formio--feedback a.active-trail {
+  color: #fff;
 }
 
 #formio-feedback {

--- a/web/themes/custom/sfgovpl/dist/css/drupal.css
+++ b/web/themes/custom/sfgovpl/dist/css/drupal.css
@@ -14154,6 +14154,10 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
   margin-top: 20px;
 }
 
+.page-node-type-form-page #formio-feedback .formio-component-reportIssue {
+  margin-top: 0;
+}
+
 @media (min-width: 740px) {
   #formio-feedback .formio-component-reportIssue {
     -webkit-box-flex: 0;

--- a/web/themes/custom/sfgovpl/dist/css/drupal.css
+++ b/web/themes/custom/sfgovpl/dist/css/drupal.css
@@ -13942,10 +13942,17 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 }
 
 .paragraph--formio--feedback {
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   background-color: #424244;
-  padding: 20px 0;
   color: #fff;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
   font-size: 1rem;
+  min-height: 81px;
+  padding: 20px 0;
 }
 
 .paragraph--formio--feedback a, .paragraph--formio--feedback label {

--- a/web/themes/custom/sfgovpl/src/sass/forms/_formio-feedback.scss
+++ b/web/themes/custom/sfgovpl/src/sass/forms/_formio-feedback.scss
@@ -136,6 +136,10 @@
     flex: 1 0 100%;
     margin-top: 20px;
 
+    .page-node-type-form-page & {
+      margin-top: 0;
+    }
+
      @media (min-width: 740px) {
       flex: 0 0 auto;
       justify-content: flex-end;

--- a/web/themes/custom/sfgovpl/src/sass/forms/_formio-feedback.scss
+++ b/web/themes/custom/sfgovpl/src/sass/forms/_formio-feedback.scss
@@ -7,8 +7,15 @@
   font-size: 1rem;
 
   a, label {
-   color: #fff;
    font-size: inherit;
+  }
+
+  label {
+    color: #fff;
+  }
+
+  a {
+    @include link-colors(#fff, #fff);
   }
 }
 

--- a/web/themes/custom/sfgovpl/src/sass/forms/_formio-feedback.scss
+++ b/web/themes/custom/sfgovpl/src/sass/forms/_formio-feedback.scss
@@ -1,10 +1,13 @@
 // Form.io Feedback form
 
 .paragraph--formio--feedback {
+  align-items: center;
   background-color: #424244;
-  padding: 20px 0;
   color: #fff;
+  display: flex;
   font-size: 1rem;
+  min-height: 81px;
+  padding: 20px 0;
 
   a, label {
    font-size: inherit;

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io--feedback.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io--feedback.html.twig
@@ -25,6 +25,10 @@
 
       Formio.createForm(el, el.getAttribute('data-source'), options)
         .then(function(form) {
+          // This is used to conditionally hide the following elements on form
+          // form pages: wasThisPageHelpful, helpfulYes, helpfulNo. See field
+          // configuration: Conditions (tab) > Advanced conditions > JavaScript.
+          form.data.isFormPage = (amplitudeData && amplitudeData.content_type === 'Form page') ? 'Yes' : 'No';
 
           var feedbackSuccess, messageComponent = '';
           if (!feedbackSuccess || !messageComponent) {


### PR DESCRIPTION
This provides a more compact version of the Feedback form above the footer on Form pages, so compare:

- Regular page: https://pr-668-sfgov.pantheonsite.io
- Form page: https://pr-668-sfgov.pantheonsite.io/node/973

Note: Most of the changes here are on the Form.io side, and when this is deployed we will need to update the [existing](https://sfds-test.form.io/feedback) form config with the [new](https://dev-sfds.form.io/feedback) one, using the [CLI tool](https://github.com/formio/formio-cli):

```bash
formio copy form https://dev-sfds.form.io/feedback https://sfds-test.form.io/feedback
```
