### PR TITLE
Add {lang} placeholder support in confirmation URL

### DIFF
--- a/config/field.field.paragraph.form_io.field_formio_confirmation_url.yml
+++ b/config/field.field.paragraph.form_io.field_formio_confirmation_url.yml
@@ -15,7 +15,9 @@ field_name: field_formio_confirmation_url
 entity_type: paragraph
 bundle: form_io
 label: 'Confirmation Page URL'
-description: 'Specify a confirmation page URL, if desired. Use the <a href="/node/add/form_confirmation_page" target="_blank">form_confirmation_page</a> content type to add a new confirmation page.'
+description: |
+  Successful submissions will redirect to the <a href="/node/add/form_confirmation_page" target="_blank">confirmation page</a> URL.
+  The optional <code>{lang}</code> placeholder will be replaced with the form language, e.g. <code>/{lang}/my-form/confirm</code>.
 required: false
 translatable: false
 default_value: {  }

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -202,7 +202,9 @@
           }
 
           if (confirmationURL) {
-            window.location = confirmationURL
+            window.location = form.language
+              ? confirmationURL.replace('{lang}', form.language)
+              : confirmationURL.replace('{lang}/', '')
           }
         })
       })


### PR DESCRIPTION
This adds support for a `{lang}` placeholder in form page confirmation URLs. I updated the field description, so now it looks like this when you're editing:

![image](https://user-images.githubusercontent.com/113896/105107985-20e96080-5a6e-11eb-801c-86793b1ef79f.png)

Here's an acceptance test:

```feature
Feature: form page confirmation URL

  Scenario: It works without a "{lang}" placeholder
   Given a form page
     And the confirmation URL is "/my-form/confirm"
    When I submit the form
    Then the URL should be "/my-form/confirm"

  Scenario: It works with a "{lang}" placeholder
   Given a form page
     And the confirmation URL is "/{lang}/my-form/confirm"
     And the page is translated in Spanish
    When I visit the form in Spanish
     And I submit the form
    Then the URL should be "/es/my-form/confirm"
```

cc: @nicolesque