### PR TITLE
Hotfix for missing form.language getter

### DIFF
--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -215,8 +215,10 @@
           }
 
           if (confirmationURL) {
-            window.location = form.language
-              ? confirmationURL.replace('{lang}', form.language)
+            // see: <https://github.com/formio/formio.js/pull/3592> for more details
+            var lang = form.language || form.options.language
+            window.location = lang
+              ? confirmationURL.replace('{lang}', lang)
               : confirmationURL.replace('{lang}/', '')
           }
         })


### PR DESCRIPTION
This is a fast follow to #784. I was testing that PR with a newer version of formio.js that includes https://github.com/formio/formio.js/pull/3592, which introduces a `language` getter to the Webform class. Without it, `form.language` always returns `undefined`. The fix is to fall back on `form.options.language`.