### PR TITLE
SG-1245: add null check before appending css class to element

### DIFF
--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -105,7 +105,8 @@
       function customAddCssClassById(classes) {
         for (var key in classes) {
           var el = document.getElementById(key)
-          el.classList.add(classes[key])
+          if(el != null)
+            el.classList.add(classes[key])
         }
       }
 


### PR DESCRIPTION
There is a setting in the form page's form.io render options to add a css class to the block-gtranslate element, the purpose is align the translation icon on mobile version.

Fixed in `paragraph--form-io.html.twig`