### PR TITLE
Rename form.submitDone "form.id" key to "form.submission_id"

### DIFF
--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -117,9 +117,11 @@
       },
       submitDone: function (submission) {
         return {
-          id: submission._id,
-          form: submission.form,
-          project: submission.project
+          submission: {
+            id: submission._id,
+            form: submission.form,
+            project: submission.project
+          }
         }
       },
       error: function (message) {

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -117,11 +117,7 @@
       },
       submitDone: function (submission) {
         return {
-          submission: {
-            id: submission._id,
-            form: submission.form,
-            project: submission.project
-          }
+          submission_id: submission._id
         }
       },
       error: function (message) {


### PR DESCRIPTION
I noticed when debugging events for #797 that the change in #790 made for some kind of awkwardly shaped event objects:

key | what it represents
:--- | :---
`form.form` | The form ID
`form.id` | The _submission_ ID
`form.project` | The ID of the project ("SFDS") in which the form lives on form.io
`form.url` | The form data source URL (unchanged)

The form and project IDs aren't really useful since we have form data source URL (`form.url`) already. This PR removes those two properties and renames `form.id`, which is both ambiguous and wrong, to `form.submission_id`.