### PR TITLE
[SG-1269] Diffs and Content Moderation

### DIFF
--- a/composer-manifest.yaml
+++ b/composer-manifest.yaml
@@ -10,6 +10,7 @@ packages:
     behat/mink-goutte-driver: v1.2.1
     behat/mink-selenium2-driver: v1.4.0
     behat/transliterator: v1.3.0
+    caxy/php-htmldiff: v0.1.9
     commerceguys/addressing: v1.0.9
     composer/ca-bundle: 1.2.8
     composer/composer: 1.10.17
@@ -64,6 +65,7 @@ packages:
     drupal/ctools: 3.4.0
     drupal/date_popup: 1.1.0
     drupal/devel: 1.2.0
+    drupal/diff: 1.0.0
     drupal/drupal-driver: v1.4.0
     drupal/drupal-extension: v3.4.1
     drupal/eck: 'dev-1.x:835945c11d906eac488fc397b143ab5718868a8b'
@@ -132,6 +134,7 @@ packages:
     drush/drush: 8.4.5
     easyrdf/easyrdf: 0.9.1
     egulias/email-validator: 2.1.17
+    ezyang/htmlpurifier: v4.13.0
     fabpot/goutte: v3.2.3
     fastglass/sendgrid: 1.0.11
     gettext/gettext: v4.8.2
@@ -148,6 +151,7 @@ packages:
     joachim-n/composer-manifest: 1.0.4
     jsanahuja/jquery.instagramfeed: 1.2.5
     justinrainbow/json-schema: 5.2.10
+    kub-at/php-simple-html-dom-parser: 1.9.1
     laminas/laminas-diactoros: 1.8.7p2
     laminas/laminas-escaper: 2.6.1
     laminas/laminas-feed: 2.12.2
@@ -156,6 +160,7 @@ packages:
     mandrill/mandrill: 1.0.55
     masterminds/html5: 2.3.0
     mikey179/vfsstream: v1.6.8
+    mkalkbrenner/php-htmldiff-advanced: 0.0.8
     myclabs/deep-copy: 1.10.2
     nikic/php-parser: v4.9.1
     oomphinc/composer-installers-extender: v1.1.2

--- a/composer.json
+++ b/composer.json
@@ -223,7 +223,8 @@
                 "Entity links ignore language negotiation API": "https://www.drupal.org/files/issues/2019-07-31/3061761-38.patch",
                 "StringFormatter generates links in wrong language when linking to entity": "patches/stringformatter-ignores-language-negotiation-2648288.patch",
                 "Use hook_theme_suggestions in views": "https://www.drupal.org/files/issues/2018-04-07/2923634-35.patch",
-                "Allow for deletion of a single value of a multiple value field": "https://www.drupal.org/files/issues/2019-10-24/1038316-204.patch"
+                "Allow for deletion of a single value of a multiple value field": "https://www.drupal.org/files/issues/2019-10-24/1038316-204.patch",
+                "Node local tasks tabs do not appear on node revisions": "https://www.drupal.org/files/issues/2019-11-12/drupal-node_revision_local_tasks_canonical-2885278-15.patch"
             },
             "drupal/amplitude": {
                 "Page scroll depth": "patches/amplitude-scroll-depth.patch",

--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
         "drupal/core-recommended": "^8.8",
         "drupal/ctools": "^3.0",
         "drupal/date_popup": "^1.1",
+        "drupal/diff": "^1.0",
         "drupal/eck": "dev-1.x",
         "drupal/entity_browser": "^2.5",
         "drupal/exif_orientation": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2ae72fcdfebd831647584d5d541707b6",
+    "content-hash": "67fc687bfdf2e45c00ef05772c600d66",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -2903,7 +2903,8 @@
                     "Entity links ignore language negotiation API": "https://www.drupal.org/files/issues/2019-07-31/3061761-38.patch",
                     "StringFormatter generates links in wrong language when linking to entity": "patches/stringformatter-ignores-language-negotiation-2648288.patch",
                     "Use hook_theme_suggestions in views": "https://www.drupal.org/files/issues/2018-04-07/2923634-35.patch",
-                    "Allow for deletion of a single value of a multiple value field": "https://www.drupal.org/files/issues/2019-10-24/1038316-204.patch"
+                    "Allow for deletion of a single value of a multiple value field": "https://www.drupal.org/files/issues/2019-10-24/1038316-204.patch",
+                    "Node local tasks tabs do not appear on node revisions": "https://www.drupal.org/files/issues/2019-11-12/drupal-node_revision_local_tasks_canonical-2885278-15.patch"
                 }
             },
             "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -123,6 +123,62 @@
             "time": "2019-12-24T22:41:47+00:00"
         },
         {
+            "name": "caxy/php-htmldiff",
+            "version": "v0.1.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/caxy/php-htmldiff.git",
+                "reference": "4bad5c6a4ecc76954d37764e6a29273b6b7bf1f8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/caxy/php-htmldiff/zipball/4bad5c6a4ecc76954d37764e6a29273b6b7bf1f8",
+                "reference": "4bad5c6a4ecc76954d37764e6a29273b6b7bf1f8",
+                "shasum": ""
+            },
+            "require": {
+                "ezyang/htmlpurifier": "^4.7",
+                "kub-at/php-simple-html-dom-parser": "^1.7",
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "doctrine/cache": "~1.0",
+                "phpunit/phpunit": "~5.0"
+            },
+            "suggest": {
+                "doctrine/cache": "Used for caching the calculated diffs using a Doctrine Cache Provider"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Caxy\\HtmlDiff": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Josh Schroeder",
+                    "email": "jschroeder@caxy.com",
+                    "homepage": "http://www.caxy.com"
+                }
+            ],
+            "description": "A library for comparing two HTML files/snippets and highlighting the differences using simple HTML.",
+            "homepage": "https://github.com/caxy/php-htmldiff",
+            "keywords": [
+                "diff",
+                "html"
+            ],
+            "time": "2019-02-20T18:52:14+00:00"
+        },
+        {
             "name": "commerceguys/addressing",
             "version": "v1.0.9",
             "source": {
@@ -3138,6 +3194,93 @@
             "homepage": "https://www.drupal.org/project/date_popup",
             "support": {
                 "source": "https://git.drupalcode.org/project/date_popup"
+            }
+        },
+        {
+            "name": "drupal/diff",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/diff.git",
+                "reference": "8.x-1.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/diff-8.x-1.0.zip",
+                "reference": "8.x-1.0",
+                "shasum": "7106ca30b7b10343fbf79a0c42fc7981b109095f"
+            },
+            "require": {
+                "drupal/core": "^8.7.7 || ^9",
+                "mkalkbrenner/php-htmldiff-advanced": "~0.0.8"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.0",
+                    "datestamp": "1578322688",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Miro Dietiker (miro_dietiker)",
+                    "homepage": "https://www.drupal.org/u/miro_dietiker",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Juampy NR (juampynr)",
+                    "homepage": "https://www.drupal.org/u/juampynr",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Lucian Hangea (lhangea)",
+                    "homepage": "https://www.drupal.org/u/lhangea",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Alan D.",
+                    "homepage": "https://www.drupal.org/u/alan-d.",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Brian Gilbert (realityloop).",
+                    "homepage": "https://www.drupal.org/u/realityloop",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "miro_dietiker",
+                    "homepage": "https://www.drupal.org/user/227761"
+                },
+                {
+                    "name": "phenaproxima",
+                    "homepage": "https://www.drupal.org/user/205645"
+                },
+                {
+                    "name": "realityloop",
+                    "homepage": "https://www.drupal.org/user/139189"
+                },
+                {
+                    "name": "rötzi",
+                    "homepage": "https://www.drupal.org/user/73064"
+                },
+                {
+                    "name": "yhahn",
+                    "homepage": "https://www.drupal.org/user/264833"
+                }
+            ],
+            "description": "Compares two entity revisions",
+            "homepage": "https://www.drupal.org/project/diff",
+            "support": {
+                "source": "http://cgit.drupalcode.org/diff",
+                "issues": "https://www.drupal.org/project/issues/diff"
             }
         },
         {
@@ -6996,6 +7139,56 @@
             "time": "2020-02-13T22:36:52+00:00"
         },
         {
+            "name": "ezyang/htmlpurifier",
+            "version": "v4.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ezyang/htmlpurifier.git",
+                "reference": "08e27c97e4c6ed02f37c5b2b20488046c8d90d75"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/08e27c97e4c6ed02f37c5b2b20488046c8d90d75",
+                "reference": "08e27c97e4c6ed02f37c5b2b20488046c8d90d75",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2"
+            },
+            "require-dev": {
+                "simpletest/simpletest": "dev-master#72de02a7b80c6bb8864ef9bf66d41d2f58f826bd"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "HTMLPurifier": "library/"
+                },
+                "files": [
+                    "library/HTMLPurifier.composer.php"
+                ],
+                "exclude-from-classmap": [
+                    "/library/HTMLPurifier/Language/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Edward Z. Yang",
+                    "email": "admin@htmlpurifier.org",
+                    "homepage": "http://ezyang.com"
+                }
+            ],
+            "description": "Standards compliant HTML filter written in PHP",
+            "homepage": "http://htmlpurifier.org/",
+            "keywords": [
+                "html"
+            ],
+            "time": "2020-06-29T00:56:53+00:00"
+        },
+        {
             "name": "fastglass/sendgrid",
             "version": "1.0.11",
             "source": {
@@ -7566,6 +7759,52 @@
             "type": "drupal-library"
         },
         {
+            "name": "kub-at/php-simple-html-dom-parser",
+            "version": "1.9.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Kub-AT/php-simple-html-dom-parser.git",
+                "reference": "ff22f98bfd9235115c128059076f3eb740d66913"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Kub-AT/php-simple-html-dom-parser/zipball/ff22f98bfd9235115c128059076f3eb740d66913",
+                "reference": "ff22f98bfd9235115c128059076f3eb740d66913",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "KubAT\\PhpSimple\\HtmlDomParser": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "S.C. Chen",
+                    "email": "me578022@gmail.com"
+                },
+                {
+                    "name": "Jakub Stawowy",
+                    "email": "Kub-AT@users.noreply.github.com"
+                }
+            ],
+            "description": "PHP Simple HTML DOM Parser with namespace and PHP 7.3 compatible",
+            "homepage": "http://simplehtmldom.sourceforge.net/",
+            "keywords": [
+                "Simple",
+                "dom",
+                "html"
+            ],
+            "time": "2019-10-25T12:34:43+00:00"
+        },
+        {
             "name": "laminas/laminas-diactoros",
             "version": "1.8.7p2",
             "source": {
@@ -7971,6 +8210,43 @@
                 "xml"
             ],
             "time": "2017-09-04T12:26:28+00:00"
+        },
+        {
+            "name": "mkalkbrenner/php-htmldiff-advanced",
+            "version": "0.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mkalkbrenner/php-htmldiff.git",
+                "reference": "3a714b48c9c3d3730baaf6d3949691e654cd37c9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mkalkbrenner/php-htmldiff/zipball/3a714b48c9c3d3730baaf6d3949691e654cd37c9",
+                "reference": "3a714b48c9c3d3730baaf6d3949691e654cd37c9",
+                "shasum": ""
+            },
+            "require": {
+                "caxy/php-htmldiff": ">=0.0.6",
+                "php": ">=5.5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/HtmlDiffAdvancedInterface.php",
+                    "src/HtmlDiffAdvanced.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GNU General Public License V2"
+            ],
+            "description": "An add-on for the php-htmldiff library for comparing two HTML files/snippets and highlighting the differences using simple HTML.",
+            "homepage": "https://github.com/mkalkbrenner/php-htmldiff",
+            "keywords": [
+                "diff",
+                "html"
+            ],
+            "time": "2016-07-25T17:07:32+00:00"
         },
         {
             "name": "nikic/php-parser",

--- a/config/core.entity_view_display.node.campaign.default.yml
+++ b/config/core.entity_view_display.node.campaign.default.yml
@@ -27,7 +27,7 @@ third_party_settings:
     group_locations_and_access:
       children: {  }
       parent_name: ''
-      weight: 15
+      weight: 14
       format_type: html_element
       region: hidden
       format_settings:
@@ -46,8 +46,13 @@ targetEntityType: node
 bundle: campaign
 mode: default
 content:
+  content_moderation_control:
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_campaign_about:
-    weight: 6
+    weight: 7
     type: text_trimmed
     label: above
     settings:
@@ -56,7 +61,7 @@ content:
     region: content
   field_contents:
     type: entity_reference_revisions_entity_view
-    weight: 3
+    weight: 4
     label: hidden
     settings:
       view_mode: default
@@ -65,7 +70,7 @@ content:
     region: content
   field_dept:
     type: entity_reference_label
-    weight: 7
+    weight: 8
     region: content
     label: above
     settings:
@@ -73,7 +78,7 @@ content:
     third_party_settings: {  }
   field_header_spotlight:
     type: entity_reference_revisions_entity_view
-    weight: 1
+    weight: 2
     label: hidden
     settings:
       view_mode: default
@@ -82,7 +87,7 @@ content:
     region: content
   field_links:
     type: link
-    weight: 8
+    weight: 9
     region: content
     label: above
     settings:
@@ -94,7 +99,7 @@ content:
     third_party_settings: {  }
   field_logo:
     type: image
-    weight: 0
+    weight: 1
     region: content
     label: hidden
     settings:
@@ -103,7 +108,7 @@ content:
     third_party_settings: {  }
   field_social_media_embed:
     type: entity_reference_revisions_entity_view
-    weight: 5
+    weight: 6
     label: hidden
     settings:
       view_mode: default
@@ -111,7 +116,7 @@ content:
     third_party_settings: {  }
     region: content
   field_spotlight:
-    weight: 4
+    weight: 5
     label: hidden
     settings:
       view_mode: default
@@ -121,7 +126,7 @@ content:
     region: content
   field_top_facts:
     type: entity_reference_revisions_entity_view
-    weight: 2
+    weight: 3
     label: hidden
     settings:
       view_mode: default
@@ -129,7 +134,6 @@ content:
     third_party_settings: {  }
     region: content
 hidden:
-  content_moderation_control: true
   field_campaign_theme: true
   langcode: true
   links: true

--- a/config/core.entity_view_display.node.event.default.yml
+++ b/config/core.entity_view_display.node.event.default.yml
@@ -31,12 +31,17 @@ content:
   body:
     label: hidden
     type: text_default
-    weight: 1
+    weight: 2
     settings: {  }
     third_party_settings: {  }
     region: content
+  content_moderation_control:
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_address:
-    weight: 6
+    weight: 7
     label: hidden
     settings:
       link: true
@@ -45,39 +50,6 @@ content:
     type: entity_reference_entity_view
     region: content
   field_call_to_action:
-    weight: 7
-    label: hidden
-    settings:
-      view_mode: default
-      link: ''
-    third_party_settings: {  }
-    type: entity_reference_revisions_entity_view
-    region: content
-  field_cost:
-    weight: 5
-    label: hidden
-    settings:
-      view_mode: default
-      link: ''
-    third_party_settings: {  }
-    type: entity_reference_revisions_entity_view
-    region: content
-  field_dept:
-    weight: 10
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  field_description:
-    weight: 2
-    label: hidden
-    settings: {  }
-    third_party_settings: {  }
-    type: text_default
-    region: content
-  field_email:
     weight: 8
     label: hidden
     settings:
@@ -86,8 +58,41 @@ content:
     third_party_settings: {  }
     type: entity_reference_revisions_entity_view
     region: content
+  field_cost:
+    weight: 6
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_entity_view
+    region: content
+  field_dept:
+    weight: 11
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_description:
+    weight: 3
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  field_email:
+    weight: 9
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_entity_view
+    region: content
   field_end_date:
-    weight: 4
+    weight: 5
     label: hidden
     settings:
       timezone_override: ''
@@ -97,7 +102,7 @@ content:
     region: content
   field_image:
     type: entity_reference_entity_view
-    weight: 0
+    weight: 1
     region: content
     label: hidden
     settings:
@@ -105,16 +110,6 @@ content:
       link: false
     third_party_settings: {  }
   field_location_in_person:
-    weight: 11
-    label: above
-    settings:
-      format: default
-      format_custom_false: ''
-      format_custom_true: ''
-    third_party_settings: {  }
-    type: boolean
-    region: content
-  field_location_online:
     weight: 12
     label: above
     settings:
@@ -124,8 +119,18 @@ content:
     third_party_settings: {  }
     type: boolean
     region: content
+  field_location_online:
+    weight: 13
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    type: boolean
+    region: content
   field_phone_numbers:
-    weight: 9
+    weight: 10
     label: hidden
     settings:
       view_mode: default
@@ -134,7 +139,7 @@ content:
     type: entity_reference_revisions_entity_view
     region: content
   field_start_date:
-    weight: 3
+    weight: 4
     label: hidden
     settings:
       timezone_override: ''
@@ -143,7 +148,6 @@ content:
     type: datetime_default
     region: content
 hidden:
-  content_moderation_control: true
   field_topics: true
   langcode: true
   links: true

--- a/config/core.entity_view_display.node.step_by_step.default.yml
+++ b/config/core.entity_view_display.node.step_by_step.default.yml
@@ -17,22 +17,27 @@ targetEntityType: node
 bundle: step_by_step
 mode: default
 content:
-  field_description:
+  content_moderation_control:
     weight: 0
-    label: hidden
+    region: content
     settings: {  }
     third_party_settings: {  }
-    type: text_default
-    region: content
-  field_intro_text:
+  field_description:
     weight: 1
     label: hidden
     settings: {  }
     third_party_settings: {  }
     type: text_default
     region: content
-  field_process_steps:
+  field_intro_text:
     weight: 2
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  field_process_steps:
+    weight: 3
     label: hidden
     settings:
       view_mode: default
@@ -41,7 +46,7 @@ content:
     type: entity_reference_revisions_entity_view
     region: content
   field_topics:
-    weight: 3
+    weight: 4
     label: hidden
     settings:
       link: true
@@ -49,6 +54,6 @@ content:
     type: entity_reference_label
     region: content
 hidden:
-  content_moderation_control: true
   langcode: true
   links: true
+  search_api_excerpt: true

--- a/config/core.entity_view_display.node.topic.default.yml
+++ b/config/core.entity_view_display.node.topic.default.yml
@@ -24,8 +24,13 @@ targetEntityType: node
 bundle: topic
 mode: default
 content:
+  content_moderation_control:
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_content:
-    weight: 4
+    weight: 5
     label: hidden
     settings:
       view_mode: default
@@ -35,7 +40,7 @@ content:
     region: content
   field_content_top:
     type: entity_reference_revisions_entity_view
-    weight: 9
+    weight: 10
     label: hidden
     settings:
       view_mode: default
@@ -43,7 +48,7 @@ content:
     third_party_settings: {  }
     region: content
   field_department_services:
-    weight: 3
+    weight: 4
     label: above
     settings:
       view_mode: default
@@ -52,7 +57,7 @@ content:
     type: entity_reference_revisions_entity_view
     region: content
   field_departments:
-    weight: 1
+    weight: 2
     label: above
     settings:
       view_mode: card
@@ -61,7 +66,7 @@ content:
     type: entity_reference_entity_view
     region: content
   field_description:
-    weight: 0
+    weight: 1
     label: hidden
     settings:
       trim_length: 600
@@ -80,14 +85,14 @@ content:
     type: smart_trim
     region: content
   field_page_design:
-    weight: 8
+    weight: 9
     label: hidden
     settings: {  }
     third_party_settings: {  }
     type: list_key
     region: content
   field_resources:
-    weight: 5
+    weight: 6
     label: above
     settings:
       view_mode: default
@@ -96,7 +101,7 @@ content:
     type: entity_reference_revisions_entity_view
     region: content
   field_spotlight:
-    weight: 2
+    weight: 3
     label: hidden
     settings:
       view_mode: default
@@ -105,7 +110,7 @@ content:
     type: entity_reference_revisions_entity_view
     region: content
   field_top_level_topic:
-    weight: 6
+    weight: 7
     label: above
     settings:
       format: default
@@ -115,7 +120,7 @@ content:
     type: boolean
     region: content
   field_topics:
-    weight: 7
+    weight: 8
     label: hidden
     settings:
       view_mode: card
@@ -124,7 +129,6 @@ content:
     type: entity_reference_entity_view
     region: content
 hidden:
-  content_moderation_control: true
   langcode: true
   links: true
   search_api_excerpt: true

--- a/config/core.entity_view_mode.node.diff.yml
+++ b/config/core.entity_view_mode.node.diff.yml
@@ -1,0 +1,16 @@
+uuid: e44afcc0-85f0-4ae2-9df6-aa3f7bd8101c
+langcode: en
+status: false
+dependencies:
+  enforced:
+    module:
+      - node
+      - diff
+  module:
+    - node
+_core:
+  default_config_hash: pqZNtad5J9THcdbYjwPD4qINqvrTxnOd8KCWn6tUBRs
+id: node.diff
+label: 'Revision comparison'
+targetEntityType: node
+cache: true

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -31,6 +31,7 @@ module:
   date_popup: 0
   datetime: 0
   dblog: 0
+  diff: 0
   dynamic_page_cache: 0
   eck: 0
   editor: 0

--- a/config/diff.settings.yml
+++ b/config/diff.settings.yml
@@ -1,0 +1,18 @@
+general_settings:
+  radio_behavior: simple
+  context_lines_leading: 1
+  context_lines_trailing: 1
+  revision_pager_limit: 50
+  layout_plugins:
+    visual_inline:
+      enabled: true
+      weight: 0
+    split_fields:
+      enabled: true
+      weight: 1
+    unified_fields:
+      enabled: true
+      weight: 2
+  visual_inline_theme: default
+_core:
+  default_config_hash: oXwX3NzLv9QK_LbNEvpQ9OPwH9tqtMSJzq5y8t63Q8w

--- a/web/modules/custom/sfgov_admin/build/package-lock.json
+++ b/web/modules/custom/sfgov_admin/build/package-lock.json
@@ -1525,10 +1525,34 @@
         "is-buffer": "^2.0.2"
       },
       "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "dev": true,
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        },
         "is-buffer": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+          "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
       }
