### PR TITLE
Catch form event handler errors and log them

### DIFF
--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -93,8 +93,12 @@
      * multiple arguments to the listener rather than a single event object.
      */
     var formEventHandlers = {
-      submit: function (submission) { },
-      submitDone: function (submission) { },
+      submit: function (submission) {
+        return { } // just log the event
+      },
+      submitDone: function (submission) {
+        return { } // just log the event
+      },
       error: function (message) {
         return { error: message }
       },
@@ -105,7 +109,10 @@
         return error ? {
           component: error.component.key,
           error: error.message
-        } : false
+        } : {
+          // if we don't get an error argument here, we should still probably log it
+          error: 'No error argument passed to "componentError" handler!'
+        }
       },
       prevPage: function (data) {
         return { page_index: data.page }
@@ -124,8 +131,12 @@
           page_index: index
         }
       },
-      saveDraft: function (submission) { },
-      restoreDraft: function (submission) { },
+      saveDraft: function (submission) {
+        return { } // just log the event
+      },
+      restoreDraft: function (submission) {
+        return { } // just log the event
+      },
       editGridAddRow: function (data) {
         return {
           component: data.component.key
@@ -142,7 +153,7 @@
           form.on(eventName, function() {
             try {
               var formData = formEventHandlers[eventName].apply(form, arguments)
-              if (formData !== false) {
+              if (formData && typeof formData === 'object') {
                 formData.url = form.url
                 amp('form.' + eventName, { form: formData })
               }

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -102,10 +102,10 @@
         return { error: message }
       },
       componentError: function (error) {
-        return {
+        return error ? {
           component: error.component.key,
           error: error.message
-        }
+        } : false
       },
       prevPage: function (data) {
         return { page_index: data.page }
@@ -140,10 +140,14 @@
 
         Object.keys(formEventHandlers).forEach(function(eventName) {
           form.on(eventName, function() {
-            var formData = formEventHandlers[eventName].apply(form, arguments)
-            if (formData !== false) {
-              formData.url = form.url
-              amp('form.' + eventName, { form: formData })
+            try {
+              var formData = formEventHandlers[eventName].apply(form, arguments)
+              if (formData !== false) {
+                formData.url = form.url
+                amp('form.' + eventName, { form: formData })
+              }
+            } catch (error) {
+              console.error('There was an error handling form event "%s":', eventName, error)
             }
           })
         })

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -106,12 +106,9 @@
         return { error: message }
       },
       componentError: function (error) {
-        return error ? {
+        return {
           component: error.component.key,
           error: error.message
-        } : {
-          // if we don't get an error argument here, we should still probably log it
-          error: 'No error argument passed to "componentError" handler!'
         }
       },
       prevPage: function (data) {


### PR DESCRIPTION
While acceptance testing forms on test-sfgov, we discovered that form submissions were being aborted by mysterious errors. One in particular looked suspicious:

![image](https://user-images.githubusercontent.com/113896/101078311-d877f100-355a-11eb-88c4-ccba208c5906.png)

The error message here is not one that I would expect to be thrown inside formiojs or formio-sfds, and it occurred to me that formiojs probably wraps form submission calls in a `try/catch` block. Turns out, the offending code was something I added in #736 to dispatch form events to amplitude:

https://github.com/SFDigitalServices/sfgov/blob/433c61b1d69460996e8fe57c4d147dbc8481fe97/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig#L143-L146

The bug is that `formData` may very well not equal `false`, but is `undefined` for the submit event handlers, which don't return anything:

https://github.com/SFDigitalServices/sfgov/blob/433c61b1d69460996e8fe57c4d147dbc8481fe97/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig#L96-L97

Hence, the error: "_Cannot set property 'url' of undefined_".

This PR wraps our own event handling and dispatching code in its own `try/catch` block and logs an error if thrown, and updates the handlers that don't return anything to explicitly return an empty object so the events are still logged.