### PR TITLE
Track form load errors, guard against ad blockers

### DIFF
--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -79,10 +79,19 @@
       })
     }
 
-    var amplitude = window.amplitude.getInstance()
-    var amp = function(eventName, data) {
-      amplitude.logEvent(eventName, Object.assign(data, amplitudeData))
-    }
+    var amp = (function() {
+      var amplitude
+      var log = function (event, data) {
+        console.log('Form event (no amplitude):', event, data)
+      }
+      return function(eventName, data) {
+        if (!amplitude && window.amplitude) {
+          amplitude = window.amplitude.getInstance()
+          log = amplitude.logEvent.bind(amplitude)
+        }
+        log(eventName, Object.assign(data, amplitudeData))
+      }
+    })()
 
     amp('window.load', { load_time: loadTime })
 

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -146,7 +146,8 @@
     }
 
     time = Date.now()
-    Formio.createForm(el, el.getAttribute('data-source'), options)
+    var dataSource = el.getAttribute('data-source')
+    Formio.createForm(el, dataSource, options)
       .then(function(form) {
         amp('form.load', { load_time: Date.now() - time })
 
@@ -204,6 +205,12 @@
           if (confirmationURL) {
             window.location = confirmationURL
           }
+        })
+      })
+      .catch(error => {
+        amp('form.loadError', {
+          url: dataSource,
+          error: error
         })
       })
 

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -59,7 +59,7 @@
 (function() {
 
   var time = Date.now()
-    
+
   var confirmationURL = {{ paragraph.field_formio_confirmation_url.value is empty ? 
     "null" : 
     paragraph.field_formio_confirmation_url.value|json_encode(constant('JSON_PRETTY_PRINT'))|raw  

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -60,9 +60,10 @@
 
   var time = Date.now()
 
-  var confirmationURL = {{ paragraph.field_formio_confirmation_url.value is empty ? 
-    "null" : 
-    paragraph.field_formio_confirmation_url.value|json_encode(constant('JSON_PRETTY_PRINT'))|raw  
+  var confirmationURL = {{
+    paragraph.field_formio_confirmation_url.value is empty
+      ? "null"
+      : paragraph.field_formio_confirmation_url.value|json_encode(constant('JSON_PRETTY_PRINT'))|raw
   }}
 
   window.addEventListener('load', function() {

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -166,18 +166,20 @@
           })
         })
 
-        //perform sfoptions, hide certain elements
-        if (options.sfoptions && options.sfoptions.hide instanceof Object) {
+        var sfoptions = options.sfoptions || {}
+        // perform sfoptions, hide certain elements
+        if (sfoptions.hide instanceof Object) {
           customHideElements(options.sfoptions.hide)
         }
         // add css class to element(by id)
-        if (options.sfoptions && options.sfoptions.addClass) {
+        if (sfoptions.addClass) {
           customAddCssClassById(options.sfoptions.addClass)
         }
         // if cookies are defined, populate the form field with cookie value.
-        if (options.sfoptions instanceof Object && options.sfoptions.cookies) {
+        if (sfoptions.cookies) {
           manageFormCookies(options.sfoptions.cookies, form, true)
         }
+
         // perform custom action on nextPage event
         form.on('nextPage', function() {
           // set form cookies, if there are any


### PR DESCRIPTION
**UPDATE**: I'm hijacking this PR to also fix the issue of forms failing when ad blockers prevent Amplitude's JS from loading. The technique is to have the `amp()` function to log to the console _unless_ `window.amplitude` is truthy, in which case it swaps out the console logger for `window.amplitude.getInstance().logEvent()`.

As discussed with @jacine, @zakiya, and @nicolesque [in Slack](https://sfdigitalservices.slack.com/archives/C010PJ7HJR3/p1610058130031400), we don't currently have any way of tracking when forms completely fail to load from form.io. This PR attempts to address that by catching the promise that rejects when the form fails to load and fires a (newly minted) `form.loadError` event to Amplitude.

We should be able to test this by adding a form page with a bad data source URL—either a non-existent or malformed URL, or an existing form.io form or resource that's not publicly visible.