@@ -1627,9 +1651,9 @@
       }
     },
     "base64-arraybuffer": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
-      "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
+      "integrity": "sha1-mBjHngWbE1X5fgQooBfIOOkLqBI=",
       "dev": true
     },
     "base64-js": {
@@ -1974,9 +1998,9 @@
       }
     },
     "bl": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+      "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -2046,28 +2070,28 @@
       }
     },
     "browser-sync": {
-      "version": "2.26.7",
-      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.26.7.tgz",
-      "integrity": "sha512-lY3emme0OyvA2ujEMpRmyRy9LY6gHLuTr2/ABxhIm3lADOiRXzP4dgekvnDrQqZ/Ec2Fz19lEjm6kglSG5766w==",
+      "version": "2.26.13",
+      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.26.13.tgz",
+      "integrity": "sha512-JPYLTngIzI+Dzx+StSSlMtF+Q9yjdh58HW6bMFqkFXuzQkJL8FCvp4lozlS6BbECZcsM2Gmlgp0uhEjvl18X4w==",
       "dev": true,
       "requires": {
-        "browser-sync-client": "^2.26.6",
-        "browser-sync-ui": "^2.26.4",
+        "browser-sync-client": "^2.26.13",
+        "browser-sync-ui": "^2.26.13",
         "bs-recipes": "1.3.4",
         "bs-snippet-injector": "^2.0.1",
-        "chokidar": "^2.0.4",
+        "chokidar": "^3.4.1",
         "connect": "3.6.6",
         "connect-history-api-fallback": "^1",
         "dev-ip": "^1.0.1",
         "easy-extender": "^2.3.4",
-        "eazy-logger": "^3",
+        "eazy-logger": "3.1.0",
         "etag": "^1.8.1",
         "fresh": "^0.5.2",
         "fs-extra": "3.0.1",
-        "http-proxy": "1.15.2",
+        "http-proxy": "^1.18.1",
         "immutable": "^3",
-        "localtunnel": "1.9.2",
-        "micromatch": "^3.1.10",
+        "localtunnel": "^2.0.0",
+        "micromatch": "^4.0.2",
         "opn": "5.3.0",
         "portscanner": "2.1.1",
         "qs": "6.2.3",
@@ -2079,14 +2103,125 @@
         "serve-static": "1.13.2",
         "server-destroy": "1.0.1",
         "socket.io": "2.1.1",
-        "ua-parser-js": "0.7.17",
-        "yargs": "6.4.0"
+        "ua-parser-js": "^0.7.18",
+        "yargs": "^15.4.1"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+          "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+          "dev": true,
+          "requires": {
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
+          }
+        },
+        "binary-extensions": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
+          "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
+          "dev": true
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "chokidar": {
+          "version": "3.4.3",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
+          "integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
+          "dev": true,
+          "requires": {
+            "anymatch": "~3.1.1",
+            "braces": "~3.0.2",
+            "fsevents": "~2.1.2",
+            "glob-parent": "~5.1.0",
+            "is-binary-path": "~2.1.0",
+            "is-glob": "~4.0.1",
+            "normalize-path": "~3.0.0",
+            "readdirp": "~3.5.0"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "fsevents": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+          "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+          "dev": true,
+          "optional": true
+        },
+        "glob-parent": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "is-binary-path": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+          "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+          "dev": true,
+          "requires": {
+            "binary-extensions": "^2.0.0"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "readdirp": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+          "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+          "dev": true,
+          "requires": {
+            "picomatch": "^2.2.1"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
       }
     },
     "browser-sync-client": {
-      "version": "2.26.6",
-      "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.26.6.tgz",
-      "integrity": "sha512-mGrkZdNzttKdf/16I+y+2dTQxoMCIpKbVIMJ/uP8ZpnKu9f9qa/2CYVtLtbjZG8nsM14EwiCrjuFTGBEnT3Gjw==",
+      "version": "2.26.13",
+      "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.26.13.tgz",
+      "integrity": "sha512-p2VbZoYrpuDhkreq+/Sv1MkToHklh7T1OaIntDwpG6Iy2q/XkBcgwPcWjX+WwRNiZjN8MEehxIjEUh12LweLmQ==",
       "dev": true,
       "requires": {
         "etag": "1.8.1",
@@ -2096,9 +2231,9 @@
       }
     },
     "browser-sync-ui": {
-      "version": "2.26.4",
-      "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.26.4.tgz",
-      "integrity": "sha512-u20P3EsZoM8Pt+puoi3BU3KlbQAH1lAcV+/O4saF26qokrBqIDotmGonfWwoRbUmdxZkM9MBmA0K39ZTG1h4sA==",
+      "version": "2.26.13",
+      "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.26.13.tgz",
+      "integrity": "sha512-6NJ/pCnhCnBMzaty1opWo7ipDmFAIk8U71JMQGKJxblCUaGfdsbF2shf6XNZSkXYia1yS0vwKu9LIOzpXqQZCA==",
       "dev": true,
       "requires": {
         "async-each-series": "0.1.1",
@@ -3130,6 +3265,12 @@
         }
       }
     },
+    "dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true
+    },
     "dom-serializer": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
@@ -3260,12 +3401,12 @@
       }
     },
     "eazy-logger": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-3.0.2.tgz",
-      "integrity": "sha1-oyWqXlPROiIliJsqxBE7K5Y29Pw=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-3.1.0.tgz",
+      "integrity": "sha512-/snsn2JqBtUSSstEl4R0RKjkisGHAhvYj89i7r3ytNUKW12y178KDZwXLXIgwDqLW6E/VRMT9qfld7wvFae8bQ==",
       "dev": true,
       "requires": {
-        "tfunk": "^3.0.1"
+        "tfunk": "^4.0.0"
       }
     },
     "ecc-jsbn": {
@@ -3325,6 +3466,12 @@
         "ws": "~3.3.1"
       },
       "dependencies": {
+        "base64-arraybuffer": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+          "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
+          "dev": true
+        },
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -3367,19 +3514,19 @@
       }
     },
     "engine.io-client": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.3.tgz",
