### PR TITLE
Use github action to trigger circleci build for main branch

### DIFF
--- a/.github/workflows/trigger-circleci-main.yml
+++ b/.github/workflows/trigger-circleci-main.yml
@@ -10,7 +10,7 @@ name: Trigger main build for circleci
 # only run on push to main
 on:
   push:
-    branches: [ main ]
+    branches: [ develop ]
 
 jobs:
   build:
@@ -20,7 +20,7 @@ jobs:
         env:
           CIRCLECI_API_TOKEN: ${{ secrets.CIRCLECI_API_TOKEN }}
         run: |
-          curl --data "{\"branch\":\"main\"}" \
+          curl --data "{\"branch\":\"develop\"}" \
             --header "Circle-Token: $CIRCLECI_API_TOKEN" \
             --request POST \
             https://circleci.com/api/v2/project/github/SFDigitalServices/sfgov/pipeline

--- a/.github/workflows/trigger-circleci-main.yml
+++ b/.github/workflows/trigger-circleci-main.yml
@@ -1,0 +1,26 @@
+# circleci is the primary ci tool for sfgov, but it is currently set to build on pr's only (with develop being the default branch)
+# because of this, main never gets built and so never gets deployed.
+# currently, circleci does not have an "allow-list" feature to build only pr's in addition to specific branches.
+# see https://discuss.circleci.com/t/allow-branch-whitelist-to-override-only-build-pull-requests/6392
+# and https://ideas.circleci.com/cloud-feature-requests/p/allow-branch-whitelist-to-override-only-build-pull-requests
+# this gh action workflow is a workaround to trigger the circleci build for main
+
+name: Trigger main build for circleci
+
+# only run on push to main
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger circleci build via api
+        env:
+          CIRCLECI_API_TOKEN: ${{ secrets.CIRCLECI_API_TOKEN }}
+        run: |
+          curl --data "{\"branch\":\"main\"}" \
+            --header "Circle-Token: $CIRCLECI_API_TOKEN" \
+            --request POST \
+            https://circleci.com/api/v2/project/github/SFDigitalServices/sfgov/pipeline

--- a/.github/workflows/trigger-circleci-main.yml
+++ b/.github/workflows/trigger-circleci-main.yml
@@ -10,7 +10,7 @@ name: Trigger main build for circleci
 # only run on push to main
 on:
   push:
-    branches: [ gh-action-main-build-trigger ]
+    branches: [ main ]
 
 jobs:
   build:
@@ -20,7 +20,7 @@ jobs:
         env:
           CIRCLECI_API_TOKEN: ${{ secrets.CIRCLECI_API_TOKEN }}
         run: |
-          curl --data "{\"branch\":\"develop\"}" \
+          curl --data "{\"branch\":\"main\"}" \
             --header "Circle-Token: $CIRCLECI_API_TOKEN" \
             --request POST \
             https://circleci.com/api/v2/project/github/SFDigitalServices/sfgov/pipeline

--- a/.github/workflows/trigger-circleci-main.yml
+++ b/.github/workflows/trigger-circleci-main.yml
@@ -10,7 +10,7 @@ name: Trigger main build for circleci
 # only run on push to main
 on:
   push:
-    branches: [ develop ]
+    branches: [ gh-action-main-build-trigger ]
 
 jobs:
   build:


### PR DESCRIPTION
Sounds loopy, but hear me out (also in comments in workflow yml):

The sfgov project uses a gitflow-ish type of workflow such that

* `main` is production ready code and hotfixes
* `develop` is the base/default to branch from for bug fixes and new features

We recently updated our circleci settings to build only for pr's because building for every commit was causing us to max our multidev limits on pantheon.  Buuut, because of our workflow above, `main` never gets built because `main` is never the compare branch for any pr.  `main` needs to get built because that's the branch that gets deployed to pantheon.  _This_ pr makes that happen by adding a github action/workflow that manually triggers a circleci build via the circleci api when `main` is pushed.

😓 

There's a circleci [discussion](https://discuss.circleci.com/t/allow-branch-whitelist-to-override-only-build-pull-requests/6392) that turned into an [idea](https://ideas.circleci.com/cloud-feature-requests/p/allow-branch-whitelist-to-override-only-build-pull-requests), but that hasn't been implemented yet.  Until then, using github actions to trigger the circleci build for `main` is a workaround.

Tested and working here (set push to this branch, and circle build branch to `develop`):

https://github.com/SFDigitalServices/sfgov/runs/1136467268?check_suite_focus=true