### PR TITLE
Log form submission metadata in amplitude

### DIFF
--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -111,7 +111,11 @@
         return { } // just log the event
       },
       submitDone: function (submission) {
-        return { } // just log the event
+        return {
+          id: submission._id,
+          form: submission.form,
+          project: submission.project
+        }
       },
       error: function (message) {
         return { error: message }


### PR DESCRIPTION
This adds three keys to the form `submitDone` event handler that generates data for Amplitude:

1. `id` is the unique submission ID (`_id` because Mongo)
2. `form` is the unique form ID
3. `project` is the unique project ID

This should allow us to get more information about odd form submissions and figure out where invalid autocomplete values are coming from (browser, version, user journey, etc.).

🔒 **None of the submission data is included in this payload.**