### PR TITLE
Alias "zh-TW" and "zh" to "zh-hant" in form confirmation URLs

### DIFF
--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -223,7 +223,7 @@
             // see: <https://github.com/formio/formio.js/pull/3592> for more details
             var formLang = form.language || form.options.language
             var lang = formLanguageMap[formLang] || formLang
-            window.location = lang
+            window.location = lang && lang !== 'en'
               ? confirmationURL.replace('{lang}', lang)
               : confirmationURL.replace('{lang}/', '')
           }

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -66,6 +66,11 @@
       : paragraph.field_formio_confirmation_url.value|json_encode(constant('JSON_PRETTY_PRINT'))|raw
   }}
 
+  var formLanguageMap = {
+    zh:       'zh-hant',
+    'zh-TW':  'zh-hant'
+  }
+
   window.addEventListener('load', function() {
     var loadTime = Date.now() - time
 
@@ -216,7 +221,8 @@
 
           if (confirmationURL) {
             // see: <https://github.com/formio/formio.js/pull/3592> for more details
-            var lang = form.language || form.options.language
+            var formLang = form.language || form.options.language
+            var lang = formLanguageMap[formLang] || formLang
             window.location = lang
               ? confirmationURL.replace('{lang}', lang)
               : confirmationURL.replace('{lang}/', '')


### PR DESCRIPTION
This adds a mapping of the `zh-TW` and `zh` language codes to `zh-hant` in form confirmation URLs with the `{lang}` placeholder to work around inconsistencies between Drupal, Google Translate, and Phrase.

During the first pass at testing I noticed that we don't support `/en/`-prefixed URLs, so in 1347b1e I opted to strip the `{lang}/` bit from the confirmation URL if the language is `en`.

@aekong LMK if you think this should live somewhere else. It might be good to have all of our language code mappings in one place, but I might need your help figuring out where that would be so that they're available to all of the scripts that need them. These are the other two I found:

https://github.com/SFDigitalServices/sfgov/blob/4fa402afe2c5e1badd2b71771d888e80708b2470/web/themes/custom/sfgovpl/src/js/translate.js#L168-L170

https://github.com/SFDigitalServices/sfgov/blob/1d246f67ff47c0745d01474a89c6aa80698daa6a/web/themes/custom/sfgovpl/includes/html.inc#L133-L136

There is one other [mapping](https://github.com/SFDigitalServices/formio-sfds/blob/b2acc4e1ea0297021975ab316a6de73ab332ba9c/src/patch.js#L361-L364) in the formio theme, but it's specific to Flatpickr, which is much pickier (sorry) about language codes. 🙃 