### PR TITLE
[SG-1138] News Card Refactor

### DIFF
--- a/config/views.view.news.yml
+++ b/config/views.view.news.yml
@@ -351,7 +351,7 @@ display:
         type: 'entity:node'
         options:
           relationship: none
-          view_mode: card
+          view_mode: card_compact
       rendering_language: '***LANGUAGE_language_interface***'
     cache_metadata:
       max-age: -1
@@ -460,7 +460,7 @@ display:
         type: 'entity:node'
         options:
           relationship: none
-          view_mode: card
+          view_mode: card_compact
       link_display: page_2
       link_url: ''
       rendering_language: '***LANGUAGE_language_interface***'

--- a/web/themes/custom/sfgovpl/dist/css/drupal.css
+++ b/web/themes/custom/sfgovpl/dist/css/drupal.css
@@ -2909,28 +2909,6 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
   width: 100%;
 }
 
-.news-front .news-front--view .view-news-block .sfgov-container-three-column .sfgov-container-item a {
-  min-height: 160px;
-  position: relative;
-}
-
-@media screen and (max-width: 768px) {
-  .news-front .news-front--view .view-news-block .sfgov-container-three-column .sfgov-container-item a {
-    min-height: 0;
-    padding-right: 20px;
-  }
-}
-
-.news-front .news-front--view .view-news-block .sfgov-container-three-column .sfgov-container-item .news--card h3 {
-  margin-bottom: 40px;
-}
-
-.news-front .news-front--view .view-news-block .sfgov-container-three-column .sfgov-container-item .field--type-datetime {
-  margin-top: 20px;
-  position: absolute;
-  bottom: 15px;
-}
-
 .news-front .news-front--twitter {
   background: #fff;
   border-radius: 8px;
@@ -7707,12 +7685,19 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 }
 
 .news--card {
+  -ms-flex-line-pack: justify;
+      align-content: space-between;
   background-color: #f4c435;
-  background-position: right top;
-  background-repeat: no-repeat;
   border-radius: 8px;
-  display: block;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+      -ms-flex-flow: row wrap;
+          flex-flow: row wrap;
   padding: 20px;
+  position: relative;
   text-decoration: none;
 }
 
@@ -7732,16 +7717,9 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
   color: #1c3e57;
 }
 
