### PR TITLE
[vaccine-sites] Gracefully fail when there's a connection timeout.

### DIFF
--- a/web/modules/custom/sfgov_vaccine/src/Controller/VaccineController.php
+++ b/web/modules/custom/sfgov_vaccine/src/Controller/VaccineController.php
@@ -94,11 +94,18 @@ class VaccineController extends ControllerBase {
    * Get data from the mircoservice.
    */
   public function dataFetch() {
-    $language = $this->languageManager()->getCurrentLanguage()->getId();
-    $url = $this->getAPIUrl() . '?lang=' . $language;
-    $request = $this->httpClient->get($url, ['http_errors' => FALSE]);
-    $response = $request->getBody();
 
+    try {
+      $language = $this->languageManager()->getCurrentLanguage()->getId();
+      $url = $this->getAPIUrl() . '?lang=' . $language;
+      $request = $this->httpClient->get($url, [
+        'http_errors' => FALSE,
+      ]);
+      $response = $request->getBody();
+    }
+    catch (ConnectException $e) {
+      $response = NULL;
+    }
     return Json::decode($response);
   }
 

--- a/web/modules/custom/sfgov_vaccine/src/Controller/VaccineController.php
+++ b/web/modules/custom/sfgov_vaccine/src/Controller/VaccineController.php
@@ -10,6 +10,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Component\Serialization\Json;
 use Drupal\Core\Template\Attribute;
 use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\ConnectException;
 
 /**
  * Creates the vaccine sites page.


### PR DESCRIPTION
Instead of throwing a white screen of confusion, we'll show an error message in the body of the page. 