### PR TITLE
Add amplitude events for form.io forms

### DIFF
--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -122,8 +122,8 @@
       .then(function(form) {
         amp.logEvent('form.load', { time: Date.now() - time })
 
-        Object.keys(formEventHandlers).forEach(function (eventName) {
-          form.on(eventName, function () {
+        Object.keys(formEventHandlers).forEach(function(eventName) {
+          form.on(eventName, function() {
             var data = formEventHandlers[eventName].apply(form, arguments)
             if (data !== false) {
               data = Object.assign({ form: form.url }, data)
@@ -141,13 +141,13 @@
           customAddCssClassById(options.sfoptions.addClass)
         }
         // if cookies are defined, populate the form field with cookie value.
-        if(options.sfoptions instanceof Object && options.sfoptions.cookies){
-          manageFormCookies(options.sfoptions["cookies"], form, true)
+        if (options.sfoptions instanceof Object && options.sfoptions.cookies) {
+          manageFormCookies(options.sfoptions.cookies, form, true)
         }
         // perform custom action on nextPage event
-        form.on('nextPage', function(){
+        form.on('nextPage', function() {
           // set form cookies, if there are any
-          if(options.sfoptions instanceof Object && options.sfoptions.cookies){
+          if (options.sfoptions instanceof Object && options.sfoptions.cookies) {
             manageFormCookies(options.sfoptions.cookies, form, false)
           }
         })
@@ -155,7 +155,7 @@
         // What to do when the submit begins.
         form.on('submitDone', function(submission) {
           // custom options defined in Form.io render options field
-          if(options.redirects instanceof Object){
+          if (options.redirects instanceof Object) {
             if (options.sfoptions && options.sfoptions.hide instanceof Object) {
               customHideElements(options.sfoptions.hide)
             }
@@ -170,7 +170,7 @@
           }
         {% if paragraph.field_formio_confirmation_url.value %}
           // if confirmation url is set, this is for backward compatibility
-          window.location = '{{ paragraph.field_formio_confirmation_url.value }}';
+          window.location = '{{ paragraph.field_formio_confirmation_url.value }}'
         {% endif %}
       })
     })
@@ -187,28 +187,28 @@
     function customHideElements(elements) {
       elements.forEach(function(klass, index) {
         var hide = document.getElementsByClassName(klass)
-        for (var i = 0; i < hide.length; i++){
+        for (var i = 0; i < hide.length; i++) {
           hide[i].style.display = "none"
         }
       })
     }
 
-    function setCookie(name, value){
-      var today = new Date();
+    function setCookie(name, value) {
+      var today = new Date()
       var expiry = new Date(today.getTime() + 90 * 24 * 3600 * 1000); // plus 90 days
-      document.cookie=name + "=" + escape(value) + "; path=/; expires=" + expiry.toGMTString();
+      document.cookie=name + "=" + escape(value) + "; path=/; expires=" + expiry.toGMTString()
     }
 
-    function getCookie(name){
-      var re = new RegExp(name + "=([^;]+)");
-      var value = re.exec(document.cookie);
-      return (value != null) ? unescape(value[1]) : null;
+    function getCookie(name) {
+      var re = new RegExp(name + "=([^;]+)")
+      var value = re.exec(document.cookie)
+      return (value != null) ? unescape(value[1]) : null
     }
 
     function setCheckboxRadioButton(field, cookieval, fieldtype) {
-      if (!cookieval) return;
+      if (!cookieval) return
 
-      if (cookieval.includes(field.value) ){
+      if (cookieval.includes(field.value)) {
         field.prop('checked', true)
       }
     }
@@ -220,7 +220,7 @@
 
         // special type: select, because formio renders select as divs
         var selectField = $('select[name*="'+item+'"]')[0]
-        if (selectField){
+        if (selectField) {
           field = $(selectField) // convert to jQuery object
         }
         if (field || populateAll) {

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -63,8 +63,6 @@
 
   window.addEventListener('load', function() {
     var loadTime = Date.now() - time
-    var amp = amplitude.getInstance()
-    amp.logEvent('window.load', { time: loadTime })
 
     // Get the properties defined in the Amplitude event for "Feedback form".
     var amplitudeData = {}
@@ -75,6 +73,13 @@
         }
       })
     }
+
+    var amplitude = window.amplitude.getInstance()
+    var amp = function(eventName, data) {
+      amplitude.logEvent(eventName, Object.assign(data, amplitudeData))
+    }
+
+    amp('window.load', { time: loadTime })
 
     // keeping this as a DOM for patch.js
     var el = document.getElementById('formio-{{ form_id }}')
@@ -131,14 +136,14 @@
     time = Date.now()
     Formio.createForm(el, el.getAttribute('data-source'), options)
       .then(function(form) {
-        amp.logEvent('form.load', { time: Date.now() - time })
+        amp('form.load', { time: Date.now() - time })
 
         Object.keys(formEventHandlers).forEach(function(eventName) {
           form.on(eventName, function() {
             var data = formEventHandlers[eventName].apply(form, arguments)
             if (data !== false) {
               data = Object.assign({ form: form.url }, amplitudeData, data)
-              amp.logEvent('form.' + eventName, data)
+              amp('form.' + eventName, data)
             }
           })
         })

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -104,6 +104,11 @@
         saveDraft: function (submission) {
         },
         restoreDraft: function (submission) {
+        },
+        editGridAddRow: function (data) {
+          return {
+            component: data.component.key
+          }
         }
       }
 

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -57,204 +57,205 @@
 {% block content %}
 <script>
 (function() {
-    var time = Date.now()
 
-    window.addEventListener('load', function() {
-      var amp = amplitude.getInstance()
-      amp.logEvent('window.load', { time: Date.now() - time })
+  var time = Date.now()
 
-      // keeping this as a DOM for patch.js
-      var el = document.getElementById('formio-{{ form_id }}')
-      var options = safeJSONParse(el.getAttribute('data-options'))
+  window.addEventListener('load', function() {
+    var amp = amplitude.getInstance()
+    amp.logEvent('window.load', { time: Date.now() - time })
 
-      var formEventHandlers = {
-        submit: function (submission) {
-        },
-        submitDone: function (submission) {
-        },
-        error: function (message) {
-          return { message: message }
-        },
-        submitError: function (message) {
-          return { message: message }
-        },
-        componentError: function (error) {
-          return {
-            component: error.component.key,
-            message: error.message
-          }
-        },
-        prevPage: function (data) {
-          return { page: data.page }
-        },
-        nextPage: function (data) {
-          return { page: data.page }
-        },
-        wizardNavigationClicked: function (page) {
-          return {
-            title: page.title
-          }
-        },
-        wizardPageSelected: function (page, index) {
-          return {
-            title: page.title,
-            page: index
-          }
-        },
-        saveDraft: function (submission) {
-        },
-        restoreDraft: function (submission) {
-        },
-        editGridAddRow: function (data) {
-          return {
-            component: data.component.key
-          }
+    // keeping this as a DOM for patch.js
+    var el = document.getElementById('formio-{{ form_id }}')
+    var options = safeJSONParse(el.getAttribute('data-options'))
+
+    /*
+     * Every key in this object is a form event name, and the value is a
+     * function that returns amplitude event data for the given event data.
+     *
+     * Note that formiojs uses eventemitter2 and usually emits event data as
+     * multiple arguments to the listener rather than as a single event
+     * object.
+     */
+    var formEventHandlers = {
+      submit: function (submission) { },
+      submitDone: function (submission) { },
+      error: function (message) {
+        return { message: message }
+      },
+      submitError: function (message) {
+        return { message: message }
+      },
+      componentError: function (error) {
+        return {
+          component: error.component.key,
+          message: error.message
         }
-      }
+      },
+      prevPage: function (data) {
+        return { page: data.page }
+      },
+      nextPage: function (data) {
+        return { page: data.page }
+      },
+      wizardNavigationClicked: function (page) {
+        return {
+          title: page.title
+        }
+      },
+      wizardPageSelected: function (page, index) {
+        return {
+          title: page.title,
+          page: index
+        }
+      },
+      saveDraft: function (submission) { },
+      restoreDraft: function (submission) { }
+    }
 
-      time = Date.now()
-      Formio.createForm(el, el.getAttribute('data-source'), options)
-        .then(function(form) {
-          amp.logEvent('form.load', { time: Date.now() - time })
+    time = Date.now()
+    Formio.createForm(el, el.getAttribute('data-source'), options)
+      .then(function(form) {
+        amp.logEvent('form.load', { time: Date.now() - time })
 
-          for (var eventName in formEventHandlers) {
-            form.on(eventName, function () {
-              const data = Object.assign({
-                form: this.url
-              }, formEventHandlers[eventName].apply(form, arguments))
+        for (var eventName in formEventHandlers) {
+          form.on(eventName, function () {
+            var data = formEventHandlers[eventName].apply(form, arguments)
+            if (data !== false) {
+              data = Object.assign({ form: form.url }, data)
               amp.logEvent('form.' + eventName, data)
-            })
-          }
-
-          //perform sfoptions, hide certain elements
-          if (options.sfoptions && options.sfoptions.hide instanceof Object) {
-            customHideElements(options.sfoptions.hide)
-          }
-          // add css class to element(by id)
-          if (options.sfoptions && options.sfoptions.addClass) {
-            customAddCssClassById(options.sfoptions.addClass)
-          }
-          // if cookies are defined, populate the form field with cookie value.
-          if(options.sfoptions instanceof Object && options.sfoptions.cookies){
-            manageFormCookies(options.sfoptions["cookies"], form, true)
-          }
-          // perform custom action on nextPage event
-          form.on('nextPage', function(){
-            // set form cookies, if there are any
-            if(options.sfoptions instanceof Object && options.sfoptions.cookies){
-              manageFormCookies(options.sfoptions.cookies, form, false)
             }
           })
+        }
 
-          // What to do when the submit begins.
-          form.on('submitDone', function(submission) {
-            // custom options defined in Form.io render options field
-            if(options.redirects instanceof Object){
-              if (options.sfoptions && options.sfoptions.hide instanceof Object) {
-                customHideElements(options.sfoptions.hide)
-              }
-              for (var key in options.redirects) {
-                var value = options.redirects[key]
-                // only one "redirect" should be "yes", this is set in the form.io form
-                if (submission.data[key] === "yes") {
-                  window.location = value
-                  break
-                }
+        //perform sfoptions, hide certain elements
+        if (options.sfoptions && options.sfoptions.hide instanceof Object) {
+          customHideElements(options.sfoptions.hide)
+        }
+        // add css class to element(by id)
+        if (options.sfoptions && options.sfoptions.addClass) {
+          customAddCssClassById(options.sfoptions.addClass)
+        }
+        // if cookies are defined, populate the form field with cookie value.
+        if(options.sfoptions instanceof Object && options.sfoptions.cookies){
+          manageFormCookies(options.sfoptions["cookies"], form, true)
+        }
+        // perform custom action on nextPage event
+        form.on('nextPage', function(){
+          // set form cookies, if there are any
+          if(options.sfoptions instanceof Object && options.sfoptions.cookies){
+            manageFormCookies(options.sfoptions.cookies, form, false)
+          }
+        })
+
+        // What to do when the submit begins.
+        form.on('submitDone', function(submission) {
+          // custom options defined in Form.io render options field
+          if(options.redirects instanceof Object){
+            if (options.sfoptions && options.sfoptions.hide instanceof Object) {
+              customHideElements(options.sfoptions.hide)
+            }
+            for (var key in options.redirects) {
+              var value = options.redirects[key]
+              // only one "redirect" should be "yes", this is set in the form.io form
+              if (submission.data[key] === "yes") {
+                window.location = value
+                break
               }
             }
-          {% if paragraph.field_formio_confirmation_url.value %}
-            // if confirmation url is set, this is for backward compatibility
-            window.location = '{{ paragraph.field_formio_confirmation_url.value }}';
-          {% endif %}
-        })
+          }
+        {% if paragraph.field_formio_confirmation_url.value %}
+          // if confirmation url is set, this is for backward compatibility
+          window.location = '{{ paragraph.field_formio_confirmation_url.value }}';
+        {% endif %}
       })
+    })
 
-      function customAddCssClassById(classes) {
-        for (var key in classes) {
-          var el = document.getElementById(key)
-          if (el != null) {
-            el.classList.add(classes[key])
-          }
+    function customAddCssClassById(classes) {
+      for (var key in classes) {
+        var el = document.getElementById(key)
+        if (el != null) {
+          el.classList.add(classes[key])
         }
       }
+    }
 
-      function customHideElements(elements) {
-        elements.forEach(function(klass, index) {
-          var hide = document.getElementsByClassName(klass)
-          for (var i = 0; i < hide.length; i++){
-            hide[i].style.display = "none"
-          }
-        })
-      }
-
-      function setCookie(name, value){
-        var today = new Date();
-        var expiry = new Date(today.getTime() + 90 * 24 * 3600 * 1000); // plus 90 days
-        document.cookie=name + "=" + escape(value) + "; path=/; expires=" + expiry.toGMTString();
-      }
-
-      function getCookie(name){
-        var re = new RegExp(name + "=([^;]+)");
-        var value = re.exec(document.cookie);
-        return (value != null) ? unescape(value[1]) : null;
-      }
-
-      function setCheckboxRadioButton(field, cookieval, fieldtype) {
-        if (!cookieval) return;
-
-        if (cookieval.includes(field.value) ){
-          field.prop('checked', true)
+    function customHideElements(elements) {
+      elements.forEach(function(klass, index) {
+        var hide = document.getElementsByClassName(klass)
+        for (var i = 0; i < hide.length; i++){
+          hide[i].style.display = "none"
         }
+      })
+    }
+
+    function setCookie(name, value){
+      var today = new Date();
+      var expiry = new Date(today.getTime() + 90 * 24 * 3600 * 1000); // plus 90 days
+      document.cookie=name + "=" + escape(value) + "; path=/; expires=" + expiry.toGMTString();
+    }
+
+    function getCookie(name){
+      var re = new RegExp(name + "=([^;]+)");
+      var value = re.exec(document.cookie);
+      return (value != null) ? unescape(value[1]) : null;
+    }
+
+    function setCheckboxRadioButton(field, cookieval, fieldtype) {
+      if (!cookieval) return;
+
+      if (cookieval.includes(field.value) ){
+        field.prop('checked', true)
       }
+    }
 
-      function manageFormCookies(cookies, form, populateAll) {
-        cookies.forEach(function(item, index) {
-          var field = $('input[name*="'+item+'"]') // use jquery to get dynamic field by name
-          var fieldtype = field.prop('type')
+    function manageFormCookies(cookies, form, populateAll) {
+      cookies.forEach(function(item, index) {
+        var field = $('input[name*="'+item+'"]') // use jquery to get dynamic field by name
+        var fieldtype = field.prop('type')
 
-          // special type: select, because formio renders select as divs
-          var selectField = $('select[name*="'+item+'"]')[0]
-          if (selectField){
-            field = $(selectField) // convert to jQuery object
+        // special type: select, because formio renders select as divs
+        var selectField = $('select[name*="'+item+'"]')[0]
+        if (selectField){
+          field = $(selectField) // convert to jQuery object
+        }
+        if (field || populateAll) {
+          var cookieval = getCookie(item)
+          if (cookieval) {
+            // set submission data, form validation needs this
+            form._submission.data[item] = cookieval
           }
-          if (field || populateAll) {
-            var cookieval = getCookie(item)
-            if (cookieval) {
-              // set submission data, form validation needs this
-              form._submission.data[item] = cookieval
+
+          if (field) { // populate fields with cookie values
+            if (fieldtype !== undefined && (fieldtype === 'radio' || fieldtype === 'checkbox')) {
+              setCheckboxRadioButton(field, cookieval, fieldtype)
+            } else {
+              field.val(cookieval)
             }
-
-            if (field) { // populate fields with cookie values
-              if (fieldtype !== undefined && (fieldtype === 'radio' || fieldtype === 'checkbox')) {
-                setCheckboxRadioButton(field, cookieval, fieldtype)
-              } else {
-                field.val(cookieval)
-              }
-            } else if (field) {
-              // set cookie for first time
-              if (fieldtype !== undefined && (fieldtype === 'radio' || fieldtype === 'checkbox')) {
-                setCookie(item, field.prop('checked'))
-              } else {
-                setCookie(item, field.val())
-              }
-            } // updates cookie if value changed
-            $(field).change(function() {
-              console.log("setting cookie for " + item + " with value " + this.value)
-              setCookie(item, this.value)
-            })
-          }
-        })
-      }
-
-      function safeJSONParse(str) {
-        var parsed = {}
-        try {
-          parsed = JSON.parse(str)
-        } catch (error) {
-          console.warn('Unable to parse form options:', str)
+          } else if (field) {
+            // set cookie for first time
+            if (fieldtype !== undefined && (fieldtype === 'radio' || fieldtype === 'checkbox')) {
+              setCookie(item, field.prop('checked'))
+            } else {
+              setCookie(item, field.val())
+            }
+          } // updates cookie if value changed
+          $(field).change(function() {
+            console.log("setting cookie for " + item + " with value " + this.value)
+            setCookie(item, this.value)
+          })
         }
-        return parsed
+      })
+    }
+
+    function safeJSONParse(str) {
+      var parsed = {}
+      try {
+        parsed = JSON.parse(str)
+      } catch (error) {
+        console.warn('Unable to parse form options:', str)
       }
+      return parsed
+    }
   })
 
 })()

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -56,32 +56,93 @@
 
 {% block content %}
 <script>
+(function() {
+   var time = Date.now()
+   var amp = amplitude.getInstance()
+   
    window.addEventListener('load', function() {
-      var el = document.getElementById('formio-{{ form_id }}'); // keeping this as a DOM for patch.js
+      amp.logEvent('window.load', { time: Date.now() - time })
+      
+      // keeping this as a DOM for patch.js
+      var el = document.getElementById('formio-{{ form_id }}')
       var options = safeJSONParse(el.getAttribute('data-options'))
+      
+      var formEventHandlers = {
+        submit: function (submission) {
+        },
+        submitDone: function (submission) {
+        },
+        error: function (message) {
+          return { message: message }
+        },
+        submitError: function (message) {
+          return { message: message }
+        },
+        componentError: function (error) {
+          return {
+            component: error.component.key,
+            message: error.message
+          }
+        },
+        prevPage: function (data) {
+          return { page: data.page }
+        },
+        nextPage: function (data) {
+          return { page: data.page }
+        },
+        wizardNavigationClicked: function (page) {
+          return {
+            title: page.title
+          }
+        },
+        wizardPageSelected: function (page, index) {
+          return {
+            title: page.title,
+            page: index
+          }
+        },
+        saveDraft: function (submission) {
+        },
+        restoreDraft: function (submission) {
+        }
+      }
+
+      time = Date.now()
       Formio.createForm(el, el.getAttribute('data-source'), options)
         .then(function(form) {
-        //perform sfoptions, hide certain elements
-        if (options.sfoptions && options.sfoptions.hide instanceof Object) {
-          customHideElements(options.sfoptions.hide)
-        }
-        // add css class to element(by id)
-        if (options.sfoptions && options.sfoptions.addClass) {
-          customAddCssClassById(options.sfoptions.addClass)
-        }
-        // if cookies are defined, populate the form field with cookie value.
-        if(options.sfoptions instanceof Object && options.sfoptions.cookies){
-          manageFormCookies(options.sfoptions["cookies"], form, true)
-        }
-        // perform custom action on nextPage event
-        form.on('nextPage', function(){
-          // set form cookies, if there are any
-          if(options.sfoptions instanceof Object && options.sfoptions.cookies){
-            manageFormCookies(options.sfoptions.cookies, form, false)
+          amp.logEvent('form.load', { time: Date.now() - time })
+          
+          for (var eventName in formEventHandlers) {
+            form.on(eventName, function () {
+              const data = Object.assign({
+                form: this.url
+              }, formEventHandlers[eventName].apply(form, arguments))
+              amp.logEvent('form.' + eventName, data)
+            })
           }
-        })
-        // What to do when the submit begins.
-        form.on('submitDone', function(submission) {
+          
+          //perform sfoptions, hide certain elements
+          if (options.sfoptions && options.sfoptions.hide instanceof Object) {
+            customHideElements(options.sfoptions.hide)
+          }
+          // add css class to element(by id)
+          if (options.sfoptions && options.sfoptions.addClass) {
+            customAddCssClassById(options.sfoptions.addClass)
+          }
+          // if cookies are defined, populate the form field with cookie value.
+          if(options.sfoptions instanceof Object && options.sfoptions.cookies){
+            manageFormCookies(options.sfoptions["cookies"], form, true)
+          }
+          // perform custom action on nextPage event
+          form.on('nextPage', function(){
+            // set form cookies, if there are any
+            if(options.sfoptions instanceof Object && options.sfoptions.cookies){
+              manageFormCookies(options.sfoptions.cookies, form, false)
+            }
+          })
+
+          // What to do when the submit begins.
+          form.on('submitDone', function(submission) {
             // custom options defined in Form.io render options field
             if(options.redirects instanceof Object){
               if (options.sfoptions && options.sfoptions.hide instanceof Object) {
@@ -90,33 +151,35 @@
               for (var key in options.redirects) {
                 var value = options.redirects[key]
                 // only one "redirect" should be "yes", this is set in the form.io form
-                if(submission.data[key] === "yes"){
+                if (submission.data[key] === "yes") {
                   window.location = value
                   break
                 }
               }
             }
-          // if confirmation url is set, this is for backward compatibility
           {% if paragraph.field_formio_confirmation_url.value %}
+            // if confirmation url is set, this is for backward compatibility
             window.location = '{{ paragraph.field_formio_confirmation_url.value }}';
           {% endif %}
-        });
-      });
+        })
+      })
+      
       function customAddCssClassById(classes) {
         for (var key in classes) {
           var el = document.getElementById(key)
-          if(el != null)
+          if (el != null) {
             el.classList.add(classes[key])
+          }
         }
       }
 
       function customHideElements(elements) {
         elements.forEach(function(klass, index) {
-            var hide = document.getElementsByClassName(klass)
-            for (var i = 0; i < hide.length; i++){
-              hide[i].style.display = "none"
-            }
-          })
+          var hide = document.getElementsByClassName(klass)
+          for (var i = 0; i < hide.length; i++){
+            hide[i].style.display = "none"
+          }
+        })
       }
 
       function setCookie(name, value){
@@ -132,44 +195,45 @@
       }
 
       function setCheckboxRadioButton(field, cookieval, fieldtype) {
-        if(!cookieval) return;
+        if (!cookieval) return;
 
-        if(cookieval.includes(field.value) ){
+        if (cookieval.includes(field.value) ){
           field.prop('checked', true)
         }
       }
 
       function manageFormCookies(cookies, form, populateAll) {
-        cookies.forEach(function(item, index){
+        cookies.forEach(function(item, index) {
           var field = $('input[name*="'+item+'"]') // use jquery to get dynamic field by name
           var fieldtype = field.prop('type')
 
           // special type: select, because formio renders select as divs
           var selectField = $('select[name*="'+item+'"]')[0]
-          if(selectField){
+          if (selectField){
             field = $(selectField) // convert to jQuery object
           }
-          if(field || populateAll){
+          if (field || populateAll) {
             var cookieval = getCookie(item)
-            if(cookieval)
-              form._submission.data[item] = cookieval //set submission data, form validation needs this
+            if (cookieval) {
+              // set submission data, form validation needs this
+              form._submission.data[item] = cookieval
+            }
 
-            if(field){ // populate fields with cookie values
-                if(fieldtype !== undefined && (fieldtype === 'radio' || fieldtype === 'checkbox')){
-                  setCheckboxRadioButton(field, cookieval, fieldtype)
-                }else{
-                  field.val(cookieval)
-                }
-            }else if(field){
-              // set cookie for first time
-              if(fieldtype !== undefined && (fieldtype === 'radio' || fieldtype === 'checkbox')){
-                setCookie(item, field.prop('checked'))
+            if (field) { // populate fields with cookie values
+              if (fieldtype !== undefined && (fieldtype === 'radio' || fieldtype === 'checkbox')) {
+                setCheckboxRadioButton(field, cookieval, fieldtype)
+              } else {
+                field.val(cookieval)
               }
-              else{
+            } else if (field) {
+              // set cookie for first time
+              if (fieldtype !== undefined && (fieldtype === 'radio' || fieldtype === 'checkbox')) {
+                setCookie(item, field.prop('checked'))
+              } else {
                 setCookie(item, field.val())
               }
             } // updates cookie if value changed
-            $(field).change( function(){
+            $(field).change(function() {
               console.log("setting cookie for " + item + " with value " + this.value)
               setCookie(item, this.value)
             })
@@ -186,8 +250,9 @@
         }
         return parsed
       }
-  });
-
+  })
+  
+})()
 </script>
 {% endblock content %}
 

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -109,7 +109,12 @@
         }
       },
       saveDraft: function (submission) { },
-      restoreDraft: function (submission) { }
+      restoreDraft: function (submission) { },
+      editGridAddRow: function (data) {
+        return {
+          component: data.component.key
+        }
+      }
     }
 
     time = Date.now()
@@ -117,7 +122,7 @@
       .then(function(form) {
         amp.logEvent('form.load', { time: Date.now() - time })
 
-        for (var eventName in formEventHandlers) {
+        Object.keys(formEventHandlers).forEach(function (eventName) {
           form.on(eventName, function () {
             var data = formEventHandlers[eventName].apply(form, arguments)
             if (data !== false) {
@@ -125,7 +130,7 @@
               amp.logEvent('form.' + eventName, data)
             }
           })
-        }
+        })
 
         //perform sfoptions, hide certain elements
         if (options.sfoptions && options.sfoptions.hide instanceof Object) {

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -62,8 +62,19 @@
   var confirmationURL = {{ paragraph.field_formio_confirmation_url.value | escape('js') }}
 
   window.addEventListener('load', function() {
+    var loadTime = Date.now() - time
     var amp = amplitude.getInstance()
-    amp.logEvent('window.load', { time: Date.now() - time })
+    amp.logEvent('window.load', { time: loadTime })
+
+    // Get the properties defined in the Amplitude event for "Feedback form".
+    var amplitudeData = {}
+    if (drupalSettings.amplitude.events.length) {
+      drupalSettings.amplitude.events.find(function(obj) {
+        if (obj.name === 'Page view') {
+          amplitudeData = JSON.parse(obj.properties)
+        }
+      })
+    }
 
     // keeping this as a DOM for patch.js
     var el = document.getElementById('formio-{{ form_id }}')
@@ -74,8 +85,7 @@
      * function that returns amplitude event data for the given event data.
      *
      * Note that formiojs uses eventemitter2 and usually emits event data as
-     * multiple arguments to the listener rather than as a single event
-     * object.
+     * multiple arguments to the listener rather than a single event object.
      */
     var formEventHandlers = {
       submit: function (submission) { },
@@ -127,7 +137,7 @@
           form.on(eventName, function() {
             var data = formEventHandlers[eventName].apply(form, arguments)
             if (data !== false) {
-              data = Object.assign({ form: form.url }, data)
+              data = Object.assign({ form: form.url }, amplitudeData, data)
               amp.logEvent('form.' + eventName, data)
             }
           })

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -59,6 +59,7 @@
 (function() {
 
   var time = Date.now()
+  var confirmationURL = {{ paragraph.field_formio_confirmation_url.value | escape('js') }}
 
   window.addEventListener('load', function() {
     var amp = amplitude.getInstance()
@@ -168,12 +169,12 @@
               }
             }
           }
-        {% if paragraph.field_formio_confirmation_url.value %}
-          // if confirmation url is set, this is for backward compatibility
-          window.location = '{{ paragraph.field_formio_confirmation_url.value }}'
-        {% endif %}
+
+          if (confirmationURL) {
+            window.location = confirmationURL
+          }
+        })
       })
-    })
 
     function customAddCssClassById(classes) {
       for (var key in classes) {

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -79,7 +79,7 @@
       amplitude.logEvent(eventName, Object.assign(data, amplitudeData))
     }
 
-    amp('window.load', { time: loadTime })
+    amp('window.load', { load_time: loadTime })
 
     // keeping this as a DOM for patch.js
     var el = document.getElementById('formio-{{ form_id }}')
@@ -96,32 +96,32 @@
       submit: function (submission) { },
       submitDone: function (submission) { },
       error: function (message) {
-        return { message: message }
+        return { error: message }
       },
       submitError: function (message) {
-        return { message: message }
+        return { error: message }
       },
       componentError: function (error) {
         return {
           component: error.component.key,
-          message: error.message
+          error: error.message
         }
       },
       prevPage: function (data) {
-        return { page: data.page }
+        return { page_index: data.page }
       },
       nextPage: function (data) {
-        return { page: data.page }
+        return { page_index: data.page }
       },
       wizardNavigationClicked: function (page) {
         return {
-          title: page.title
+          page_title: page.title
         }
       },
       wizardPageSelected: function (page, index) {
         return {
-          title: page.title,
-          page: index
+          page_title: page.title,
+          page_index: index
         }
       },
       saveDraft: function (submission) { },
@@ -136,14 +136,14 @@
     time = Date.now()
     Formio.createForm(el, el.getAttribute('data-source'), options)
       .then(function(form) {
-        amp('form.load', { time: Date.now() - time })
+        amp('form.load', { load_time: Date.now() - time })
 
         Object.keys(formEventHandlers).forEach(function(eventName) {
           form.on(eventName, function() {
-            var data = formEventHandlers[eventName].apply(form, arguments)
-            if (data !== false) {
-              data = Object.assign({ form: form.url }, amplitudeData, data)
-              amp('form.' + eventName, data)
+            var formData = formEventHandlers[eventName].apply(form, arguments)
+            if (formData !== false) {
+              formData.url = form.url
+              amp('form.' + eventName, { form: formData })
             }
           })
         })

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -57,16 +57,16 @@
 {% block content %}
 <script>
 (function() {
-   var time = Date.now()
-   var amp = amplitude.getInstance()
-   
-   window.addEventListener('load', function() {
+    var time = Date.now()
+
+    window.addEventListener('load', function() {
+      var amp = amplitude.getInstance()
       amp.logEvent('window.load', { time: Date.now() - time })
-      
+
       // keeping this as a DOM for patch.js
       var el = document.getElementById('formio-{{ form_id }}')
       var options = safeJSONParse(el.getAttribute('data-options'))
-      
+
       var formEventHandlers = {
         submit: function (submission) {
         },
@@ -116,7 +116,7 @@
       Formio.createForm(el, el.getAttribute('data-source'), options)
         .then(function(form) {
           amp.logEvent('form.load', { time: Date.now() - time })
-          
+
           for (var eventName in formEventHandlers) {
             form.on(eventName, function () {
               const data = Object.assign({
@@ -125,7 +125,7 @@
               amp.logEvent('form.' + eventName, data)
             })
           }
-          
+
           //perform sfoptions, hide certain elements
           if (options.sfoptions && options.sfoptions.hide instanceof Object) {
             customHideElements(options.sfoptions.hide)
@@ -168,7 +168,7 @@
           {% endif %}
         })
       })
-      
+
       function customAddCssClassById(classes) {
         for (var key in classes) {
           var el = document.getElementById(key)
@@ -256,7 +256,7 @@
         return parsed
       }
   })
-  
+
 })()
 </script>
 {% endblock content %}


### PR DESCRIPTION
This PR adds log Amplitude events for more general timing related bits:

- `window.load` with `load_time` from the start of the form paragraph `<script>` execution to window `load` event firing, in milliseconds
- `form.load` with `load_time` from the window `load` to when the `Formio.createForm()` promise resolves, also in milliseconds

And for more specific form interactions. The below events include a `form` object with, at the very least, a `url` key indicating the form.io data source URL. Additional event data noted below is nested in the event's `form` object.

- `form.submit` before the submission is sent to form.io (no additional data)
- `form.submitDone` after successful submission (no additional data)
- `form.submitError` when a submission fails validity checks (`component` is the component key, and `error` is the validity error message)
- `form.error` whenever an error occurs (`error` is the error message)
- `form.componentError` for errors specific to a component, including validity failures (`component` is the component key, and `error` is the error message)
- `form.prevPage` when the "Back" form nav button is clicked (`page_index` is the _destination_ page index, starting from zero)
- `form.nextPage` when the "Next" form nav button is clicked (`page_index` is the _destination_ page index, starting from zero)
- `form.wizardNavigationClicked` when the page nav button is clicked, but _before the page is set_ (`page_title` is the title of the selected page)
- `form.wizardPageSelected` _after_ the page nav is clicked and the page is selected (`page_index` and `page_title` are the index and title of the selected page)
- `form.saveDraft` when a draft submission is saved (no additional data)
- `form.restoreDraft` when a draft submission is restored (no additional data)
- `form.editGridAddRow` when the "Add another" button is clicked in an edit grid (`component` is the component key)