### PR TITLE
Update formio-sfds to 6.4.0

### DIFF
--- a/config/sfgov_formio.settings.yml
+++ b/config/sfgov_formio.settings.yml
@@ -1,2 +1,2 @@
 formio_version: 'https://unpkg.com/formiojs@4.11.2/dist/formio.full.min.js'
-formio_sfds_version: 'https://unpkg.com/formio-sfds@6.3.0/dist/formio-sfds.standalone.js'
+formio_sfds_version: 'https://unpkg.com/formio-sfds@6.4.0/dist/formio-sfds.standalone.js'


### PR DESCRIPTION
See https://github.com/SFDigitalServices/formio-sfds/releases/tag/v6.4.0 for more info.

@aekong This release has been tested more thoroughly and is ready to go. This supersedes #695.