-      "integrity": "sha512-0NGY+9hioejTEJCaSJZfWZLk4FPI9dN+1H1C4+wj2iuFba47UgZbJzfWs4aNFajnX/qAaYKbe2lLTfEEWzCmcw==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.4.tgz",
+      "integrity": "sha512-iU4CRr38Fecj8HoZEnFtm2EiKGbYZcPn3cHxqNGl/tmdWRf60KhK+9vE0JeSjgnlS/0oynEfLgKbT9ALpim0sQ==",
       "dev": true,
       "requires": {
         "component-emitter": "~1.3.0",
         "component-inherit": "0.0.3",
-        "debug": "~4.1.0",
+        "debug": "~3.1.0",
         "engine.io-parser": "~2.2.0",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
-        "parseqs": "0.0.5",
-        "parseuri": "0.0.5",
+        "parseqs": "0.0.6",
+        "parseuri": "0.0.6",
         "ws": "~6.1.0",
         "xmlhttprequest-ssl": "~1.5.4",
         "yeast": "0.1.2"
@@ -3390,18 +3537,33 @@
           "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
           "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
           "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
     "engine.io-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.0.tgz",
-      "integrity": "sha512-6I3qD9iUxotsC5HEMuuGsKA0cXerGz+4uGcXQEkfBidgKf0amsjrrtwcbwK/nzpZBxclXlV7gGl9dgWvu4LF6w==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.1.tgz",
+      "integrity": "sha512-x+dN/fBH8Ro8TFwJ+rkB2AmuVw9Yu2mockR/p3W8f8YtExwFgDvBDi0GWyb4ZLkpahtDGZgtr3zLovanJghPqg==",
       "dev": true,
       "requires": {
         "after": "0.8.2",
         "arraybuffer.slice": "~0.0.7",
-        "base64-arraybuffer": "0.1.5",
+        "base64-arraybuffer": "0.1.4",
         "blob": "0.0.5",
         "has-binary2": "~1.0.2"
       }
@@ -3537,9 +3699,9 @@
       }
     },
     "eventemitter3": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
-      "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg=",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "dev": true
     },
     "exec-buffer": {
@@ -4118,30 +4280,10 @@
       }
     },
     "follow-redirects": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-      "dev": true,
-      "requires": {
-        "debug": "=3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        }
-      }
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
+      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==",
+      "dev": true
     },
     "for-in": {
       "version": "1.0.2",
@@ -5045,13 +5187,14 @@
       }
     },
     "http-proxy": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.2.tgz",
-      "integrity": "sha1-ZC/cr/5S00SNK9o7AHnpQJBk2jE=",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
       "dev": true,
       "requires": {
-        "eventemitter3": "1.x.x",
-        "requires-port": "1.x.x"
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
       }
     },
     "http-signature": {
@@ -5885,36 +6028,154 @@
       }
     },
     "localtunnel": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.9.2.tgz",
-      "integrity": "sha512-NEKF7bDJE9U3xzJu3kbayF0WTvng6Pww7tzqNb/XtEARYwqw7CKEX7BvOMg98FtE9es2CRizl61gkV3hS8dqYg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-2.0.0.tgz",
+      "integrity": "sha512-g6E0aLgYYDvQDxIjIXkgJo2+pHj3sGg4Wz/XP3h2KtZnRsWPbOQY+hw1H8Z91jep998fkcVE9l+kghO+97vllg==",
       "dev": true,
       "requires": {
         "axios": "0.19.0",
         "debug": "4.1.1",
         "openurl": "1.1.1",
-        "yargs": "6.6.0"
+        "yargs": "13.3.0"
       },
       "dependencies": {
-        "yargs": {
-          "version": "6.6.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
-          "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
           "dev": true,
           "requires": {
-            "camelcase": "^3.0.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^1.4.0",
-            "read-pkg-up": "^1.0.1",
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "get-caller-file": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "13.3.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+          "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
             "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
+            "require-main-filename": "^2.0.0",
             "set-blocking": "^2.0.0",
-            "string-width": "^1.0.2",
-            "which-module": "^1.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^4.2.0"
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.1"
           }
         }
       }
@@ -6619,12 +6880,6 @@
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true
     },
-    "object-path": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.9.2.tgz",
-      "integrity": "sha1-D9mnT8X60a45aLWGvaXGMr1sBaU=",
-      "dev": true
-    },
     "object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -6937,22 +7192,16 @@
       "dev": true
     },
     "parseqs": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
-      "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
-      "dev": true,
-      "requires": {
-        "better-assert": "~1.0.0"
-      }
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz",
+      "integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w==",
+      "dev": true
     },
     "parseuri": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
-      "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
-      "dev": true,
-      "requires": {
-        "better-assert": "~1.0.0"
-      }
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
+      "integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow==",
+      "dev": true
     },
     "parseurl": {
       "version": "1.3.3",
@@ -8367,6 +8616,12 @@
         "socket.io-parser": "~3.2.0"
       },
       "dependencies": {
+        "base64-arraybuffer": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+          "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
+          "dev": true
+        },
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -8413,6 +8668,24 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
+        },
+        "parseqs": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
+          "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
+          "dev": true,
+          "requires": {
+            "better-assert": "~1.0.0"
+          }
+        },
+        "parseuri": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
+          "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
+          "dev": true,
+          "requires": {
+            "better-assert": "~1.0.0"
+          }
         },
         "socket.io-client": {
           "version": "2.1.1",
@@ -8467,38 +8740,64 @@
       "dev": true
     },
     "socket.io-client": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.3.0.tgz",
-      "integrity": "sha512-cEQQf24gET3rfhxZ2jJ5xzAOo/xhZwK+mOqtGRg5IowZsMgwvHwnf/mCRapAAkadhM26y+iydgwsXGObBB5ZdA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.3.1.tgz",
+      "integrity": "sha512-YXmXn3pA8abPOY//JtYxou95Ihvzmg8U6kQyolArkIyLd0pgVhrfor/iMsox8cn07WCOOvvuJ6XKegzIucPutQ==",
       "dev": true,
       "requires": {
         "backo2": "1.0.2",
-        "base64-arraybuffer": "0.1.5",
         "component-bind": "1.0.0",
-        "component-emitter": "1.2.1",
-        "debug": "~4.1.0",
+        "component-emitter": "~1.3.0",
+        "debug": "~3.1.0",
         "engine.io-client": "~3.4.0",
         "has-binary2": "~1.0.2",
-        "has-cors": "1.1.0",
         "indexof": "0.0.1",
-        "object-component": "0.0.3",
-        "parseqs": "0.0.5",
-        "parseuri": "0.0.5",
+        "parseqs": "0.0.6",
+        "parseuri": "0.0.6",
         "socket.io-parser": "~3.3.0",
         "to-array": "0.1.4"
+      },
+      "dependencies": {
+        "component-emitter": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+          "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
       }
     },
     "socket.io-parser": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
-      "integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.1.tgz",
+      "integrity": "sha512-1QLvVAe8dTz+mKmZ07Swxt+LAo4Y1ff50rlyoEx00TQmDFVQYPfcqGvIDJLGaBdhdNCecXtyKpD+EgKGcmmbuQ==",
       "dev": true,
       "requires": {
-        "component-emitter": "1.2.1",
+        "component-emitter": "~1.3.0",
         "debug": "~3.1.0",
         "isarray": "2.0.1"
       },
       "dependencies": {
+        "component-emitter": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+          "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+          "dev": true
+        },
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -8961,13 +9260,13 @@
       }
     },
     "tfunk": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tfunk/-/tfunk-3.1.0.tgz",
-      "integrity": "sha1-OORBT8ZJd9h6/apy+sttKfgve1s=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tfunk/-/tfunk-4.0.0.tgz",
+      "integrity": "sha512-eJQ0dGfDIzWNiFNYFVjJ+Ezl/GmwHaFTBTjrtqNPW0S7cuVDBrZrmzUz6VkMeCR4DZFqhd4YtLwsw3i2wYHswQ==",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.1",
-        "object-path": "^0.9.0"
+        "chalk": "^1.1.3",
+        "dlv": "^1.1.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -9205,9 +9504,9 @@
       "dev": true
     },
     "ua-parser-js": {
-      "version": "0.7.17",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
-      "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g==",
+      "version": "0.7.22",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.22.tgz",
+      "integrity": "sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q==",
       "dev": true
     },
     "ultron": {
@@ -9588,12 +9887,6 @@
         "string-width": "^1.0.2 || 2"
       }
     },
-    "window-size": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-      "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
-      "dev": true
-    },
     "wrap-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
@@ -9644,34 +9937,215 @@
       "dev": true
     },
     "yargs": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.4.0.tgz",
-      "integrity": "sha1-gW4ahm1VmMzzTlWW3c4i2S2kkNQ=",
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
       "dev": true,
       "requires": {
-        "camelcase": "^3.0.0",
-        "cliui": "^3.2.0",
-        "decamelize": "^1.1.1",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^1.4.0",
-        "read-pkg-up": "^1.0.1",
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
         "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
+        "require-main-filename": "^2.0.0",
         "set-blocking": "^2.0.0",
-        "string-width": "^1.0.2",
-        "which-module": "^1.0.0",
-        "window-size": "^0.2.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^4.1.0"
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "get-caller-file": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "dev": true
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
       }
     },
     "yargs-parser": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
