### PR TITLE
bump formio-sfds to 7.0.2

### DIFF
--- a/config/sfgov_formio.settings.yml
+++ b/config/sfgov_formio.settings.yml
@@ -1,2 +1,2 @@
 formio_version: 'https://unpkg.com/formiojs@4.11.2/dist/formio.full.min.js'
-formio_sfds_version: 'https://unpkg.com/formio-sfds@7.0.1/dist/formio-sfds.standalone.js'
+formio_sfds_version: 'https://unpkg.com/formio-sfds@7.0.2/dist/formio-sfds.standalone.js'


### PR DESCRIPTION
[This release](https://github.com/SFDigitalServices/formio-sfds/releases/tag/v7.0.2) fixes some missing form translation keys in our radio/checkbox templates. I've already updated the config in prod because it's needed for a form that's going live today.

