### PR TITLE
Add form page (panel) title to next/prev page events

### DIFF
--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -159,10 +159,16 @@
         return false
       },
       prevPage: function (data) {
-        return { page_index: data.page }
+        return {
+          page_index: data.page,
+          page_title: getPageTitle(data, this)
+        }
       },
       nextPage: function (data) {
-        return { page_index: data.page }
+        return {
+          page_index: data.page,
+          page_title: getPageTitle(data, this)
+        }
       },
       wizardNavigationClicked: function (page) {
         return {
@@ -263,6 +269,16 @@
           error: error
         })
       })
+
+    function getPageTitle(data, form) {
+      if (!form || !form.pages || form.pages.length === 0) {
+        return undefined
+      }
+      var page = form.pages[data.page]
+      return page && page.component
+        ? page.component.title
+        : undefined
+    }
 
     function customAddCssClassById(classes) {
       for (var key in classes) {

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -257,7 +257,7 @@
           }
         })
       })
-      .catch(error => {
+      .catch(function(error) {
         amp('form.loadError', {
           url: dataSource,
           error: error


### PR DESCRIPTION
This adds a `page_title` property to our `form.prevPage` and `form.nextPage` Amplitude events so that funnel analyses are easier to build and read, as reported in SG-1313.

⚠️ **Note**: page titles are whatever is stored in the form—not the panel title translations—even when viewed in English.

Also, c54e4ef replaces an arrow function (`=>`) that I added in a previous PR with the more legacy-browser-compatible `function` keyword.