### PR TITLE
only push language with existing key

### DIFF
--- a/web/modules/custom/sfgov_vaccine/src/Controller/VaccineController.php
+++ b/web/modules/custom/sfgov_vaccine/src/Controller/VaccineController.php
@@ -234,8 +234,10 @@ class VaccineController extends ControllerBase {
     $site_data_languages = $access_data['languages'];
     foreach ($site_data_languages as $short_key => $boolean) {
       if ($boolean === TRUE) {
-        $languages = $this->t($this->settings('languages.' . $short_key));
-        array_push($printed_languages, $languages);
+        $languages = $this->settings('languages.' . $short_key);
+        if (!empty($languages)) {
+          array_push($printed_languages, $this->t($languages));
+        }
       }
     }
 


### PR DESCRIPTION
It looks like new languages were added via https://github.com/SFDigitalServices/vaccination-site-microservice/pull/102, which weren't accounted for in the `sfgov_vaccine` module settings.  

This pr will prevent drupal's `t` function from attempting to translate an empty string (a lang code that doesn't exist in `/config/sfgov_vaccine.settings.yml`).  

Allowing the attempt caused the exception:
 ```
Uncaught PHP Exception InvalidArgumentException: "$string ("") must be a string.
```