-.news--card.has-image {
-  min-height: 160px;
-  padding: 20px 180px 20px 20px;
-}
-
-@media screen and (max-width: 768px) {
-  .news--card.has-image {
-    background-image: none !important;
-    height: auto;
-    padding-right: 0;
+@media screen and (min-width: 768px) {
+  .news--card {
+    min-height: 160px;
   }
 }
 
@@ -7749,14 +7727,46 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
   background-color: #e7b22e;
 }
 
-.news--card .article--card__title {
+.news--card.news--card-compact {
+  -ms-flex-line-pack: start;
+      align-content: start;
+}
+
+@media screen and (min-width: 768px) {
+  .news--card.news--card-compact {
+    min-height: 0;
+  }
+}
+
+@media screen and (max-width: 950px) {
+  .news--card.has-image {
+    background-image: none !important;
+  }
+}
+
+@media screen and (min-width: 950px) {
+  .news--card.has-image {
+    background-position: right top;
+    background-repeat: no-repeat;
+    background-size: 160px 100%;
+    padding-right: 180px;
+  }
+}
+
+.news--card > * {
+  -webkit-box-flex: 1;
+      -ms-flex: 1 0 100%;
+          flex: 1 0 100%;
+}
+
+.news--card .article__title {
   font-size: 17px;
   font-weight: 500;
   line-height: 24px;
-  margin: 0 0 11px;
+  margin: 0 0 10px 0;
 }
 
-.news--card .article--card__title.sfgov-translate-lang-zh-TW {
+.news--card .article__title.sfgov-translate-lang-zh-TW {
   font-size: 18px;
   line-height: 26px;
   letter-spacing: 1px;
@@ -7765,6 +7775,10 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
   -webkit-font-smoothing: antialiased;
   font-smoothing: antialiased;
   font-smooth: always;
+}
+
+.news--card .__date {
+  line-height: 1;
 }
 
 .news--teaser {

--- a/web/themes/custom/sfgovpl/src/sass/components/_news-front.scss
+++ b/web/themes/custom/sfgovpl/src/sass/components/_news-front.scss
@@ -11,7 +11,7 @@
     padding-bottom: 80px;
     padding-top: 80px;
   }
-  
+
   @include media-max($medium-screen) {
     padding-left: 0;
     padding-right: 0;
@@ -24,7 +24,7 @@
   .news-front--container {
     padding: 0;
     position: relative;
-    
+
     @include media($narrow-screen) {
       padding: 0;
     }
@@ -36,7 +36,7 @@
     display: block;
     width: 50%;
     padding-right: 20px;
-    
+
     @include media-max($medium-screen) {
       float: none;
       clear: both;
@@ -47,27 +47,10 @@
     .view-news-block {
       .sfgov-container-three-column {
         display: block;
+
         .sfgov-container-item {
           display: block;
           width: 100%;
-          
-          a {
-            min-height: 160px;
-            position: relative;
-            
-            @include media-max($medium-screen) {
-              min-height: 0;
-              padding-right: 20px;
-            }
-          }
-          .news--card h3 {
-            margin-bottom: 40px;
-          }
-          .field--type-datetime {
-            margin-top: 20px;
-            position: absolute;
-            bottom: 15px;
-          }
         }
       }
     }
@@ -82,7 +65,7 @@
     width: 50%;
     position: relative;
     top: 110px;
-    
+
     @include media-max($medium-screen) {
       float: none;
       clear: both;

--- a/web/themes/custom/sfgovpl/src/sass/node/_node-news-card.scss
+++ b/web/themes/custom/sfgovpl/src/sass/node/_node-news-card.scss
@@ -1,31 +1,71 @@
+// News Card
+//
+// News card is rendered by the "News" view (/admin/structure/views/view/news).
+// It has 2 variants that map to Drupal view modes:
+//
+// - card:
+//   - fields: Title, Date, Image
+//   - selector: .news--card {}
+//   - used on: Home page
+//
+// - card_compact:
+//   - fields: Title, Date
+//   - selector: .news--card.news--card-compact {}
+//   - used on: Departments (e.g. /oceia), Topics (e.g. /topics/immigrants)
+//
+// -----------------------------------------------------------------------------
+
 .news--card {
   @include link-colors($c-slate);
+  align-content: space-between;
   background-color: $c-yellow-3;
-  background-position: right top;
-  background-repeat: no-repeat;
   border-radius: 8px;
-  display: block; // <= Default needed for homepage, overridden on dept page.
+  display: flex;
+  flex-flow: row wrap;
   padding: 20px;
+  position: relative;
   text-decoration: none;
 
-  &.has-image {
+  @include media($medium-screen) {
     min-height: 160px;
-    padding: 20px 180px 20px 20px;
-
-    @include media-max($medium-screen) {
-      background-image: none !important;
-      height: auto;
-      padding-right: 0;
-    }
   }
 
   &:hover {
     background-color: $c-yellow-4;
   }
 
+  &.news--card-compact {
+    align-content: start;
 
-  .article--card__title {
+    @include media($medium-screen) {
+      min-height: 0;
+    }
+  }
+
+  // 'card' will render an image, but it's an optional field.
+  &.has-image {
+    @include media-max($narrow-screen) {
+      background-image: none !important;
+    }
+
+    @include media($narrow-screen) {
+      background-position: right top;
+      background-repeat: no-repeat;
+      background-size: 160px 100%; // Stretch height for longer titles.
+      padding-right: 180px; // 160px + 20px padding.
+    }
+  }
+
+  > * {
+    flex: 1 0 100%;
+  }
+
+  .article__title {
     @include fs-body-bold;
-    margin: 0 0 11px;
+    margin: 0 0 10px 0;
+  }
+
+  .__date {
+    line-height: 1;
   }
 }


### PR DESCRIPTION
- Use the proper view mode when there is an image (homepage) vs not (topics, departments).
- Remove homepage-specific CSS, which as using a different layout technique.
- All the News card CSS lives in one place, and is documented.
- Change the breakpoint for when the image appears, as there is never enough room for it to look good until `$narrow-screen`.