### PR TITLE
handle empty array value for confirmation url

### DIFF
--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -59,7 +59,11 @@
 (function() {
 
   var time = Date.now()
-  var confirmationURL = {{ paragraph.field_formio_confirmation_url.value|json_encode(constant('JSON_PRETTY_PRINT'))|raw  }}
+    
+  var confirmationURL = {{ paragraph.field_formio_confirmation_url.value is empty ? 
+    "null" : 
+    paragraph.field_formio_confirmation_url.value|json_encode(constant('JSON_PRETTY_PRINT'))|raw  
+  }}
 
   window.addEventListener('load', function() {
     var loadTime = Date.now() - time


### PR DESCRIPTION
for empty field values, drupal appears to send an empty array.  this was causing issues with the confirmation page redirect logic.

some notes copied from a slack convo:

> i think it has to do with this line: https://github.com/SFDigitalServices/sfgov/blob/f0d02537e37baf4da696815688fd51566cc5e158/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig#L62
>
>if paragraph.field_formio_confirmation_url.value doesn’t have a value, the twig filters evaluate to [] (empty array).
>
>further down the file:
>https://github.com/SFDigitalServices/sfgov/blob/f0d02537e37baf4da696815688fd51566cc5e158/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig#L200-L202
>
> since confirmationURL is `[]` and not `null` or `undefined`, `window.location = []` just refreshes the browser