### PR TITLE
upgrade formio-sfds from 7.0.2 to 7.2.0

### DIFF
--- a/config/sfgov_formio.settings.yml
+++ b/config/sfgov_formio.settings.yml
@@ -1,2 +1,2 @@
 formio_version: '4.11.2'
-formio_sfds_version: '7.0.2'
+formio_sfds_version: '7.2.0'


### PR DESCRIPTION
See the release notes for the two releases since 7.0.2:
- [7.1.0](https://github.com/SFDigitalServices/formio-sfds/releases/tag/v7.1.0)
- [7.2.0](https://github.com/SFDigitalServices/formio-sfds/releases/tag/v7.2.0)