-      "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
       "dev": true,
       "requires": {
-        "camelcase": "^3.0.0"
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        }
       }
     },
     "yauzl": {

--- a/web/modules/custom/sfgov_admin/build/package.json
+++ b/web/modules/custom/sfgov_admin/build/package.json
@@ -15,7 +15,7 @@
     "@babel/preset-env": "^7.10.2",
     "@babel/register": "^7.10.1",
     "autoprefixer": "^9.8.0",
-    "browser-sync": "^2.26.7",
+    "browser-sync": "^2.26.13",
     "gulp": "^4.0.2",
     "gulp-babel": "^8.0.0",
     "gulp-imagemin": "^7.1.0",

--- a/web/modules/custom/sfgov_admin/sfgov_admin.module
+++ b/web/modules/custom/sfgov_admin/sfgov_admin.module
@@ -4,6 +4,8 @@ use Drupal\Core\Template\Attribute;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Component\Utility\Html;
+use Drupal\Core\Entity\EntityForm;
+use Drupal\Core\Url;
 
 /**
  * Implements hook_theme().
@@ -260,15 +262,46 @@ function sfgov_admin_preprocess_file_upload_help(&$variables) {
 /**
  * Implements hook_form_FORM_ID_alter().
  */
-function sfgov_admin_form_content_moderation_entity_moderation_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
-  $current_state = $form['current']['#markup'];
-  $classes = [
-    'form-item-current-state',
-    'form-item-current-state--' .  Html::cleanCssIdentifier(strtolower($current_state)),
-  ];
+function sfgov_admin_form_content_moderation_entity_moderation_form_alter(&$form, $form_state, $form_id) {
+  /** @var \Drupal\node\NodeInterface $revision */
+  $revision = $form_state->get('entity');
 
-  $form['current']['#title'] = t('Current state');
-  $form['current']['#markup'] = '<div class="' . implode($classes, ' ') . '">' . $current_state . '</div>';
-  $form['revision_log']['#placeholder'] = t('Log message');
-  $form['revision_log']['#size'] = NULL;
+  if ($revision->getEntityTypeId() == 'node') {
+    // Base node for the revision.
+    /** @var \Drupal\node\NodeInterface $node */
+    $node = \Drupal::entityTypeManager()->getStorage('node')->load($revision->id());
+
+    // We treat also the latest translation-affecting revision as the current
+    // revision, if it was the default revision, as its values for the
+    // current language will be the same of the current default revision in
+    // this case.
+    $current_revision_displayed = FALSE;
+    $is_current_revision = $revision->getRevisionId() == $node->getRevisionId() || (!$current_revision_displayed && $revision->wasDefaultRevision());
+    if (!$is_current_revision) {
+      $node_url = new Url('entity.node.revision', ['node' => $node->id(), 'node_revision' => $revision->getRevisionId()]);
+    }
+    else {
+      $node_url = $node->toUrl();
+      $current_revision_displayed = TRUE;
+    }
+
+    $current_state = $form['current']['#markup'];
+    $classes = [
+      'form-item-current-state',
+      'form-item-current-state--' .  Html::cleanCssIdentifier(strtolower($current_state)),
+    ];
+
+    // Send properties to the entity-moderation-form.html.twig template.
+    $form['#node'] = $node;
+    $form['#node_revision'] = $revision;
+    $form['#current_state'] = $current_state;
+    $form['#node_url'] = $node_url->toString();
+
+    // Alter form elements.
+    $form['current']['#title'] = t('Current state');
+    $form['current']['#markup'] = '<div class="' . implode($classes, ' ') . '">' . $current_state . '</div>';
+    $form['new_state']['#title'] = t('Change from "@current_state" to', ['@current_state' => $current_state]);
+    $form['revision_log']['#placeholder'] = t('Log message');
+    $form['revision_log']['#size'] = NULL;
+  }
 }

--- a/web/modules/custom/sfgov_admin/sfgov_admin.module
+++ b/web/modules/custom/sfgov_admin/sfgov_admin.module
@@ -28,8 +28,17 @@ function sfgov_admin_page_attachments(array &$page) {
   /** @var \Drupal\Core\Routing\AdminContext $is_admin */
   $is_admin = \Drupal::service('router.admin_context')->isAdminRoute($route);
 
-  if ($is_admin) {
+  $active_theme = \Drupal::service('theme.manager')->getActiveTheme()->getName();
+  if ($is_admin && $active_theme == 'seven') {
     $page['#attached']['library'][] = 'sfgov_admin/admin';
+  }
+
+  // This library is for backend-related functionality, like inline Diffs,
+  // Preview, and Workflow functionality, where default theme is active, and
+  // administrative tools are on page.
+  $logged_in = \Drupal::currentUser()->isAuthenticated();
+  if ($logged_in && $active_theme == 'sfgovpl') {
+    $page['#attached']['library'][] = 'sfgovpl/sfgov-editorial';
   }
 }
 

--- a/web/modules/custom/sfgov_admin/sfgov_admin.module
+++ b/web/modules/custom/sfgov_admin/sfgov_admin.module
@@ -3,6 +3,7 @@
 use Drupal\Core\Template\Attribute;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
+use Drupal\Component\Utility\Html;
 
 /**
  * Implements hook_theme().
@@ -194,9 +195,9 @@ function sfgov_admin_preprocess_field_multiple_value_form__autocomplete(&$variab
 }
 
 function sfgov_admin_form_views_exposed_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  $viewId = $form['#id']; 
-  if ($viewId != 'views-exposed-form-content-transactions') { // return if this is not a content view transaction display  
-    return; 
+  $viewId = $form['#id'];
+  if ($viewId != 'views-exposed-form-content-transactions') { // return if this is not a content view transaction display
+    return;
   }
 
   $form['field_direct_external_url_uri_op']['#options'] = array(
@@ -245,4 +246,20 @@ function sfgov_admin_preprocess_file_upload_help(&$variables) {
   // Remove all help text except for the user-entered description.
   $variables['descriptions'] = $variables['description'];
 
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function sfgov_admin_form_content_moderation_entity_moderation_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
+  $current_state = $form['current']['#markup'];
+  $classes = [
+    'form-item-current-state',
+    'form-item-current-state--' .  Html::cleanCssIdentifier(strtolower($current_state)),
+  ];
+
+  $form['current']['#title'] = t('Current state');
+  $form['current']['#markup'] = '<div class="' . implode($classes, ' ') . '">' . $current_state . '</div>';
+  $form['revision_log']['#placeholder'] = t('Log message');
+  $form['revision_log']['#size'] = NULL;
 }

--- a/web/modules/custom/sfgov_admin/sfgov_admin.module
+++ b/web/modules/custom/sfgov_admin/sfgov_admin.module
@@ -271,7 +271,7 @@ function sfgov_admin_form_content_moderation_entity_moderation_form_alter(&$form
     /** @var \Drupal\node\NodeInterface $node */
     $node = \Drupal::entityTypeManager()->getStorage('node')->load($revision->id());
 
-    // We treat also the latest translation-affecting revision as the current
+    // We also treat the latest translation-affecting revision as the current
     // revision, if it was the default revision, as its values for the
     // current language will be the same of the current default revision in
     // this case.
@@ -295,12 +295,13 @@ function sfgov_admin_form_content_moderation_entity_moderation_form_alter(&$form
     $form['#node'] = $node;
     $form['#node_revision'] = $revision;
     $form['#current_state'] = $current_state;
+    // Note: Can't use toString() in the template.
     $form['#node_url'] = $node_url->toString();
 
     // Alter form elements.
     $form['current']['#title'] = t('Current state');
     $form['current']['#markup'] = '<div class="' . implode($classes, ' ') . '">' . $current_state . '</div>';
-    $form['new_state']['#title'] = t('Change from "@current_state" to', ['@current_state' => $current_state]);
+    $form['revision_log']['#title'] = t('Add a revision note');
     $form['revision_log']['#placeholder'] = t('Log message');
     $form['revision_log']['#size'] = NULL;
   }

--- a/web/themes/custom/sfgovpl/dist/css/drupal.css
+++ b/web/themes/custom/sfgovpl/dist/css/drupal.css
@@ -9473,6 +9473,7 @@ header[role="banner"] .sfgov-mobile-nav-btn.sfgov-mobile-search {
 }
 
 .sfgov-campaign-spotlight-main {
+  background-color: #212123;
   position: relative;
   border-radius: 8px;
   display: -webkit-box;

--- a/web/themes/custom/sfgovpl/dist/css/editorial.css
+++ b/web/themes/custom/sfgovpl/dist/css/editorial.css
@@ -1,0 +1,307 @@
+@import url("/core/themes/seven/css/components/dropbutton.component.css");
+.content-moderation-entity-moderation-form {
+  max-width: none;
+}
+
+.content-moderation-control {
+  background: #f9f9f9;
+  border-radius: 0;
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+
+.content-moderation-control summary {
+  /* antialiased, none, subpixel-antialiased*/
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  background: #2d2d2d;
+  border-radius: 0;
+  border: 0;
+  color: #fff;
+}
+
+.content-moderation-control:not([open]) summary::after {
+  background-color: #fff;
+  background-image: none;
+  -webkit-mask: url("/themes/custom/sfgovpl/src/img/plus-blue.svg") no-repeat 50% 50%;
+          mask: url("/themes/custom/sfgovpl/src/img/plus-blue.svg") no-repeat 50% 50%;
+  -webkit-mask-size: 19px 19px;
+          mask-size: 19px 19px;
+}
+
+.content-moderation-control[open] summary {
+  background: #2d2d2d;
+  border: 0;
+  border-radius: 0;
+}
+
+.content-moderation-control__content {
+  margin: 0 auto;
+  max-width: 1090px;
+  padding: 40px 20px 60px 20px;
+}
+
+@media screen and (min-width: 950px) {
+  .content-moderation-control__transition {
+    -webkit-box-align: center;
+        -ms-flex-align: center;
+            align-items: center;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+  }
+}
+
+.content-moderation-control__transition .form-item {
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  margin: 0 0 20px 0;
+  padding: 0;
+  max-width: 400px;
+}
+
+@media screen and (min-width: 950px) {
+  .content-moderation-control__transition .form-item {
+    margin: 0;
+  }
+}
+
+@media screen and (min-width: 950px) {
+  .content-moderation-control__transition .form-item:not(:first-child) {
+    margin-left: 2rem;
+  }
+}
+
+.content-moderation-control__transition label {
+  display: block;
+  font-size: 1.2rem;
+  font-weight: normal;
+  margin: 0 1rem 0 0;
+}
+
+@media screen and (max-width: 950px) {
+  .content-moderation-control__transition label {
+    -webkit-box-flex: 1;
+        -ms-flex: 1 0 115px;
+            flex: 1 0 115px;
+    font-size: 1.1rem;
+  }
+}
+
+@media screen and (min-width: 950px) {
+  .content-moderation-control__transition label {
+    min-width: -webkit-max-content;
+    min-width: -moz-max-content;
+    min-width: max-content;
+  }
+}
+
+.content-moderation-control__transition .form-item-current-state {
+  border-radius: 8px;
+  border: solid 2px #323a45;
+  color: #1c3e57;
+  cursor: not-allowed;
+  padding: 0.64rem 1rem;
+  width: 100%;
+}
+
+.content-moderation-control__transition .form-item-current-state--draft {
+  background-color: #f5e9e5;
+  border-color: #efcabb;
+}
+
+.content-moderation-control__transition .form-item-current-state--ready-for-review {
+  background-color: #f8f1df;
+  border-color: #f9e3a3;
+}
+
+.content-moderation-control__log {
+  -webkit-box-align: stretch;
+      -ms-flex-align: stretch;
+          align-items: stretch;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  margin-top: 20px;
+}
+
+.content-moderation-control__log .form-item-revision-log {
+  -webkit-box-align: stretch;
+      -ms-flex-align: stretch;
+          align-items: stretch;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+      -ms-flex: 1 0 auto;
+          flex: 1 0 auto;
+  position: relative;
+}
+
+.content-moderation-control__log .form-item-revision-log label {
+  clip: rect(1px, 1px, 1px, 1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute !important;
+  width: 1px;
+  word-wrap: normal;
+}
+
+.content-moderation-control__log .form-item-revision-log input {
+  border-bottom-right-radius: 0;
+  border-right: 0;
+  border-top-right-radius: 0;
+  -webkit-box-flex: 1;
+      -ms-flex: 1 1 auto;
+          flex: 1 1 auto;
+  margin: 0;
+  width: 100%;
+}
+
+.content-moderation-control__log .form-submit {
+  border-bottom-left-radius: 0;
+  border-left: 0;
+  border-top-left-radius: 0;
+  -webkit-box-flex: 0;
+      -ms-flex: 0 1 80px;
+          flex: 0 1 80px;
+  margin: 0;
+}
+
+.diff-header,
+.diff-controls {
+  background: #f8f8f8;
+  border: solid 1px #ccc;
+  margin: 0 auto;
+  max-width: 1090px;
+}
+
+.diff-header {
+  border-radius: 8px 8px 0 0;
+  border-bottom-width: 0;
+  padding: 20px;
+}
+
+.diff-controls {
+  border-top-width: 0;
+  padding: 20px;
+  margin-bottom: 20px;
+  border-radius: 0 0 8px 8px;
+}
+
+.diff-responsive-table-wrapper > .article__title {
+  display: none;
+}
+
+del, ins {
+  display: inline-block;
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+}
+
+del, del > *, ins, ins > * {
+  color: #1c3e57 !important;
+}
+
+del {
+  outline-color: #c9563a;
+}
+
+del, del > * {
+  background-color: #efcabb !important;
+  text-decoration: line-through !important;
+}
+
+ins {
+  outline-color: #00896d !important;
+}
+
+ins, ins > * {
+  background-color: #c0e2c5;
+  text-decoration: underline !important;
+}
+
+div.layout-container {
+  margin: 0 !important;
+}
+
+@media screen and (min-width: 38em) {
+  div.layout-container {
+    margin: 0 !important;
+  }
+}
+
+.node-preview-container {
+  background: #2d2d2d;
+  color: #fff;
+  padding: 1rem;
+}
+
+.node-preview-backlink {
+  background: #4f66ee;
+  border-radius: 8px;
+  color: #fff;
+  font-size: 17px;
+  font-weight: 500;
+  padding: 13px 20px 11px;
+  text-align: center;
+  text-decoration: none;
+  display: inline-block;
+  line-height: 1;
+  background: #fff;
+  color: #4f66ee;
+  font-family: "Rubik", sans-serif;
+}
+
+.node-preview-backlink:hover {
+  background: #0c1464;
+}
+
+.node-preview-backlink:hover {
+  background: #fff;
+  color: #0c1464;
+}
+
+.node-preview-form-select {
+  max-width: none;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
+  -webkit-box-pack: justify;
+      -ms-flex-pack: justify;
+          justify-content: space-between;
+}
+
+@media screen and (min-width: 950px) {
+  .node-preview-form-select .form-item-view-mode {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-align: stretch;
+        -ms-flex-align: stretch;
+            align-items: stretch;
+  }
+}
+
+.node-preview-form-select .form-item-view-mode label {
+  color: #fff;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
+  font-size: 1rem;
+  white-space: nowrap;
+  margin: 0 20px 0 0;
+}
+
+/*# sourceMappingURL=editorial.css.map */

--- a/web/themes/custom/sfgovpl/dist/css/editorial.css
+++ b/web/themes/custom/sfgovpl/dist/css/editorial.css
@@ -3,7 +3,7 @@
   max-width: none;
 }
 
-.content-moderation-control {
+.content-moderation {
   background: #f9f9f9;
   border-radius: 0;
   border: 0;
@@ -11,39 +11,102 @@
   padding: 0;
 }
 
-.content-moderation-control summary {
+.content-moderation summary,
+.content-moderation[open] summary {
   /* antialiased, none, subpixel-antialiased*/
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background: #2d2d2d;
   border-radius: 0;
-  border: 0;
-  color: #fff;
+  border: solid 1px;
+  color: #1c3e57;
+  padding: 0 !important;
 }
 
-.content-moderation-control:not([open]) summary::after {
-  background-color: #fff;
-  background-image: none;
+.content-moderation.is-draft summary,
+.content-moderation.is-draft[open] summary {
+  background-color: #f5e9e5;
+  border-color: #efcabb;
+}
+
+.content-moderation.is-ready-for-review summary,
+.content-moderation.is-ready-for-review[open] summary {
+  background-color: #f8f1df;
+  border-color: #f9e3a3;
+}
+
+.content-moderation.is-archived summary,
+.content-moderation.archived[open] summary {
+  background-color: #edebf6;
+  border-color: #cccced;
+}
+
+.content-moderation:not([open]) summary::after,
+.content-moderation[open] summary::after {
+  display: none;
+}
+
+.content-moderation_summary-container {
+  margin: 0 auto;
+  max-width: 1090px;
+  padding-left: 20px;
+  padding-right: 20px;
+  width: 100%;
+  padding-bottom: 20px;
+  padding-top: 20px;
+  position: relative;
+}
+
+@media screen and (min-width: 1280px) {
+  .content-moderation_summary-container {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+.content-moderation_summary-container::after {
+  background-color: #1c3e57;
+  content: '';
+  height: 30px;
   -webkit-mask: url("/themes/custom/sfgovpl/src/img/plus-blue.svg") no-repeat 50% 50%;
           mask: url("/themes/custom/sfgovpl/src/img/plus-blue.svg") no-repeat 50% 50%;
   -webkit-mask-size: 19px 19px;
           mask-size: 19px 19px;
+  position: absolute;
+  right: 20px;
+  top: 20px;
+  width: 30px;
 }
 
-.content-moderation-control[open] summary {
-  background: #2d2d2d;
-  border: 0;
-  border-radius: 0;
+.content-moderation[open] .content-moderation_summary-container::after {
+  -webkit-mask: url("/themes/custom/sfgovpl/src/img/minus-white.svg") no-repeat 50% 50%;
+          mask: url("/themes/custom/sfgovpl/src/img/minus-white.svg") no-repeat 50% 50%;
+  -webkit-mask-size: 19px 3px;
+          mask-size: 19px 3px;
 }
 
-.content-moderation-control__content {
+.content-moderation__content {
   margin: 0 auto;
   max-width: 1090px;
-  padding: 40px 20px 60px 20px;
+  padding-left: 20px;
+  padding-right: 20px;
+  width: 100%;
+  padding-top: 30px;
+  padding-bottom: 60px;
 }
 
-@media screen and (min-width: 950px) {
-  .content-moderation-control__transition {
+@media screen and (min-width: 1280px) {
+  .content-moderation__content {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+.content-moderation__message {
+  margin-bottom: 2rem;
+}
+
+@media screen and (min-width: 700px) {
+  .content-moderation__transition {
     -webkit-box-align: center;
         -ms-flex-align: center;
             align-items: center;
@@ -53,74 +116,53 @@
   }
 }
 
-.content-moderation-control__transition .form-item {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
-  display: -webkit-box;
-  display: -ms-flexbox;
-  display: flex;
+.content-moderation__transition .form-item {
   margin: 0 0 20px 0;
   padding: 0;
-  max-width: 400px;
+  max-width: 50%;
 }
 
-@media screen and (min-width: 950px) {
-  .content-moderation-control__transition .form-item {
+@media screen and (min-width: 700px) {
+  .content-moderation__transition .form-item {
+    -webkit-box-align: center;
+        -ms-flex-align: center;
+            align-items: center;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
     margin: 0;
+    max-width: 520px;
   }
 }
 
-@media screen and (min-width: 950px) {
-  .content-moderation-control__transition .form-item:not(:first-child) {
+@media screen and (min-width: 700px) {
+  .content-moderation__transition .form-item:not(:first-child) {
     margin-left: 2rem;
   }
 }
 
-.content-moderation-control__transition label {
+.content-moderation__transition label {
   display: block;
   font-size: 1.2rem;
   font-weight: normal;
   margin: 0 1rem 0 0;
 }
 
-@media screen and (max-width: 950px) {
-  .content-moderation-control__transition label {
-    -webkit-box-flex: 1;
-        -ms-flex: 1 0 115px;
-            flex: 1 0 115px;
+@media screen and (max-width: 700px) {
+  .content-moderation__transition label {
     font-size: 1.1rem;
   }
 }
 
-@media screen and (min-width: 950px) {
-  .content-moderation-control__transition label {
+@media screen and (min-width: 700px) {
+  .content-moderation__transition label {
     min-width: -webkit-max-content;
     min-width: -moz-max-content;
     min-width: max-content;
   }
 }
 
-.content-moderation-control__transition .form-item-current-state {
-  border-radius: 8px;
-  border: solid 2px #323a45;
-  color: #1c3e57;
-  cursor: not-allowed;
-  padding: 0.64rem 1rem;
-  width: 100%;
-}
-
-.content-moderation-control__transition .form-item-current-state--draft {
-  background-color: #f5e9e5;
-  border-color: #efcabb;
-}
-
-.content-moderation-control__transition .form-item-current-state--ready-for-review {
-  background-color: #f8f1df;
-  border-color: #f9e3a3;
-}
-
-.content-moderation-control__log {
+.content-moderation__log {
   -webkit-box-align: stretch;
       -ms-flex-align: stretch;
           align-items: stretch;
@@ -130,7 +172,7 @@
   margin-top: 20px;
 }
 
-.content-moderation-control__log .form-item-revision-log {
+.content-moderation__log .form-item-revision-log {
   -webkit-box-align: stretch;
       -ms-flex-align: stretch;
           align-items: stretch;
@@ -143,7 +185,7 @@
   position: relative;
 }
 
-.content-moderation-control__log .form-item-revision-log label {
+.content-moderation__log .form-item-revision-log label {
   clip: rect(1px, 1px, 1px, 1px);
   height: 1px;
   overflow: hidden;
@@ -152,7 +194,7 @@
   word-wrap: normal;
 }
 
-.content-moderation-control__log .form-item-revision-log input {
+.content-moderation__log .form-item-revision-log input {
   border-bottom-right-radius: 0;
   border-right: 0;
   border-top-right-radius: 0;
@@ -163,7 +205,7 @@
   width: 100%;
 }
 
-.content-moderation-control__log .form-submit {
+.content-moderation__log .form-submit {
   border-bottom-left-radius: 0;
   border-left: 0;
   border-top-left-radius: 0;
@@ -171,6 +213,23 @@
       -ms-flex: 0 1 80px;
           flex: 0 1 80px;
   margin: 0;
+}
+
+.content-moderation__status {
+  display: inline-block;
+  border-radius: 8px;
+  font-size: 0.923rem;
+  padding: 0 0.5rem;
+}
+
+.content-moderation__status.is-published {
+  background: #00896d;
+  color: #fff;
+}
+
+.content-moderation__status.is-unpublished {
+  background: #c9563a;
+  color: #fff;
 }
 
 .diff-header,

--- a/web/themes/custom/sfgovpl/dist/css/editorial.css
+++ b/web/themes/custom/sfgovpl/dist/css/editorial.css
@@ -4,40 +4,32 @@
 }
 
 .content-moderation {
-  background: #f9f9f9;
+  background: #2d2d2d;
+  color: #fff;
   border-radius: 0;
   border: 0;
   margin: 0;
   padding: 0;
 }
 
-.content-moderation summary,
-.content-moderation[open] summary {
-  /* antialiased, none, subpixel-antialiased*/
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  border-radius: 0;
-  border: solid 1px;
-  color: #1c3e57;
-  padding: 0 !important;
+.content-moderation a:link {
+  color: #fff;
 }
 
-.content-moderation.is-draft summary,
-.content-moderation.is-draft[open] summary {
-  background-color: #f5e9e5;
-  border-color: #efcabb;
+.content-moderation a:visited, .content-moderation a:link:visited {
+  color: #fff;
 }
 
-.content-moderation.is-ready-for-review summary,
-.content-moderation.is-ready-for-review[open] summary {
-  background-color: #f8f1df;
-  border-color: #f9e3a3;
+.content-moderation a:focus {
+  color: #fff;
 }
 
-.content-moderation.is-archived summary,
-.content-moderation.archived[open] summary {
-  background-color: #edebf6;
-  border-color: #cccced;
+.content-moderation a.active:hover, .content-moderation a.is-active:hover, .content-moderation a.active-trail:hover, .content-moderation a.visited:hover, .content-moderation a:hover {
+  color: #fff;
+}
+
+.content-moderation a.is-active, .content-moderation a:active, .content-moderation a.active-trail {
+  color: #fff;
 }
 
 .content-moderation:not([open]) summary::after,
@@ -45,7 +37,74 @@
   display: none;
 }
 
-.content-moderation_summary-container {
+.content-moderation label,
+.content-moderation .content-moderation__label {
+  font-size: 17px;
+  font-weight: 500;
+  line-height: 24px;
+  color: #fff;
+  display: block;
+}
+
+.content-moderation label.sfgov-translate-lang-zh-TW,
+.content-moderation .content-moderation__label.sfgov-translate-lang-zh-TW {
+  font-size: 18px;
+  line-height: 26px;
+  letter-spacing: 1px;
+  font-weight: 700;
+  /* antialiased, none, subpixel-antialiased*/
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.content-moderation mark {
+  border-radius: 8px;
+  color: #fff;
+  display: inline-block;
+  padding: 5px 15px 5px 15px;
+  margin-left: 1ch;
+}
+
+.content-moderation mark.is-draft {
+  background-color: #c9563a;
+}
+
+.content-moderation mark.is-ready-for-review {
+  background-color: #f4c435;
+  color: #1c3e57;
+}
+
+.content-moderation mark.is-archived {
+  background-color: #607889;
+}
+
+.content-moderation .content-moderation__summary,
+.content-moderation .content-moderation__summary[open] {
+  font-size: 17px;
+  font-weight: 500;
+  line-height: 24px;
+  /* antialiased, none, subpixel-antialiased*/
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  background: #333;
+  border-radius: 0;
+  border: 0;
+  color: #fff;
+  padding: 0 !important;
+}
+
+.content-moderation .content-moderation__summary.sfgov-translate-lang-zh-TW,
+.content-moderation .content-moderation__summary[open].sfgov-translate-lang-zh-TW {
+  font-size: 18px;
+  line-height: 26px;
+  letter-spacing: 1px;
+  font-weight: 700;
+  /* antialiased, none, subpixel-antialiased*/
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.content-moderation .content-moderation__summary-container {
   margin: 0 auto;
   max-width: 1090px;
   padding-left: 20px;
@@ -57,31 +116,27 @@
 }
 
 @media screen and (min-width: 1280px) {
-  .content-moderation_summary-container {
+  .content-moderation .content-moderation__summary-container {
     padding-left: 0;
     padding-right: 0;
   }
 }
 
-.content-moderation_summary-container::after {
-  background-color: #1c3e57;
+.content-moderation .content-moderation__summary-container::after {
+  color: #fff;
+  background: url("data:image/svg+xml,%3Csvg width='20' height='20' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M9.96 14.755a1.245 1.245 0 01-.885-.365l-7.5-7.5a1.252 1.252 0 011.77-1.77l6.615 6.62 6.615-6.62a1.251 1.251 0 111.77 1.77l-7.5 7.5a1.247 1.247 0 01-.885.365z' fill='%23fff'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: 50% 50%;
   content: '';
-  height: 30px;
-  -webkit-mask: url("/themes/custom/sfgovpl/src/img/plus-blue.svg") no-repeat 50% 50%;
-          mask: url("/themes/custom/sfgovpl/src/img/plus-blue.svg") no-repeat 50% 50%;
-  -webkit-mask-size: 19px 19px;
-          mask-size: 19px 19px;
+  height: 20px;
   position: absolute;
   right: 20px;
-  top: 20px;
-  width: 30px;
+  top: 26px;
+  width: 20px;
 }
 
-.content-moderation[open] .content-moderation_summary-container::after {
-  -webkit-mask: url("/themes/custom/sfgovpl/src/img/minus-white.svg") no-repeat 50% 50%;
-          mask: url("/themes/custom/sfgovpl/src/img/minus-white.svg") no-repeat 50% 50%;
-  -webkit-mask-size: 19px 3px;
-          mask-size: 19px 3px;
+[open] > .content-moderation .content-moderation__summary-container::after {
+  background-image: url("data:image/svg+xml,%3Csvg width='20' height='20' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M17.46 14.755a1.245 1.245 0 01-.885-.365L9.96 7.775 3.345 14.39a1.252 1.252 0 01-1.77-1.77l7.5-7.5a1.26 1.26 0 011.77 0l7.5 7.5a1.26 1.26 0 010 1.77 1.246 1.246 0 01-.885.365z' fill='%23fff'/%3E%3C/svg%3E");
 }
 
 .content-moderation__content {
@@ -91,7 +146,7 @@
   padding-right: 20px;
   width: 100%;
   padding-top: 30px;
-  padding-bottom: 60px;
+  padding-bottom: 40px;
 }
 
 @media screen and (min-width: 1280px) {
@@ -101,135 +156,81 @@
   }
 }
 
-.content-moderation__message {
-  margin-bottom: 2rem;
+.content-moderation__log-message {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.32);
+  margin-top: 1px;
+  padding-bottom: 25px;
 }
 
-@media screen and (min-width: 700px) {
-  .content-moderation__transition {
-    -webkit-box-align: center;
-        -ms-flex-align: center;
-            align-items: center;
-    display: -webkit-box;
-    display: -ms-flexbox;
-    display: flex;
-  }
+.content-moderation__message p {
+  margin: 2px 0 22px 0;
 }
 
-.content-moderation__transition .form-item {
-  margin: 0 0 20px 0;
-  padding: 0;
-  max-width: 50%;
-}
-
-@media screen and (min-width: 700px) {
-  .content-moderation__transition .form-item {
-    -webkit-box-align: center;
-        -ms-flex-align: center;
-            align-items: center;
-    display: -webkit-box;
-    display: -ms-flexbox;
-    display: flex;
-    margin: 0;
-    max-width: 520px;
-  }
-}
-
-@media screen and (min-width: 700px) {
-  .content-moderation__transition .form-item:not(:first-child) {
-    margin-left: 2rem;
-  }
-}
-
-.content-moderation__transition label {
-  display: block;
-  font-size: 1.2rem;
-  font-weight: normal;
-  margin: 0 1rem 0 0;
-}
-
-@media screen and (max-width: 700px) {
-  .content-moderation__transition label {
-    font-size: 1.1rem;
-  }
-}
-
-@media screen and (min-width: 700px) {
-  .content-moderation__transition label {
-    min-width: -webkit-max-content;
-    min-width: -moz-max-content;
-    min-width: max-content;
-  }
-}
-
-.content-moderation__log {
-  -webkit-box-align: stretch;
-      -ms-flex-align: stretch;
-          align-items: stretch;
-  display: -webkit-box;
-  display: -ms-flexbox;
-  display: flex;
+.content-moderation__fields {
   margin-top: 20px;
 }
 
-.content-moderation__log .form-item-revision-log {
-  -webkit-box-align: stretch;
-      -ms-flex-align: stretch;
-          align-items: stretch;
+@media screen and (min-width: 768px) {
+  .content-moderation__fields {
+    -webkit-box-align: stretch;
+        -ms-flex-align: stretch;
+            align-items: stretch;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+  }
+}
+
+.content-moderation__fields label {
+  margin: 0 0 8px 0;
+}
+
+.content-moderation__fields .form-item {
+  margin: 0 0 15px 0;
+  padding: 0;
+}
+
+@media screen and (min-width: 768px) {
+  .content-moderation__fields .form-item:not(:first-child) {
+    margin-left: 20px;
+  }
+}
+
+.content-moderation__fields .form-item-revision-log {
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-flex: 1;
-      -ms-flex: 1 0 auto;
-          flex: 1 0 auto;
-  position: relative;
-}
-
-.content-moderation__log .form-item-revision-log label {
-  clip: rect(1px, 1px, 1px, 1px);
-  height: 1px;
-  overflow: hidden;
-  position: absolute !important;
-  width: 1px;
-  word-wrap: normal;
-}
-
-.content-moderation__log .form-item-revision-log input {
-  border-bottom-right-radius: 0;
-  border-right: 0;
-  border-top-right-radius: 0;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: column;
+          flex-direction: column;
   -webkit-box-flex: 1;
       -ms-flex: 1 1 auto;
           flex: 1 1 auto;
-  margin: 0;
-  width: 100%;
 }
 
-.content-moderation__log .form-submit {
-  border-bottom-left-radius: 0;
-  border-left: 0;
-  border-top-left-radius: 0;
-  -webkit-box-flex: 0;
-      -ms-flex: 0 1 80px;
-          flex: 0 1 80px;
-  margin: 0;
-}
-
-.content-moderation__status {
-  display: inline-block;
+.content-moderation__button .form-submit {
+  background: #4f66ee;
   border-radius: 8px;
-  font-size: 0.923rem;
-  padding: 0 0.5rem;
+  color: #fff;
+  font-size: 17px;
+  font-weight: 500;
+  padding: 13px 20px 11px;
+  text-align: center;
+  text-decoration: none;
+  display: inline-block;
+  line-height: 1;
+  width: auto;
+  margin: 0;
 }
 
-.content-moderation__status.is-published {
-  background: #00896d;
-  color: #fff;
+.content-moderation__button .form-submit:hover {
+  background: #0c1464;
 }
 
-.content-moderation__status.is-unpublished {
-  background: #c9563a;
-  color: #fff;
+.content-moderation__button .form-submit:hover, .content-moderation__button .form-submit:focus {
+  background-color: #203eea;
+  border-color: #203eea;
 }
 
 .diff-header,

--- a/web/themes/custom/sfgovpl/dist/css/editorial.css
+++ b/web/themes/custom/sfgovpl/dist/css/editorial.css
@@ -78,8 +78,7 @@
   background-color: #607889;
 }
 
-.content-moderation .content-moderation__summary,
-.content-moderation .content-moderation__summary[open] {
+.content-moderation .content-moderation__summary {
   font-size: 17px;
   font-weight: 500;
   line-height: 24px;
@@ -93,8 +92,7 @@
   padding: 0 !important;
 }
 
-.content-moderation .content-moderation__summary.sfgov-translate-lang-zh-TW,
-.content-moderation .content-moderation__summary[open].sfgov-translate-lang-zh-TW {
+.content-moderation .content-moderation__summary.sfgov-translate-lang-zh-TW {
   font-size: 18px;
   line-height: 26px;
   letter-spacing: 1px;
@@ -135,7 +133,7 @@
   width: 20px;
 }
 
-[open] > .content-moderation .content-moderation__summary-container::after {
+.content-moderation[open] .content-moderation__summary-container::after {
   background-image: url("data:image/svg+xml,%3Csvg width='20' height='20' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M17.46 14.755a1.245 1.245 0 01-.885-.365L9.96 7.775 3.345 14.39a1.252 1.252 0 01-1.77-1.77l7.5-7.5a1.26 1.26 0 011.77 0l7.5 7.5a1.26 1.26 0 010 1.77 1.246 1.246 0 01-.885.365z' fill='%23fff'/%3E%3C/svg%3E");
 }
 

--- a/web/themes/custom/sfgovpl/sfgovpl.info.yml
+++ b/web/themes/custom/sfgovpl/sfgovpl.info.yml
@@ -41,6 +41,10 @@ libraries-override:
         css/components/tabledrag.module.css: false
         css/components/tablesort.module.css: false
         css/components/tree-child.module.css: false
+  node/drupal.node.preview:
+    css:
+      theme:
+        /core/themes/stable/css/node/node.preview.css: false
   views/views.module: false
 
 regions:

--- a/web/themes/custom/sfgovpl/sfgovpl.info.yml
+++ b/web/themes/custom/sfgovpl/sfgovpl.info.yml
@@ -20,6 +20,7 @@ libraries:
   - sfgovpl/sfgov-in-this-page
 
 libraries-override:
+  content_moderation/content_moderation: false
   system/base:
     css:
       component:

--- a/web/themes/custom/sfgovpl/sfgovpl.libraries.yml
+++ b/web/themes/custom/sfgovpl/sfgovpl.libraries.yml
@@ -12,6 +12,11 @@ sfgov-drupal-specific-styles:
     theme:
       'dist/css/drupal.css': {}
 
+sfgov-editorial:
+  css:
+    theme:
+      'dist/css/editorial.css': {}
+
 # javascript
 sfgov-navigation:
   js:

--- a/web/themes/custom/sfgovpl/src/sass/_variables.scss
+++ b/web/themes/custom/sfgovpl/src/sass/_variables.scss
@@ -3,6 +3,7 @@ $base-font-size: 17;
 $c-white: #fff;
 $c-black: #212123;
 $c-slate: #1c3e57;
+$c-light-slate: #607889;
 $c-dark-blue: #0c1464;
 $c-bright-blue: #4f66ee;
 $c-blue-1: #edf4f7;

--- a/web/themes/custom/sfgovpl/src/sass/editorial.scss
+++ b/web/themes/custom/sfgovpl/src/sass/editorial.scss
@@ -1,0 +1,12 @@
+// @file
+// Styles for editorial functionality, such as content moderation, inline diff,
+// etc.  Note: Only available to logged in users.
+
+@import 'variables';
+@import 'functions';
+@import 'mixins';
+@import 'mixins-fs';
+
+@import './forms/node.content-moderation';
+@import './forms/node.diff';
+@import './forms/node.preview';

--- a/web/themes/custom/sfgovpl/src/sass/forms/_node.content-moderation.scss
+++ b/web/themes/custom/sfgovpl/src/sass/forms/_node.content-moderation.scss
@@ -1,0 +1,135 @@
+// Content Moderation Widget
+//------------------------------------------------------------------------------
+
+.content-moderation-entity-moderation-form {
+  max-width: none;
+}
+
+.content-moderation-control {
+  background: $c-black-opacity-3;
+  border-radius: 0;
+  border: 0;
+  margin: 0;
+  padding: 0;
+
+  summary {
+    @include antialiasing;
+    background: #2d2d2d;
+    border-radius: 0;
+    border: 0;
+    color: $c-white;
+  }
+
+  &:not([open]) summary::after {
+    background-color: $c-white;
+    background-image: none;
+    mask: url('/themes/custom/sfgovpl/src/img/plus-blue.svg') no-repeat 50% 50%;
+    mask-size: 19px 19px;
+  }
+
+  &[open] summary {
+    background: #2d2d2d;
+    border: 0;
+    border-radius: 0;
+  }
+}
+
+.content-moderation-control__content {
+  margin: 0 auto;
+  max-width: 1090px;
+  padding: 40px 20px 60px 20px;
+}
+
+.content-moderation-control__transition {
+  @include media($narrow-screen) {
+    align-items: center;
+    display: flex;
+  }
+
+  .form-item {
+    align-items: center;
+    display: flex;
+    margin: 0 0 20px 0;
+    padding: 0;
+    max-width: 400px;
+
+    @include media($narrow-screen) {
+      margin: 0;
+    }
+
+    &:not(:first-child) {
+      @include media($narrow-screen) {
+        margin-left: 2rem;
+      }
+    }
+  }
+
+  label {
+    display: block;
+    font-size: 1.2rem;
+    font-weight: normal;
+    margin: 0 1rem 0 0;
+
+    @include media-max($narrow-screen) {
+      flex: 1 0 115px;
+      font-size: 1.1rem;
+    }
+
+    @include media($narrow-screen) {
+      min-width: max-content;
+    }
+  }
+
+  .form-item-current-state {
+    border-radius: 8px;
+    border: solid 2px $c-grey-5;
+    color: $c-slate;
+    cursor: not-allowed;
+    padding: 0.64rem 1rem;
+    width: 100%;
+
+    &--draft {
+      background-color: $c-red-1;
+      border-color: $c-red-2;
+
+    }
+    &--ready-for-review {
+      background-color: $c-yellow-1;
+      border-color: $c-yellow-2;
+    }
+  }
+}
+
+.content-moderation-control__log {
+  align-items: stretch;
+  display: flex;
+  margin-top: 20px;
+
+  .form-item-revision-log {
+    align-items: stretch;
+    display: flex;
+    flex: 1 0 auto;
+    position: relative;
+
+    label {
+      @include visually-hidden;
+    }
+
+    input {
+      border-bottom-right-radius: 0;
+      border-right: 0;
+      border-top-right-radius: 0;
+      flex: 1 1 auto;
+      margin: 0;
+      width: 100%;
+    }
+  }
+
+  .form-submit {
+    border-bottom-left-radius: 0;
+    border-left: 0;
+    border-top-left-radius: 0;
+    flex: 0 1 80px;
+    margin: 0;
+  }
+}

--- a/web/themes/custom/sfgovpl/src/sass/forms/_node.content-moderation.scss
+++ b/web/themes/custom/sfgovpl/src/sass/forms/_node.content-moderation.scss
@@ -5,60 +5,102 @@
   max-width: none;
 }
 
-.content-moderation-control {
+.content-moderation {
   background: $c-black-opacity-3;
   border-radius: 0;
   border: 0;
   margin: 0;
   padding: 0;
 
-  summary {
+  summary,
+  &[open] summary {
     @include antialiasing;
-    background: #2d2d2d;
     border-radius: 0;
-    border: 0;
-    color: $c-white;
+    border: solid 1px;
+    color: $c-slate;
+    padding: 0 !important;
   }
 
-  &:not([open]) summary::after {
-    background-color: $c-white;
-    background-image: none;
+  // Color by workflow moderation state.
+  &.is-draft summary,
+  &.is-draft[open] summary {
+    background-color: $c-red-1;
+    border-color: $c-red-2;
+  }
+
+  &.is-ready-for-review summary,
+  &.is-ready-for-review[open] summary {
+    background-color: $c-yellow-1;
+    border-color: $c-yellow-2;
+  }
+
+  &.is-archived summary,
+  &.archived[open] summary {
+    background-color: $c-purple-1;
+    border-color: $c-purple-2;
+  }
+
+  // Override base <details> styles. We want the +/- icons inside the container.
+  &:not([open]) summary::after,
+  &[open] summary::after {
+    display: none;
+  }
+}
+
+.content-moderation_summary-container {
+  @include contain-1090;
+  padding-bottom: 20px;
+  padding-top: 20px;
+  position: relative;
+
+  &::after {
+    background-color: $c-slate;
+    content: '';
+    height: 30px;
     mask: url('/themes/custom/sfgovpl/src/img/plus-blue.svg') no-repeat 50% 50%;
     mask-size: 19px 19px;
-  }
-
-  &[open] summary {
-    background: #2d2d2d;
-    border: 0;
-    border-radius: 0;
+    position: absolute;
+    right: 20px;
+    top: 20px;
+    width: 30px;
   }
 }
 
-.content-moderation-control__content {
-  margin: 0 auto;
-  max-width: 1090px;
-  padding: 40px 20px 60px 20px;
+.content-moderation[open] .content-moderation_summary-container::after {
+  mask: url('/themes/custom/sfgovpl/src/img/minus-white.svg') no-repeat 50% 50%;
+  mask-size: 19px 3px;
 }
 
-.content-moderation-control__transition {
-  @include media($narrow-screen) {
+.content-moderation__content {
+  @include contain-1090;
+  padding-top: 30px;
+  padding-bottom: 60px;
+}
+
+.content-moderation__message {
+  margin-bottom: 2rem;
+}
+
+.content-moderation__transition {
+  @include media($mobile-screen) {
     align-items: center;
     display: flex;
   }
 
   .form-item {
-    align-items: center;
-    display: flex;
     margin: 0 0 20px 0;
     padding: 0;
-    max-width: 400px;
+    max-width: 50%;
 
-    @include media($narrow-screen) {
+    @include media($mobile-screen) {
+      align-items: center;
+      display: flex;
       margin: 0;
+      max-width: 520px;
     }
 
     &:not(:first-child) {
-      @include media($narrow-screen) {
+      @include media($mobile-screen) {
         margin-left: 2rem;
       }
     }
@@ -70,37 +112,18 @@
     font-weight: normal;
     margin: 0 1rem 0 0;
 
-    @include media-max($narrow-screen) {
-      flex: 1 0 115px;
+    @include media-max($mobile-screen) {
+
       font-size: 1.1rem;
     }
 
-    @include media($narrow-screen) {
+    @include media($mobile-screen) {
       min-width: max-content;
-    }
-  }
-
-  .form-item-current-state {
-    border-radius: 8px;
-    border: solid 2px $c-grey-5;
-    color: $c-slate;
-    cursor: not-allowed;
-    padding: 0.64rem 1rem;
-    width: 100%;
-
-    &--draft {
-      background-color: $c-red-1;
-      border-color: $c-red-2;
-
-    }
-    &--ready-for-review {
-      background-color: $c-yellow-1;
-      border-color: $c-yellow-2;
     }
   }
 }
 
-.content-moderation-control__log {
+.content-moderation__log {
   align-items: stretch;
   display: flex;
   margin-top: 20px;
@@ -131,5 +154,22 @@
     border-top-left-radius: 0;
     flex: 0 1 80px;
     margin: 0;
+  }
+}
+
+.content-moderation__status {
+  display: inline-block;
+  border-radius: 8px;
+  font-size: 0.923rem;
+  padding: 0 0.5rem;
+
+  &.is-published {
+    background: $c-green-3;
+    color: $c-white;
+  }
+
+  &.is-unpublished {
+    background: $c-red-3;
+    color: $c-white;
   }
 }

--- a/web/themes/custom/sfgovpl/src/sass/forms/_node.content-moderation.scss
+++ b/web/themes/custom/sfgovpl/src/sass/forms/_node.content-moderation.scss
@@ -6,170 +6,142 @@
 }
 
 .content-moderation {
-  background: $c-black-opacity-3;
+  background: #2d2d2d;
+  color: $c-white;
   border-radius: 0;
   border: 0;
   margin: 0;
   padding: 0;
 
-  summary,
-  &[open] summary {
-    @include antialiasing;
-    border-radius: 0;
-    border: solid 1px;
-    color: $c-slate;
-    padding: 0 !important;
+  a {
+    @include link-colors($c-white, $c-white);
   }
 
-  // Color by workflow moderation state.
-  &.is-draft summary,
-  &.is-draft[open] summary {
-    background-color: $c-red-1;
-    border-color: $c-red-2;
-  }
-
-  &.is-ready-for-review summary,
-  &.is-ready-for-review[open] summary {
-    background-color: $c-yellow-1;
-    border-color: $c-yellow-2;
-  }
-
-  &.is-archived summary,
-  &.archived[open] summary {
-    background-color: $c-purple-1;
-    border-color: $c-purple-2;
-  }
-
-  // Override base <details> styles. We want the +/- icons inside the container.
+  // Override base <details> icons. We want them inside the container.
   &:not([open]) summary::after,
   &[open] summary::after {
     display: none;
   }
-}
 
-.content-moderation_summary-container {
-  @include contain-1090;
-  padding-bottom: 20px;
-  padding-top: 20px;
-  position: relative;
-
-  &::after {
-    background-color: $c-slate;
-    content: '';
-    height: 30px;
-    mask: url('/themes/custom/sfgovpl/src/img/plus-blue.svg') no-repeat 50% 50%;
-    mask-size: 19px 19px;
-    position: absolute;
-    right: 20px;
-    top: 20px;
-    width: 30px;
+  label,
+  .content-moderation__label {
+    @include fs-body-bold;
+    color: $c-white;
+    display: block;
   }
-}
 
-.content-moderation[open] .content-moderation_summary-container::after {
-  mask: url('/themes/custom/sfgovpl/src/img/minus-white.svg') no-repeat 50% 50%;
-  mask-size: 19px 3px;
+  mark {
+    border-radius: 8px;
+    color: $c-white;
+    display: inline-block;
+    padding: 5px 15px 5px 15px;
+    margin-left: 1ch;
+
+    &.is-draft {
+      background-color: $c-red-3;
+    }
+
+    &.is-ready-for-review {
+      background-color: $c-yellow-3;
+      color: $c-slate;
+    }
+
+    &.is-archived {
+      background-color: $c-light-slate;
+    }
+  }
+
+  .content-moderation__summary,
+  .content-moderation__summary[open] {
+    @include fs-body-bold;
+    @include antialiasing;
+    background: #333;
+    border-radius: 0;
+    border: 0;
+    color: $c-white;
+    padding: 0 !important;
+  }
+
+  .content-moderation__summary-container {
+    @include contain-1090;
+    padding-bottom: 20px;
+    padding-top: 20px;
+    position: relative;
+
+    &::after {
+      color: $c-white;
+      background: url("data:image/svg+xml,%3Csvg width='20' height='20' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M9.96 14.755a1.245 1.245 0 01-.885-.365l-7.5-7.5a1.252 1.252 0 011.77-1.77l6.615 6.62 6.615-6.62a1.251 1.251 0 111.77 1.77l-7.5 7.5a1.247 1.247 0 01-.885.365z' fill='%23fff'/%3E%3C/svg%3E");
+      background-repeat: no-repeat;
+      background-position: 50% 50%;
+      content: '';
+      height: 20px;
+      position: absolute;
+      right: 20px;
+      top: 26px;
+      width: 20px;
+    }
+
+    [open] > &::after {
+      background-image: url("data:image/svg+xml,%3Csvg width='20' height='20' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M17.46 14.755a1.245 1.245 0 01-.885-.365L9.96 7.775 3.345 14.39a1.252 1.252 0 01-1.77-1.77l7.5-7.5a1.26 1.26 0 011.77 0l7.5 7.5a1.26 1.26 0 010 1.77 1.246 1.246 0 01-.885.365z' fill='%23fff'/%3E%3C/svg%3E");
+    }
+  }
 }
 
 .content-moderation__content {
   @include contain-1090;
   padding-top: 30px;
-  padding-bottom: 60px;
+  padding-bottom: 40px;
 }
 
-.content-moderation__message {
-  margin-bottom: 2rem;
+.content-moderation__log-message {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.32);
+  margin-top: 1px;
+  padding-bottom: 25px;
 }
 
-.content-moderation__transition {
-  @include media($mobile-screen) {
-    align-items: center;
+.content-moderation__message p {
+  margin: 2px 0 22px 0;
+}
+
+.content-moderation__fields {
+  margin-top: 20px;
+
+  @include media($medium-screen) {
+    align-items: stretch;
     display: flex;
   }
 
-  .form-item {
-    margin: 0 0 20px 0;
-    padding: 0;
-    max-width: 50%;
+  label {
+    margin: 0 0 8px 0;
+  }
 
-    @include media($mobile-screen) {
-      align-items: center;
-      display: flex;
-      margin: 0;
-      max-width: 520px;
-    }
+  .form-item {
+    margin: 0 0 15px 0;
+    padding: 0;
 
     &:not(:first-child) {
-      @include media($mobile-screen) {
-        margin-left: 2rem;
+      @include media($medium-screen) {
+        margin-left: 20px;
       }
     }
   }
 
-  label {
-    display: block;
-    font-size: 1.2rem;
-    font-weight: normal;
-    margin: 0 1rem 0 0;
-
-    @include media-max($mobile-screen) {
-
-      font-size: 1.1rem;
-    }
-
-    @include media($mobile-screen) {
-      min-width: max-content;
-    }
-  }
-}
-
-.content-moderation__log {
-  align-items: stretch;
-  display: flex;
-  margin-top: 20px;
-
   .form-item-revision-log {
-    align-items: stretch;
     display: flex;
-    flex: 1 0 auto;
-    position: relative;
-
-    label {
-      @include visually-hidden;
-    }
-
-    input {
-      border-bottom-right-radius: 0;
-      border-right: 0;
-      border-top-right-radius: 0;
-      flex: 1 1 auto;
-      margin: 0;
-      width: 100%;
-    }
-  }
-
-  .form-submit {
-    border-bottom-left-radius: 0;
-    border-left: 0;
-    border-top-left-radius: 0;
-    flex: 0 1 80px;
-    margin: 0;
+    flex-direction: column;
+    flex: 1 1 auto;
   }
 }
 
-.content-moderation__status {
-  display: inline-block;
-  border-radius: 8px;
-  font-size: 0.923rem;
-  padding: 0 0.5rem;
+.content-moderation__button {
+  .form-submit {
+    @include button;
+    width: auto;
+    margin: 0;
 
-  &.is-published {
-    background: $c-green-3;
-    color: $c-white;
-  }
-
-  &.is-unpublished {
-    background: $c-red-3;
-    color: $c-white;
+    &:hover, &:focus {
+      background-color: darken($c-bright-blue, 10%);
+      border-color: darken($c-bright-blue, 10%);
+    }
   }
 }

--- a/web/themes/custom/sfgovpl/src/sass/forms/_node.content-moderation.scss
+++ b/web/themes/custom/sfgovpl/src/sass/forms/_node.content-moderation.scss
@@ -51,8 +51,7 @@
     }
   }
 
-  .content-moderation__summary,
-  .content-moderation__summary[open] {
+  .content-moderation__summary {
     @include fs-body-bold;
     @include antialiasing;
     background: #333;
@@ -80,10 +79,10 @@
       top: 26px;
       width: 20px;
     }
+  }
 
-    [open] > &::after {
-      background-image: url("data:image/svg+xml,%3Csvg width='20' height='20' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M17.46 14.755a1.245 1.245 0 01-.885-.365L9.96 7.775 3.345 14.39a1.252 1.252 0 01-1.77-1.77l7.5-7.5a1.26 1.26 0 011.77 0l7.5 7.5a1.26 1.26 0 010 1.77 1.246 1.246 0 01-.885.365z' fill='%23fff'/%3E%3C/svg%3E");
-    }
+  &[open] .content-moderation__summary-container::after {
+    background-image: url("data:image/svg+xml,%3Csvg width='20' height='20' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M17.46 14.755a1.245 1.245 0 01-.885-.365L9.96 7.775 3.345 14.39a1.252 1.252 0 01-1.77-1.77l7.5-7.5a1.26 1.26 0 011.77 0l7.5 7.5a1.26 1.26 0 010 1.77 1.246 1.246 0 01-.885.365z' fill='%23fff'/%3E%3C/svg%3E");
   }
 }
 

--- a/web/themes/custom/sfgovpl/src/sass/forms/_node.diff.scss
+++ b/web/themes/custom/sfgovpl/src/sass/forms/_node.diff.scss
@@ -30,18 +30,31 @@
   display: none;
 }
 
-// Todo, add some styles to deal with button links... these tags are not visible.
 del, ins {
-  // display: inline-block;
-  // padding: 1em !important;
+  display: inline-block;
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  &, > * {
+    color: $c-slate !important;
+  }
 }
 
 del {
-  background-color: #fcc;
+  outline-color: $c-red-3;
+
+  &, > * {
+    background-color: $c-red-2 !important;
+    text-decoration: line-through !important;
+  }
 }
 
 ins {
-  background-color: #cfc;
+  outline-color: $c-green-3 !important;
+
+  &, > * {
+    background-color: $c-green-2;
+    text-decoration: underline !important;
+  }
 }
 
 // System CSS Overrides

--- a/web/themes/custom/sfgovpl/src/sass/forms/_node.diff.scss
+++ b/web/themes/custom/sfgovpl/src/sass/forms/_node.diff.scss
@@ -1,0 +1,58 @@
+// DropButton styles from Seven.
+// Needed by Diff module; no support in sfgovpl.
+@import url('/core/themes/seven/css/components/dropbutton.component.css');
+
+// Diff Controls
+//------------------------------------------------------------------------------
+
+.diff-header,
+.diff-controls {
+  background: #f8f8f8;
+  border: solid 1px #ccc;
+  margin: 0 auto;
+  max-width: 1090px;
+}
+
+.diff-header {
+  border-radius: 8px 8px 0 0;
+  border-bottom-width: 0;
+  padding: 20px;
+}
+
+.diff-controls {
+  border-top-width: 0;
+  padding: 20px;
+  margin-bottom: 20px;
+  border-radius: 0 0 8px 8px;
+}
+
+.diff-responsive-table-wrapper > .article__title {
+  display: none;
+}
+
+// Todo, add some styles to deal with button links... these tags are not visible.
+del, ins {
+  // display: inline-block;
+  // padding: 1em !important;
+}
+
+del {
+  background-color: #fcc;
+}
+
+ins {
+  background-color: #cfc;
+}
+
+// System CSS Overrides
+//------------------------------------------------------------------------------
+// This is an odd case where administrative and default theme can potentially
+// mix, likely due to dependencies of "admin widgets on the front-end".
+
+// Overrides system.admin.css.
+div.layout-container {
+  margin: 0 !important;
+  @media screen and (min-width: 38em) {
+    margin: 0 !important;
+  }
+}

--- a/web/themes/custom/sfgovpl/src/sass/forms/_node.preview.scss
+++ b/web/themes/custom/sfgovpl/src/sass/forms/_node.preview.scss
@@ -1,0 +1,36 @@
+// Node Preview widget.
+//------------------------------------------------------------------------------
+
+.node-preview-container {
+  background: #2d2d2d;
+  color: $c-white;
+  padding: 1rem;
+}
+
+.node-preview-backlink {
+  @include button-clear;
+  @include rubik;
+}
+
+.node-preview-form-select {
+  max-width: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  .form-item-view-mode {
+    @include media($narrow-screen) {
+      display: flex;
+      align-items: stretch;
+    }
+
+    label {
+      color: $c-white;
+      display: flex;
+      align-items: center;
+      font-size: 1rem;
+      white-space: nowrap;
+      margin: 0 20px 0 0;
+    }
+  }
+}

--- a/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-campaign-spotlight.scss
+++ b/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-campaign-spotlight.scss
@@ -16,6 +16,9 @@
 }
 
 .sfgov-campaign-spotlight-main {
+  // NOTE: This will be overridden by a style attribute in the template, but
+  // should also exist so that content is here when viewing inline diff
+  background-color: #212123;
   position: relative;
   border-radius: 8px;
   display: flex;

--- a/web/themes/custom/sfgovpl/templates/content-edit/entity-moderation-form.html.twig
+++ b/web/themes/custom/sfgovpl/templates/content-edit/entity-moderation-form.html.twig
@@ -16,73 +16,87 @@
  * @see sfgov_admin_form_content_moderation_entity_moderation_form_alter()
  */
 #}
-{% set node = form['#node'] %}
-{% set revision = form['#node_revision'] %}
+
 {% set current_state = form['#current_state'] %}
+{% set current_state_class = current_state|clean_class %}
 
 {# Note: Using methods and filters, like clean_class does not work inside
 {% trans %} tags, so we need to set these variables outside the block. #}
-{% set revision_status = revision.isPublished() ? 'published' : 'unpublished' %}
-{% set node_status = node.isPublished() ? 'published' : 'unpublished' %}
-{% set current_state_class = current_state|clean_class %}
-{% set node_status_class = node_status|clean_class %}
-{% set node_title = node.label() %}
+{% set node = form['#node'] %}
 {% set node_url = form['#node_url'] %}
+{% set node_title = node.label() %}
+
+{% set revision = form['#node_revision'] %}
+{% set revision_user = revision.getRevisionUser() %}
+{% set revision_author = revision_user.getDisplayName() %}
+{% set revision_date = revision.getRevisionCreationTime()|format_date('custom', 'F j, Y, g:i a') %}
+{% set revision_log_message = revision.getRevisionLogMessage() %}
 
 {% set classes = [
   'content-moderation',
   'is-' ~ current_state_class,
 ] %}
 
-<details{{ attributes.addClass(classes) }} open>
+<details{{ attributes.addClass(classes) }}>
   <summary class="content-moderation__summary">
-    <div class="content-moderation_summary-container">
+    <div class="content-moderation__summary-container">
       {% trans %}
-        <span class="content-moderation__state is-{{ current_state_class }}">
-          Current state: {{ current_state }}
-        </span>
-        <span class="content-moderation__status is-{{ revision_status }}">
-          {{ revision_status }}
+        <div class="content-moderation__state">
+          <span>Current state</span>
+          <mark class="is-{{ current_state_class }}">
+            {{ current_state }}
+          </mark>
         </span>
       {% endtrans %}
     </div>
   </summary>
 
   <div class="content-moderation__content">
+    {% if node.revision_log.value or revision_author %}
+      <div class="content-moderation__log">
+        {% if revision_author %}
+          <strong class="content-moderation__label" title="Revision created: {{ revision_date }}">
+            {{ 'Last revision from @username'|t({ '@username': revision_author }) }}
+          </strong>
+        {% endif %}
+
+        {% if revision_log_message %}
+          <div class="content-moderation__log">
+            <p class="content-moderation__log-message">
+              {{ revision_log_message }}
+            </p>
+          </div>
+        {% endif %}
+      </div>
+    {% endif %}
+
+    <div class="content-moderation__fields">
+      {{ form.new_state }}
+      {{ form.revision_log }}
+    </div>
+
     <div class="content-moderation__message">
       <p>
+       {{ 'This is the latest, unpublished, version of this page.'|t }}
+
         {% if node.isPublished() %}
           {% trans %}
-            This is the latest, <em>unpublished</em> revision, in
-            <em class="{{ current_state_class }}">{{ current_state }}</em> state, of
-            <a href="{{ node_url }}" target="_blank" rel="noopener">{{ node_title }} [{{node_status}}]</a>.
+            <a href="{{ node_url }}" target="_blank" rel="noopener" title="{{ node_title }}">
+              View the version that is currently published.
+            </a>
           {% endtrans %}
 
         {% else %}
-          {% trans %}
-            This is the latest, <em>unpublished</em> revision, in
-            <em class="{{ current_state_class }}">{{ current_state }}</em>
-            state, of this page. There are no published revisions available.
-          {% endtrans %}
+          {{ 'There are currently no published versions.'|t }}
         {% endif %}
       </p>
     </div>
 
-    <div class="content-moderation__transition">
-      {{ form.new_state }}
-    </div>
-
-    <div class="content-moderation__log">
-      {{ form.revision_log }}
+    <div class="content-moderation__button">
       {{ form.submit }}
     </div>
 
-    {% if node.revision_log.value %}
-      <div class="content-moderation__message">
-        <p><em>{{ 'Previous log message:'|t }}</em> {{ node.revision_log.value }}</p>
-      </div>
-    {% endif %}
-
     {{ form|without('current', 'new_state', 'revision_log', 'submit') }}
+
   </div>
 </details>

--- a/web/themes/custom/sfgovpl/templates/content-edit/entity-moderation-form.html.twig
+++ b/web/themes/custom/sfgovpl/templates/content-edit/entity-moderation-form.html.twig
@@ -2,24 +2,87 @@
 /**
  * @file
  * Template override for the "Content moderation" widget.
+ *
+ * The moderation form is only displayed only when viewing the latest
+ * (translation-affecting) revision, unless it was created as published default
+ * revision.
+ *
+ * Additional variables:
+ * - form['#node']: Node object for the base node.
+ * - form['#node_revision']: Node object for the revision being viewed.
+ * - form['#current_state'] = Current moderation state.
+ * - form['#node_url']: Url of base node, or the revision (string).
+ *
+ * @see sfgov_admin_form_content_moderation_entity_moderation_form_alter()
  */
 #}
+{% set node = form['#node'] %}
+{% set revision = form['#node_revision'] %}
+{% set current_state = form['#current_state'] %}
 
-<details class="content-moderation-control">
-  <summary><span>{{'Moderate'|t }}</span></summary>
+{# Note: Using methods and filters, like clean_class does not work inside
+{% trans %} tags, so we need to set these variables outside the block. #}
+{% set revision_status = revision.isPublished() ? 'published' : 'unpublished' %}
+{% set node_status = node.isPublished() ? 'published' : 'unpublished' %}
+{% set current_state_class = current_state|clean_class %}
+{% set node_status_class = node_status|clean_class %}
+{% set node_title = node.label() %}
+{% set node_url = form['#node_url'] %}
 
-  <div class="content-moderation-control__content">
-    <div class="content-moderation-control__transition">
-      {{ form.current }}
+{% set classes = [
+  'content-moderation',
+  'is-' ~ current_state_class,
+] %}
+
+<details{{ attributes.addClass(classes) }} open>
+  <summary class="content-moderation__summary">
+    <div class="content-moderation_summary-container">
+      {% trans %}
+        <span class="content-moderation__state is-{{ current_state_class }}">
+          Current state: {{ current_state }}
+        </span>
+        <span class="content-moderation__status is-{{ revision_status }}">
+          {{ revision_status }}
+        </span>
+      {% endtrans %}
+    </div>
+  </summary>
+
+  <div class="content-moderation__content">
+    <div class="content-moderation__message">
+      <p>
+        {% if node.isPublished() %}
+          {% trans %}
+            This is the latest, <em>unpublished</em> revision, in
+            <em class="{{ current_state_class }}">{{ current_state }}</em> state, of
+            <a href="{{ node_url }}" target="_blank" rel="noopener">{{ node_title }} [{{node_status}}]</a>.
+          {% endtrans %}
+
+        {% else %}
+          {% trans %}
+            This is the latest, <em>unpublished</em> revision, in
+            <em class="{{ current_state_class }}">{{ current_state }}</em>
+            state, of this page. There are no published revisions available.
+          {% endtrans %}
+        {% endif %}
+      </p>
+    </div>
+
+    <div class="content-moderation__transition">
       {{ form.new_state }}
     </div>
 
-    <div class="content-moderation-control__log">
+    <div class="content-moderation__log">
       {{ form.revision_log }}
       {{ form.submit }}
     </div>
 
+    {% if node.revision_log.value %}
+      <div class="content-moderation__message">
+        <p><em>{{ 'Previous log message:'|t }}</em> {{ node.revision_log.value }}</p>
+      </div>
+    {% endif %}
+
     {{ form|without('current', 'new_state', 'revision_log', 'submit') }}
   </div>
 </details>
-

--- a/web/themes/custom/sfgovpl/templates/content-edit/entity-moderation-form.html.twig
+++ b/web/themes/custom/sfgovpl/templates/content-edit/entity-moderation-form.html.twig
@@ -1,0 +1,25 @@
+{#
+/**
+ * @file
+ * Template override for the "Content moderation" widget.
+ */
+#}
+
+<details class="content-moderation-control">
+  <summary><span>{{'Moderate'|t }}</span></summary>
+
+  <div class="content-moderation-control__content">
+    <div class="content-moderation-control__transition">
+      {{ form.current }}
+      {{ form.new_state }}
+    </div>
+
+    <div class="content-moderation-control__log">
+      {{ form.revision_log }}
+      {{ form.submit }}
+    </div>
+
+    {{ form|without('current', 'new_state', 'revision_log', 'submit') }}
+  </div>
+</details>
+

--- a/web/themes/custom/sfgovpl/templates/content-edit/entity-moderation-form.html.twig
+++ b/web/themes/custom/sfgovpl/templates/content-edit/entity-moderation-form.html.twig
@@ -56,7 +56,7 @@
       <div class="content-moderation__log">
         {% if revision_author %}
           <strong class="content-moderation__label" title="Revision created: {{ revision_date }}">
-            {{ 'Last revision from @username'|t({ '@username': revision_author }) }}
+            {{ 'Latest revision from @username'|t({ '@username': revision_author }) }}
           </strong>
         {% endif %}
 

--- a/web/themes/custom/sfgovpl/templates/layout/html.html.twig
+++ b/web/themes/custom/sfgovpl/templates/layout/html.html.twig
@@ -23,10 +23,13 @@
  * @see template_preprocess_html()
  */
 #}
+{# Root path (used below) will not be true for revisions and inline diffs. #}
+{% set is_front = (node.id() == 2) ? true : false %}
+
 {%
   set body_classes = [
   logged_in ? 'user-logged-in',
-  not root_path ? 'path-frontpage' : 'path-' ~ root_path|clean_class,
+  is_front ? 'path-frontpage' : 'path-' ~ root_path|clean_class,
   node_type ? 'page-node-type-' ~ node_type|clean_class,
   db_offline ? 'db-offline',
 ]

--- a/web/themes/custom/sfgovpl/templates/node/node--about--full.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--about--full.html.twig
@@ -1,3 +1,5 @@
+{{ content.content_moderation_control }}
+
 <article{{ attributes.addClass(classes) }}>
   {% include '@theme/hero-banner-color.twig' with {
     'banner': {

--- a/web/themes/custom/sfgovpl/templates/node/node--campaign--full.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--campaign--full.html.twig
@@ -85,7 +85,7 @@
 <article{{ attributes.addClass(classes) }}>
   {% block content %}
     <div{{ content_attributes.addClass(bundle ~ '__content') }}>
-      {{ content | without('links', 'field_logo', 'field_social_media_embed', 'field_campaign_about', 'field_campaign_about', 'field_links', 'field_dept') }}
+      {{ content | without('links', 'field_logo', 'field_social_media_embed', 'field_campaign_about', 'field_campaign_about', 'field_links', 'field_dept', 'content_moderation_control') }}
       {% if content.field_social_media_embed|render is not empty %}
         <div class="__campaign-social-media-wrapper sfgov-full-bleed">
           <div class="sfgov-section-container">

--- a/web/themes/custom/sfgovpl/templates/node/node--campaign--full.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--campaign--full.html.twig
@@ -80,6 +80,8 @@
   bundle ~ '__title--' ~ view_mode|clean_class,
 ] %}
 
+{{ content.content_moderation_control }}
+
 <article{{ attributes.addClass(classes) }}>
   {% block content %}
     <div{{ content_attributes.addClass(bundle ~ '__content') }}>

--- a/web/themes/custom/sfgovpl/templates/node/node--department--full.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--department--full.html.twig
@@ -65,6 +65,7 @@
  *
  * @see template_preprocess_node()
 #}
+{{ content.content_moderation_control }}
 
 {% set description = node.get('field_description').getValue()[0]['value'] %}
 

--- a/web/themes/custom/sfgovpl/templates/node/node--form-confirmation-page--full.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--form-confirmation-page--full.html.twig
@@ -1,3 +1,5 @@
+{{ content.content_moderation_control }}
+
  {% block header %}
     {% include '@theme/hero-banner-with-image.twig' with {
       'banner': {
@@ -11,6 +13,7 @@
   {% block content %}
       <div class="confirmation--left">
         {{ content|without(
+          'content_moderation_control',
           'field_confirmation_sidebar',
           'field_banner_color',
           'field_banner_image',

--- a/web/themes/custom/sfgovpl/templates/node/node--full.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--full.html.twig
@@ -80,6 +80,8 @@
   bundle ~ '__title--' ~ view_mode|clean_class,
 ] %}
 
+{{ content.content_moderation_control }}
+
 <article{{ attributes.addClass(classes) }}>
   {% block header %}
     {{ title_prefix }}
@@ -107,6 +109,7 @@
   {% block content %}
     <div{{ content_attributes.addClass(bundle ~ '__content') }}>
       {{ content|without(
+        'content_moderation_control',
         'field_description',
         'links'
       ) }}

--- a/web/themes/custom/sfgovpl/templates/node/node--information-page--full.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--information-page--full.html.twig
@@ -1,3 +1,5 @@
+{{ content.content_moderation_control }}
+
 {% if node.field_transactions.value %}
   {% set hasTags = true %}
   {% set classes = ['info--has-tags'] %}
@@ -15,7 +17,7 @@
       'label': content.field_transactions|render
     }
   } %}
-  
+
   <div class="info--content">
     <div class="info--left">
       {{ content.field_information_section }}
@@ -27,10 +29,10 @@
       <div class="info--right">
         {{ content.field_related_content }}
       </div>
-    {% endif %}  
+    {% endif %}
 
   </div>
-  
+
   {% if hasDept %}
     <div class="info--departments-container">
       <div class="info--departments">

--- a/web/themes/custom/sfgovpl/templates/node/node--meeting--full.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--meeting--full.html.twig
@@ -5,6 +5,8 @@
     : 'Part of <a href="@url">@public_body meetings</a>'|t({'@public_body': meeting_list_label, '@url': path('view.meetings.page_upcoming', {arg_0: content.field_public_body[0]['#node'].id() })})
 %}
 
+{{ content.content_moderation_control }}
+
 <article{{ attributes.addClass(classes) }}>
   {% include '@theme/hero-banner-color.twig' with {
     'banner': {

--- a/web/themes/custom/sfgovpl/templates/node/node--news--full.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--news--full.html.twig
@@ -38,6 +38,7 @@
     <div{{ content_attributes.addClass(bundle ~ '--body') }}>
       <div class="news--body-inner">
         {{ content|without(
+          'content_moderation_control',
           'field_abstract',
           'field_date',
           'field_dept',

--- a/web/themes/custom/sfgovpl/templates/node/node--page--full.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--page--full.html.twig
@@ -1,3 +1,5 @@
+{{ content.content_moderation_control }}
+
 <article{{ attributes.addClass(classes) }}>
   {% include '@theme/hero-banner-color.twig' with {
     'banner': {

--- a/web/themes/custom/sfgovpl/templates/node/node--public-body--full.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--public-body--full.html.twig
@@ -85,6 +85,8 @@
   }
 %}
 
+{{ content.content_moderation_control }}
+
 <div class="sfds-layout-container">
   <div class="sfds-responsive-container">
     {% include '@theme/hero-banner-default.twig' with {

--- a/web/themes/custom/sfgovpl/templates/node/node--step-by-step--full.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--step-by-step--full.html.twig
@@ -14,7 +14,11 @@
 
   {% block content %}
     <div class="step-by-step-content">
-      {{ content | without('field_description', 'field_topics') }}
+      {{ content|without(
+        'content_moderation_control',
+        'field_description',
+        'field_topics'
+      ) }}
     </div>
     {% include '@theme/last-updated.twig' with {
       'date': node.changedtime|date('F d, Y')

--- a/web/themes/custom/sfgovpl/templates/node/node--transaction--full.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--transaction--full.html.twig
@@ -49,6 +49,7 @@
         {% endif %}
 
         {{ content|without(
+          'content_moderation_control',
           'field_description',
           'field_cost',
           'field_things_to_know',

--- a/web/themes/custom/sfgovpl/templates/node/node.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node.html.twig
@@ -104,7 +104,10 @@
 
       <div{{ content_attributes.addClass(bundle ~ '__content') }}>
         {% block body %}
-        {{ content|without('links') }}
+        {{ content|without(
+          'content_moderation_control',
+          'links'
+        ) }}
         {% endblock body %}
       </div>
 


### PR DESCRIPTION
1. Customizes the Content Moderation Widget
2. Customizes the Preview form widget.
3. Adds the Diff module.

## Moderation

![ContentModerationWidget](https://user-images.githubusercontent.com/60979/104366496-77dbbc80-54e7-11eb-9354-9691641ca0c0.png)

## Previews

![Node Previews](https://user-images.githubusercontent.com/60979/99573247-db43e500-29a3-11eb-83d4-9ba7d79be1ba.png)

## Diff

![NodeDiff](https://user-images.githubusercontent.com/60979/99572927-65d81480-29a3-11eb-91b9-7149721af571.png)

Note: While the "inline" screenshot shows it looking perfect, that is NOT the case on most content types. There are various reasons for this, mostly related to how things are done in the theme, but also because Diff module strips all style tags (which removes a lot of our background styles for things like campaign spotlights, and because it does not use the proper templates when rendering... I have some ideas for improving this experience, that I will bring up when there is time.

_UPDATE (1/12/21):  I think that using a separate theme for inline diffs would potentially be a good solution. Maybe Gin, maybe even Seven. Making this work visually with the front end theme is not going to be viable, as even if we put in the work required, there would still be major issues due to the wqy the Diff module works, and does not use the appropriate template suggestion when generating the rendered HTML._
