### PR TITLE
Update formio-sfds to 6.4.3

### DIFF
--- a/config/sfgov_formio.settings.yml
+++ b/config/sfgov_formio.settings.yml
@@ -1,2 +1,2 @@
 formio_version: 'https://unpkg.com/formiojs@4.11.2/dist/formio.full.min.js'
-formio_sfds_version: 'https://unpkg.com/formio-sfds@6.4.1/dist/formio-sfds.standalone.js'
+formio_sfds_version: 'https://unpkg.com/formio-sfds@6.4.3/dist/formio-sfds.standalone.js'


### PR DESCRIPTION
This bumps us two patch versions:

- [6.4.2](https://github.com/SFDigitalServices/formio-sfds/releases/tag/v6.4.2) fixes state and zip inputs bumping up on smaller screens and the order of our CSS utilities in the output
- [6.4.3](https://github.com/SFDigitalServices/formio-sfds/releases/tag/v6.4.3) adds U.S. states to state input lists and removes a `globalThis` reference that was breaking IE and Edge ≤ 18

See [the diff](https://github.com/SFDigitalServices/formio-sfds/compare/v6.4.1...v6.4.3) for the nitty gritty.