### PR TITLE
Silence form.componentError Amplitude events + fix form.error payloads

### DIFF
--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -156,10 +156,7 @@
         return { error: message }
       },
       componentError: function (error) {
-        return {
-          component: error.component.key,
-          error: error.message
-        }
+        return false
       },
       prevPage: function (data) {
         return { page_index: data.page }

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -89,7 +89,7 @@
       var log = function (event, data) {
         console.log('Form event (no amplitude):', event, data)
       }
-      return function(eventName, data) {
+      return function (eventName, data) {
         if (!amplitude && window.amplitude) {
           amplitude = window.amplitude.getInstance()
           log = amplitude.logEvent.bind(amplitude)

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -122,8 +122,35 @@
           project: submission.project
         }
       },
-      error: function (message) {
-        return { error: message }
+      error: function (messageOrErrors) {
+        if (Array.isArray(messageOrErrors)) {
+          /**
+           * If we get an array of errors, create a mapping of component keys
+           * to error messages, with exactly one entry per component. Only the
+           * first validation message will be sent to Amplitude.
+           *
+           * {
+           *   [component.key]: component.message
+           * }
+           *
+           * <https://github.com/formio/formio.js/blob/v4.11.2/src/Webform.js#L1208>
+           */
+          var errors = {}
+          messageOrErrors.forEach(function(error) {
+            if (error && error.component && error.message) {
+              errors[error.component.key] = error.message
+            }
+          })
+          return {
+            errors: components
+          }
+        } else if (typeof messageOrErrors === 'string') {
+          // in some instances, formiojs sends a single error message:
+          // <https://github.com/formio/formio.js/blob/v4.11.2/src/Webform.js#L1048>
+          return {
+            message: messageOrErrors
+          }
+        }
       },
       submitError: function (message) {
         return { error: message }

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -135,14 +135,14 @@
            *
            * <https://github.com/formio/formio.js/blob/v4.11.2/src/Webform.js#L1208>
            */
-          var errors = {}
+          var components = {}
           messageOrErrors.forEach(function(error) {
             if (error && error.component && error.message) {
-              errors[error.component.key] = error.message
+              components[error.component.key] = error.message
             }
           })
           return {
-            errors: components
+            components: components
           }
         } else if (typeof messageOrErrors === 'string') {
           // in some instances, formiojs sends a single error message:

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -130,7 +130,9 @@
            * first validation message will be sent to Amplitude.
            *
            * {
-           *   [component.key]: component.message
+           *   errors: {
+           *     [component.key]: component.message
+           *   }
            * }
            *
            * <https://github.com/formio/formio.js/blob/v4.11.2/src/Webform.js#L1208>
@@ -142,7 +144,7 @@
             }
           })
           return {
-            components: components
+            errors: components
           }
         } else if (typeof messageOrErrors === 'string') {
           // in some instances, formiojs sends a single error message:


### PR DESCRIPTION
This is for SG-1314. My working theory is that our `form.error` events aren't structured properly—maybe because they're arrays, or they're too big?—and Amplitude is throwing them away. We're currently only collecting `form.componentError` events, which bubble up from every single component validation failure, and could include practically every single keystroke in some text/email/phone/etc. fields. 😱 

### Tasks
- [x] Disable the `form.componentError` events
- [x] Get `form.error` events showing up in Amplitude
- [x] Include component info in `form.error` events so that we can filter and segment them

### Due diligence
There are a couple of different places that formio.js [emits `error` events](https://github.com/formio/formio.js/search?l=JavaScript&q=emit+error):

- [`emit('error', errors)`](https://github.com/formio/formio.js/blob/v4.11.2/src/Webform.js#L1208) in [`showErrors()`](https://github.com/formio/formio.js/search?q=showErrors), which gets called in a bunch of different places, but only emits an event in a few. Notably, `errors` is an array of error objects which should have `component` and `message` keys. We should be able to construct a mapping of component keys to error messages from that.

- [`emit('error', false)`](https://github.com/formio/formio.js/blob/v4.11.2/src/Webform.js#L1048) when there are no "alerts". I think this case is meant to signal a form's transition from an invalid to valid state.