### PR TITLE
Update Lando Configuration for Xdebug 3 and Composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,7 +111,8 @@ Thumbs.db
 !web/core/**/*.gz
 
 # visual code config
-.vscode
+.vscode/*
+!.vscode/launch.json.example
 
 # secrets
 # These are created in the build process by circleci

--- a/.lando.yml
+++ b/.lando.yml
@@ -4,12 +4,12 @@ config:
   framework: drupal8
   site: sfgov
   id: 91d50373-c4cf-40e4-a646-cb73e16a140c
-  composer_version: 1-latest
-  # Note: xDebug negatively impacts performance. Leaving it off globally, and
-  # enabling it as needed, is recommended. The custom tooling commands (below)
-  # can be used toggle it on (lando xdebug-on) /off (lando xdebug-off).
-  # xdebug: true
   webroot: web
+  composer_version: 1-latest
+  # Note: Xdebug negatively impacts performance. It should be toggled on/off
+  # using the custom tooling commands, 'lando xdebug-on' and 'lando xdebug-off',
+  # as needed.
+  # xdebug: develop,debug
 services:
   appserver:
     run:
@@ -21,6 +21,8 @@ services:
           "http://sfgov.lndo.site", "goutte": { "guzzle_parameters": { "verify":
           false } } }, "Drupal\\DrupalExtension": { "drush": { "root":
           "/app/web" } } } }
+        XDEBUG_MODE: develop,debug
+        XDEBUG_SESSION_START: LANDO
 tooling:
   behat:
     service: appserver

--- a/.lando.yml
+++ b/.lando.yml
@@ -4,6 +4,7 @@ config:
   framework: drupal8
   site: sfgov
   id: 91d50373-c4cf-40e4-a646-cb73e16a140c
+  composer_version: 1-latest
   # Note: xDebug negatively impacts performance. Leaving it off globally, and
   # enabling it as needed, is recommended. The custom tooling commands (below)
   # can be used toggle it on (lando xdebug-on) /off (lando xdebug-off).

--- a/.vscode/launch.json.example
+++ b/.vscode/launch.json.example
@@ -1,0 +1,15 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Listen for Xdebug",
+      "type": "php",
+      "request": "launch",
+      "port": 9003,
+      "log": true,
+      "pathMappings": {
+        "/app": "${workspaceRoot}",
+      }
+    }
+  ]
+}

--- a/composer-manifest.yaml
+++ b/composer-manifest.yaml
@@ -1,5 +1,4 @@
 packages:
-    ajgl/breakpoint-twig-extension: 0.3.4
     alchemy/zippy: 0.4.9
     asm89/stack-cors: 1.3.0
     behat/behat: v3.7.0
@@ -123,7 +122,6 @@ packages:
     drupal/token: 1.7.0
     drupal/twig_tweak: 2.6.0
     drupal/twig_vardumper: 1.3.0
-    drupal/twig_xdebug: 1.2.0
     drupal/user_email_textformat: 1.5.0
     drupal/variationcache: 1.0.0
     drupal/video_embed_field: 2.4.0

--- a/composer.json
+++ b/composer.json
@@ -126,8 +126,7 @@
         "drupal/devel": "^1.2",
         "drupal/drupal-extension": "^3.1",
         "drupal/search_kint": "^1.0",
-        "drupal/stage_file_proxy": "^1.1",
-        "drupal/twig_xdebug": "^1.0"
+        "drupal/stage_file_proxy": "^1.1"
     },
     "conflict": {
         "drupal/drupal": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "67fc687bfdf2e45c00ef05772c600d66",
+    "content-hash": "a1972520c75b2bd74971894747936eba",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -13593,66 +13593,6 @@
     ],
     "packages-dev": [
         {
-            "name": "ajgl/breakpoint-twig-extension",
-            "version": "0.3.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ajgarlag/AjglBreakpointTwigExtension.git",
-                "reference": "13ee39406dc3d959c5704b462a3dbc3cbf088f16"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ajgarlag/AjglBreakpointTwigExtension/zipball/13ee39406dc3d959c5704b462a3dbc3cbf088f16",
-                "reference": "13ee39406dc3d959c5704b462a3dbc3cbf088f16",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.6",
-                "twig/twig": "^1.14|^2.0"
-            },
-            "require-dev": {
-                "symfony/framework-bundle": "^2.7|^3.2|^4.1",
-                "symfony/phpunit-bridge": "^3.4|^4.1",
-                "symfony/twig-bundle": "^2.7|^3.2|^4.1"
-            },
-            "suggest": {
-                "ext-xdebug": "The Xdebug extension is required for the breakpoint to work",
-                "symfony/framework-bundle": "The framework bundle to integrate the extension into Symfony",
-                "symfony/twig-bundle": "The twig bundle to integrate the extension into Symfony"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "0.3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Ajgl\\Twig\\Extension\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Antonio J. García Lagar",
-                    "email": "aj@garcialagar.es",
-                    "homepage": "http://aj.garcialagar.es",
-                    "role": "developer"
-                }
-            ],
-            "description": "Twig extension to set breakpoints",
-            "homepage": "https://github.com/ajgarlag/AjglBreakpointTwigExtension",
-            "keywords": [
-                "Xdebug",
-                "breakpoint",
-                "twig"
-            ],
-            "time": "2019-04-10T11:41:26+00:00"
-        },
-        {
             "name": "behat/behat",
             "version": "v3.7.0",
             "source": {
@@ -14960,51 +14900,6 @@
             "homepage": "https://www.drupal.org/project/stage_file_proxy",
             "support": {
                 "source": "https://git.drupalcode.org/project/stage_file_proxy"
-            }
-        },
-        {
-            "name": "drupal/twig_xdebug",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/twig_xdebug.git",
-                "reference": "8.x-1.2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/twig_xdebug-8.x-1.2.zip",
-                "reference": "8.x-1.2",
-                "shasum": "fa4dfc8edebc0628257b998ca6521790c52250e8"
-            },
-            "require": {
-                "ajgl/breakpoint-twig-extension": "^0.3.4",
-                "drupal/core": "^8 || ^9"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "drupal": {
-                    "version": "8.x-1.2",
-                    "datestamp": "1588041097",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "charginghawk",
-                    "homepage": "https://www.drupal.org/user/2626341"
-                }
-            ],
-            "description": "Enables Xdebug breakpoints in Twig.",
-            "homepage": "https://www.drupal.org/project/twig_xdebug",
-            "support": {
-                "source": "https://git.drupalcode.org/project/twig_xdebug"
             }
         },
         {


### PR DESCRIPTION
A [new version](https://xdebug.org/docs/upgrade_guide) of Xdebug came out last month.  The next time you rebuild your Lando instance, you will get v3. v2 settings are not compatible with v3.  You would also get Composer 2, which will not work with our code base.  This PR:

1. Updates the Xdebug settings for v3.
2. Locks Lando's composer version to 1.x.
3. Removes Twig Xdebug module. Twig tweak actually provides the ability to use `{{ drupal_breakpoint() }}`, which is basically the same thing.

We can/should still use the tooling commands to toggle Xdebug, e.g. `lando xdebug-on`.

---

## Instructions

1. Rebuilding your Lando instance is required: `lando rebuild -y`
2. If you use VSCode, you'll need to update the `launch.json` config. Specifically, the default port is now 9003. Here's my configuration:

```json
{
  "version": "0.2.0",
  "configurations": [
    {
      "name": "Listen for Xdebug",
      "type": "php",
      "request": "launch",
      "port": 9003,
      "log": true,
      "pathMappings": {
        "/app": "${workspaceRoot}",
      }
    }
  ]
}
```