### PR TITLE
Fix and centralize code for getting $node object in theme hooks…

### DIFF
--- a/web/modules/custom/sfgov_alerts/sfgov_alerts.module
+++ b/web/modules/custom/sfgov_alerts/sfgov_alerts.module
@@ -7,6 +7,7 @@
 
 use Drupal\sfgov_alerts\Alert;
 use Drupal\Core\Form\FormState;
+use Drupal\node\NodeInterface;
 
 /**
  * @param $entity Drupal\Core\Entity\Entity
@@ -23,7 +24,8 @@ function sfgov_alerts_entity_presave($entity) {
  * Implements hook_form_alter().
  */
 function sfgov_alerts_form_alter(&$form, FormState $form_state, $form_id) {
-  if ($node = \Drupal::routeMatch()->getParameter('node')) {
+  $node = \Drupal::routeMatch()->getParameter('node');
+  if (!empty($node) && $node instanceof NodeInterface) {
     if ($node->hasField('field_alert_expiration_date')) {
       $date_exp = $node->field_alert_expiration_date->value;
       $date_today = date('Y-m-d');

--- a/web/modules/custom/sfgov_event_subscriber/src/EventSubscriber/RedirectEventSubscriber.php
+++ b/web/modules/custom/sfgov_event_subscriber/src/EventSubscriber/RedirectEventSubscriber.php
@@ -11,6 +11,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Drupal\Core\Routing\TrustedRedirectResponse;
+use Drupal\node\NodeInterface;
 
 /**
  * Event Subscriber RedirectEventSubscriber.
@@ -39,8 +40,8 @@ class RedirectEventSubscriber implements EventSubscriberInterface {
     $node = $event->getRequest()->attributes->get('node');
     $media = $event->getRequest()->attributes->get('media');
 
-    if($node) {
-      if(!$node->isPublished()) {
+    if ($node && $node instanceof NodeInterface) {
+      if (!$node->isPublished()) {
         return;
       }
       else {

--- a/web/modules/custom/sfgov_utilities/sfgov_utilities.module
+++ b/web/modules/custom/sfgov_utilities/sfgov_utilities.module
@@ -185,7 +185,7 @@ function sfgov_utilities_page_attachments(array &$page) {
         $view->setDisplay('topics_more_services');
         $view->execute();
         $view_result = $view->result;
-        $excluded_services = topic_page_services();
+        $excluded_services = topic_page_services($node);
 
         // Check More Services for unpublished items
         foreach ($view_result as $key => $value) {

--- a/web/modules/custom/sfgov_utilities/sfgov_utilities.module
+++ b/web/modules/custom/sfgov_utilities/sfgov_utilities.module
@@ -5,6 +5,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\pathauto\PathautoState;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Cache\Cache;
+use Drupal\node\NodeInterface;
 
 /**
  * Implements hook_template_preprocess_default_variables_alter().
@@ -152,7 +153,7 @@ function sfgov_utilities_page_attachments(array &$page) {
   // Don't run on admin pages
   if (!\Drupal::service('router.admin_context')->isAdminRoute()) {
     $node = \Drupal::routeMatch()->getParameter('node');
-    if (isset($node)) {
+    if (!empty($node) && $node instanceOf NodeInterface) {
       $bundle = $node->bundle();
       // Only check department and topic nodes
       if ($bundle == 'department' || $bundle == 'topic') {

--- a/web/themes/custom/sfgovpl/includes/html.inc
+++ b/web/themes/custom/sfgovpl/includes/html.inc
@@ -1,99 +1,111 @@
 <?php
 
+/**
+ * @file
+ * Preprocess functions for the 'html' theme hooks.
+ */
+
 use Drupal\Core\Url;
+use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
 use Drupal\paragraphs\Entity\Paragraph;
-use org\bovigo\vfs\content\FileContent;
 
+/**
+ * Implements hook_preprocess_HOOK().
+ */
 function sfgovpl_preprocess_html(&$variables) {
+  // Make sure we have a node object that works on revisions, diffs, etc.
+  _sfgovpl_node_object($variables);
 
-  // for metadata
-  if(!empty($variables['node_type'])) {
-    $nodeType = $variables['node_type'];
-    if($nodeType == 'department') {
-      $node = \Drupal::request()->attributes->get('node');
+  if (!empty($variables['node']) && $variables['node'] instanceof NodeInterface) {
+    $node = $variables['node'];
+    $node_type = $node->bundle();
 
-      $metaDeptPhone = [
-        '#tag' => 'meta',
-        '#attributes' => [
-          'name' => 'departmentPhone',
-          'content' => '',
-        ]
-      ];
-      $metaDeptAddress = [
-        '#tag' => 'meta',
-        '#attributes' => [
-          'name' => 'departmentAddress',
-          'content' => '',
-        ]
-      ];
+    // Send these variables to html.html.twig as well.
+    $variables['node'] = $node;
+    $variables['node_type'] = $node_type;
 
-      if(count($node->get('field_phone_numbers')->getValue()) > 0) {
-        $paragraphPhoneId = $node->get('field_phone_numbers')->getValue()[0]['target_id'];
-        $phone = Paragraph::load($paragraphPhoneId);
-        $metaDeptPhone['#attributes']['content'] = $phone->field_tel->value;
-      }
-
-      if(count($node->get('field_address')->getValue()) > 0) {
-        $paragraphAddressId = $node->get('field_address')->getValue()[0]['target_id'];
-        $paragraphAddress = Paragraph::load($paragraphAddressId);
-        $address = $node->get('field_address')->referencedEntities()[0];
-        $metaDeptAddress['#attributes']['content'] = $address->field_address->address_line1;
-      }
-
-      $variables['page']['#attached']['html_head'][] = [$metaDeptPhone, 'departmentPhone'];
-      $variables['page']['#attached']['html_head'][] = [$metaDeptAddress, 'departmentAddress'];
-    }
-
-    if($nodeType == 'transaction') {
-      $txNode = \Drupal::request()->attributes->get('node');
-      $relatedDepts = $txNode->get('field_departments')->getValue();
-      $transaction = [
-        'related_depts' => [],
-      ];
-      foreach($relatedDepts as $relatedDept) {
-        $relatedDeptId = $relatedDept['target_id'];
-        $relatedDeptNode = \Drupal\node\Entity\Node::load($relatedDeptId);
-        $relatedDeptInfo = [
-          'id' => $relatedDeptId,
-          'title' => $relatedDeptNode ? $relatedDeptNode->getTitle() : '',
+    // For metadata.
+    switch ($node_type) {
+      case 'department':
+        $metaDeptPhone = [
+          '#tag' => 'meta',
+          '#attributes' => [
+            'name' => 'departmentPhone',
+            'content' => '',
+          ]
         ];
-        $transaction['related_depts'][] = $relatedDeptInfo;
-      }
-      $metaTx = [
-        '#tag' => 'meta',
-        '#attributes' => [
-          'name' => 'transaction',
-          'content' => json_encode($transaction, JSON_HEX_QUOT),
-        ],
-      ];
+        $metaDeptAddress = [
+          '#tag' => 'meta',
+          '#attributes' => [
+            'name' => 'departmentAddress',
+            'content' => '',
+          ]
+        ];
 
-      $metaTxRelatedDept = [
-        '#tag' => 'meta',
-        '#attributes' => [
-          'name' => 'transactionRelatedDept',
-          'content' => '',
-        ]
-      ];
+        if (count($node->get('field_phone_numbers')->getValue()) > 0) {
+          $paragraphPhoneId = $node->get('field_phone_numbers')->getValue()[0]['target_id'];
+          $phone = Paragraph::load($paragraphPhoneId);
+          $metaDeptPhone['#attributes']['content'] = $phone->field_tel->value;
+        }
 
-      if(count($relatedDepts) > 0) {
-        $oneRelatedDept = \Drupal\Node\Entity\Node::load($relatedDepts[0]['target_id']);
-        $metaTxRelatedDept['#attributes']['content'] = $oneRelatedDept ? $oneRelatedDept->getTitle() : '';
-      }
-      $variables['page']['#attached']['html_head'][] = [$metaTx, 'transaction'];
-      $variables['page']['#attached']['html_head'][] = [$metaTxRelatedDept, 'transactionRelatedDept'];
-    }
+        if (count($node->get('field_address')->getValue()) > 0) {
+          $paragraphAddressId = $node->get('field_address')->getValue()[0]['target_id'];
+          $paragraphAddress = Paragraph::load($paragraphAddressId);
+          $address = $node->get('field_address')->referencedEntities()[0];
+          $metaDeptAddress['#attributes']['content'] = $address->field_address->address_line1;
+        }
 
-    // Add class page-campaign-[theme] to body tag.
-    if ($nodeType == 'campaign') {
-      $node = \Drupal::request()->attributes->get('node');
-      if (!empty($node)) {
+        $variables['page']['#attached']['html_head'][] = [$metaDeptPhone, 'departmentPhone'];
+        $variables['page']['#attached']['html_head'][] = [$metaDeptAddress, 'departmentAddress'];
+        break;
+
+      case 'transaction':
+        $relatedDepts = $node->get('field_departments')->getValue();
+        $transaction = [
+          'related_depts' => [],
+        ];
+        foreach ($relatedDepts as $relatedDept) {
+          $relatedDeptId = $relatedDept['target_id'];
+          $relatedDeptNode = Node::load($relatedDeptId);
+          $relatedDeptInfo = [
+            'id' => $relatedDeptId,
+            'title' => $relatedDeptNode ? $relatedDeptNode->getTitle() : '',
+          ];
+          $transaction['related_depts'][] = $relatedDeptInfo;
+        }
+        $metaTx = [
+          '#tag' => 'meta',
+          '#attributes' => [
+            'name' => 'transaction',
+            'content' => json_encode($transaction, JSON_HEX_QUOT),
+          ],
+        ];
+
+        $metaTxRelatedDept = [
+          '#tag' => 'meta',
+          '#attributes' => [
+            'name' => 'transactionRelatedDept',
+            'content' => '',
+          ]
+        ];
+
+        if (count($relatedDepts) > 0) {
+          $oneRelatedDept = Node::load($relatedDepts[0]['target_id']);
+          $metaTxRelatedDept['#attributes']['content'] = $oneRelatedDept ? $oneRelatedDept->getTitle() : '';
+        }
+        $variables['page']['#attached']['html_head'][] = [$metaTx, 'transaction'];
+        $variables['page']['#attached']['html_head'][] = [$metaTxRelatedDept, 'transactionRelatedDept'];
+        break;
+
+      case 'campaign':
+        // Add class page-campaign-[theme] to body tag.
         $theme = $node->field_campaign_theme->entity;
         if (!empty($theme)) {
           $theme_class = 'page-campaign-' . \Drupal::service('pathauto.alias_cleaner')->cleanString($theme->label());
           $variables['attributes']['class'][] = $theme_class;
         }
-      }
+        break;
     }
   }
 
@@ -118,7 +130,6 @@ function sfgovpl_preprocess_html(&$variables) {
   $currentLanguage = $languageManager->getCurrentLanguage()->getId();
   $currentRoute = \Drupal::service('current_route_match');
   $routeParameters = $currentRoute->getParameters()->all();
-  $node = \Drupal::routeMatch()->getParameter('node');
   $gTranslatePrefixMap = [
     'fil' => 'tl',
     'zh-hant' => 'zh-TW',
@@ -126,8 +137,9 @@ function sfgovpl_preprocess_html(&$variables) {
   $pageInfo = [];
   $pageInfo['current_language'] = isset($gTranslatePrefixMap[$currentLanguage]) ? $gTranslatePrefixMap[$currentLanguage] : $currentLanguage;
   $isFront = \Drupal::service('path.matcher')->isFrontPage();
-  if ($node instanceof NodeInterface) {
-    $theNode = \Drupal::entityTypeManager()->getStorage('node')->load($node->id());
+
+  if (!empty($variables['node']) && $variables['node'] instanceof NodeInterface && $currentRoute->getRouteName() == 'entity.node.canonical') {
+    $theNode = $variables['node'];
     $pageInfo['nid'] = $theNode->id();
     $pageInfo['nurl'] = $theNode->toUrl()->toString();
     $langs = $theNode->getTranslationLanguages();

--- a/web/themes/custom/sfgovpl/includes/node.inc
+++ b/web/themes/custom/sfgovpl/includes/node.inc
@@ -1,10 +1,12 @@
 <?php
 
+/**
+ * @file
+ * Preprocess functions for 'node' theme hooks.
+ */
+
 use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\node\Entity\Node;
-use Drupal\eck\Entity\EckEntityBundle;
-use Drupal\Core\Entity;
-use Drupal\file\Entity\File;
 use Drupal\views\Views;
 use Drupal\image\Entity\ImageStyle;
 use Drupal\Core\Url;
@@ -14,18 +16,31 @@ use Drupal\Core\Link;
  * Implements hook_preprocess_node().
  */
 function sfgovpl_preprocess_node(&$variables) {
-  if(!empty($variables['node'])) {
-    $content_type = $variables['node']->getType();
-    if ($content_type == 'department' && $variables['view_mode'] == 'full') {
-      $variables['dept_fields'] = dept_page_fields();
-      sfgovpl_add_regions_to_node(['department_news'], $variables);
-      sfgovpl_add_regions_to_node(['department_events'], $variables);
-    }
-    if($content_type == 'topic') {
-      $variables['service_section_ids'] = topic_page_services();
-    }
-    if($content_type == 'public_body') {
-      $variables['public_body_fields'] = public_body_page_fields();
+  // Make sure we have a node object that works on revisions, diffs, etc.
+  _sfgovpl_node_object($variables);
+
+  if (!empty($variables['node']) && $variables['node'] instanceof NodeInterface) {
+    $node = $variables['node'];
+    $content_type = $node->bundle();
+
+    if ($variables['view_mode'] == 'full') {
+      switch ($content_type) {
+        case 'department':
+          $variables['dept_fields'] = dept_page_fields($node);
+          sfgovpl_add_regions_to_node([
+            'department_news',
+            'department_events',
+          ], $variables);
+          break;
+
+        case 'topic':
+          $variables['service_section_ids'] = topic_page_services($node);
+          break;
+
+        case 'public_body':
+          $variables['public_body_fields'] = public_body_page_fields($node);
+          break;
+      }
     }
 
     // If the node being displayed is a translation, add a "notranslate" wrapper
@@ -107,13 +122,14 @@ function sfgovpl_preprocess_node__meeting__teaser(&$variables) {
   }
 }
 
-/*
-* retrieve the transaction ids in field_department_services that will be excluded from "more services" section on topic page
-* send the list of ids to a twig var which will then get passed to view contextual filters via twig_tweak
-*/
-function topic_page_services() {
-  $node = \Drupal::request()->attributes->get('node');
-  if($node) {
+/**
+ * Retrieve the transaction ids in field_department_services that will be
+ * excluded from "more services" section on topic page send the list of ids to a
+ * Twig var which will then get passed to view contextual filters via
+ * twig_tweak.
+ */
+function topic_page_services($node) {
+  if (!empty($node)) {
     if($node->hasField('field_department_services')) {
       $services = $node->get('field_department_services');
       if(!empty($services->getValue())) {
@@ -122,7 +138,7 @@ function topic_page_services() {
           $serviceSectionId = $service->getValue()['target_id'];
           $serviceSectionLoaded = Paragraph::load($serviceSectionId);
 
-          // load the paragraph and get the transactions
+          // Load the paragraph and get the transactions.
           $topicTransactions = $serviceSectionLoaded->get('field_dept_service_sect_services')->getValue();
           for($i=0; $i<count($topicTransactions); $i++) {
             $txId = $topicTransactions[$i]['target_id'];
@@ -136,8 +152,7 @@ function topic_page_services() {
   return null;
 }
 
-function dept_page_fields() {
-  $node = \Drupal::request()->attributes->get('node');
+function dept_page_fields($node) {
   $theFields = array(
     'featured_items' => array(),
     'services' => array(),
@@ -452,9 +467,8 @@ function dept_page_fields() {
   return $theFields;
 }
 
-function public_body_page_fields() {
+function public_body_page_fields($node) {
   $styleThumbnail = ImageStyle::load('thumbnail');
-  $node = \Drupal::request()->attributes->get('node');
   $theFields = array(
     'featured_items' => array(),
     'services' => array(),

--- a/web/themes/custom/sfgovpl/includes/node.inc
+++ b/web/themes/custom/sfgovpl/includes/node.inc
@@ -7,6 +7,7 @@
 
 use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\node\Entity\Node;
+use Drupal\node\NodeInterface;
 use Drupal\views\Views;
 use Drupal\image\Entity\ImageStyle;
 use Drupal\Core\Url;

--- a/web/themes/custom/sfgovpl/includes/page.inc
+++ b/web/themes/custom/sfgovpl/includes/page.inc
@@ -1,36 +1,34 @@
 <?php
 
-function sfgovpl_preprocess_page(&$variables) {
+/**
+ * @file
+ * Preprocess functions for the 'page' theme hooks.
+ */
 
-// The following tests the error messages.
-
-//  $messenger = Drupal::messenger();
-//  $messenger->addError('Error occurred');
-//  $messenger->addMessage('Info message');
-//  $messenger->addWarning('Warning message');
-//  $messenger->addStatus('Status message');
-
-}
+use Drupal\node\NodeInterface;
 
 /**
  * Implements theme_preprocess_HOOK().
  */
 function sfgovpl_preprocess_page__node__campaign(&$variables) {
-  // Conditionally render Logo or Title.
+  // Make sure we have a node object that works on revisions, diffs, etc.
+  _sfgovpl_node_object($variables);
+
+  if (!empty($variables['node']) && $variables['node'] instanceof NodeInterface) {
     $node = $variables['node'];
-    
-    if (!empty($node)) {
-      if ($node->field_logo->entity) {
-        $variables['campaign_branding'] = $node->field_logo->view([
-          'type' => 'image',
-          'label' => 'hidden',
-          'settings' => array(
-            'image_style' => 'campaign_logo',
-          ),
-        ]);
-      }
-      else {
-        $variables['campaign_branding'] = [
+
+    // Conditionally render Logo or Title.
+    if ($node->field_logo->entity) {
+      $variables['campaign_branding'] = $node->field_logo->view([
+        'type' => 'image',
+        'label' => 'hidden',
+        'settings' => [
+          'image_style' => 'campaign_logo',
+        ],
+      ]);
+    }
+    else {
+      $variables['campaign_branding'] = [
         '#markup' => '<h1>' . $node->label() . '</h1>',
       ];
     }

--- a/web/themes/custom/sfgovpl/includes/suggestions.inc
+++ b/web/themes/custom/sfgovpl/includes/suggestions.inc
@@ -1,23 +1,42 @@
 <?php
+
 /**
- * @param array $suggestions
- * @param array $variables
- *
- * @return array
+ * @file
+ * Alter hook implementations for template suggestions.
  */
-function sfgovpl_theme_suggestions_page_alter(array &$suggestions, array $variables){
+
+use Drupal\node\NodeInterface;
+
+/**
+ * Implements hook_theme_suggestions_HOOK_alter().
+ */
+function sfgovpl_theme_suggestions_page_alter(array &$suggestions, array $variables) {
   $http_error_suggestions = [
     'system.404' => 'page__404',
   ];
 
+  // @todo I believe we can remove this, as suggestions for this have since been
+  // added to Drupal core.
   $route_name = \Drupal::routeMatch()->getRouteName();
   if (isset($http_error_suggestions[$route_name])) {
     $suggestions[] = $http_error_suggestions[$route_name];
   }
 
-  // Add content type suggestions.
-  if ($node = \Drupal::request()->attributes->get('node')) {
-    array_splice($suggestions, 1, 0, 'page__node__' . $node->getType());
+  // Make sure we have a node object that works on revisions, diffs, etc.
+  _sfgovpl_node_object($variables);
+
+  if (!empty($variables['node'])) {
+    if ($variables['node'] instanceof NodeInterface) {
+      $node = $variables['node'];
+    }
+    elseif (!empty($variables['node_revision'])) {
+      $node = $variables['node_revision'];
+    }
+
+    if (!empty($node)) {
+      // Add content type suggestions.
+      array_splice($suggestions, 1, 0, 'page__node__' . $node->bundle());
+    }
   }
 
   return $suggestions;

--- a/web/themes/custom/sfgovpl/sfgovpl.theme
+++ b/web/themes/custom/sfgovpl/sfgovpl.theme
@@ -1,4 +1,7 @@
 <?php
+
+use Drupal\node\NodeInterface;
+
 /**
  * @file
  * Theme hooks for SFGOV.
@@ -8,4 +11,54 @@
 $includes_path = dirname(__FILE__) . '/includes/*.inc';
 foreach (glob($includes_path) as $filename) {
   require_once dirname(__FILE__) . '/includes/' . basename($filename);
+}
+
+/**
+ * Centralize code to get node object in various hooks based on route.
+ *
+ * Some routes, like revisions and inline diffs, do not provide a node object.
+ * In these cases $node is simply a nid string. We need to make sure we have a
+ * real node object to work with.
+ */
+function _sfgovpl_node_object(&$variables) {
+  // If we already have a node object, we do NOT want to make any changes here.
+  if (!empty($variables['node']) && $variables['node'] instanceof NodeInterface) {
+    return;
+  }
+
+  // This code resolves issues where $variables['node'] does not exist, or is
+  // simply a node id string, such as preprocess and suggestion hooks like:
+  // hook_preprocess_html(), hook_preprocess_page(), and
+  // hook_theme_suggestions_HOOK_alter().
+  $route_name = \Drupal::routeMatch()->getRouteName();
+  switch ($route_name) {
+    case 'entity.node.canonical':
+    case 'entity.node.latest_version':
+    case 'public_preview.preview_link':
+      $nid = \Drupal::routeMatch()->getRawParameter('node');
+      $variables['node'] = \Drupal::entityTypeManager()->getStorage('node')->load($nid);
+      break;
+
+    case 'entity.node.preview':
+      $variables['node'] = \Drupal::routeMatch()->getParameter('node_preview');
+      break;
+
+    case 'entity.node.revision':
+      $nid = \Drupal::routeMatch()->getRawParameter('node');
+      $variables['node'] = \Drupal::entityTypeManager()->getStorage('node')->load($nid);
+      // When viewing a revision, node_revision is the node being viewed, and
+      // node is a $nid string. In order to offer a page--node--TYPE suggestion,
+      // we substitute node_revision for node, so we can use $node->bundle. 🙄
+      // @see: web/themes/custom/sfgovpl/includes/suggestions.inc
+      $rid = \Drupal::routeMatch()->getRawParameter('node_revision');
+      $variables['node_revision'] = \Drupal::entityTypeManager()->getStorage('node')->loadRevision($rid);
+    break;
+
+    case 'diff.revisions_diff':
+      $nid = \Drupal::routeMatch()->getRawParameter('node');
+      $variables['node'] = \Drupal::entityTypeManager()->getStorage('node')->load($nid);
+      break;
+
+    return $variables;
+  }
 }


### PR DESCRIPTION
for all kinds of routes including:

- node view (necessary for non-node hooks, like html, page, and suggestions)
- revisions
- previews
- public previews
- diffs (coming soon)

_Note:  This code was split out from #739, which is getting some design changes, because it is needed for #766._