### PR TITLE
[SG-1351] White screen on translated pages with event cards.

### DIFF
--- a/web/themes/custom/sfgovpl/src/js/exclude-from-gtranslate.js
+++ b/web/themes/custom/sfgovpl/src/js/exclude-from-gtranslate.js
@@ -10,12 +10,7 @@
         'London Breed',
         'Breed',
       ];
-
-      // Add Drupal translations to the do not translate list.
-      if (typeof drupalTranslations !== "undefined") {
-        const translations = Object.keys(drupalTranslations.strings[""]);
-        Array.prototype.push.apply(do_not_translate, translations);
-      }
+      
       $.each(do_not_translate, function (index, value) {
         $('P, A, SPAN, H1, H2, H3, H4, H5, H6, LI, div.field.__abstract, div.person-subtitle', context)
           .filter("*:contains(" + value + ")")

--- a/web/themes/custom/sfgovpl/templates/node/node--event--card.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--event--card.html.twig
@@ -22,7 +22,7 @@
   <div class="event-info">
     <p class="title">{{ label }}</p>
     <p class="description">
-      {{ start_date_time }}
+      {{ start_date_timestamp|date("l, F j") }}<br/>
     </p>
   </div>
 </a>

--- a/web/themes/custom/sfgovpl/templates/node/node--event--card.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--event--card.html.twig
@@ -1,5 +1,6 @@
 {% set start_date_time = content.field_start_date.0['#markup'] %}
-{% set end_date_time = content.field_end_date.0['#attributes']['datetime'] %}
+{% set start_date_timestamp = node.field_start_date.0.value %}
+
 {% set hasImage = false %}
 {% set eventClass = "date" %}
 {% if content.field_image|render|striptags %}
@@ -14,8 +15,8 @@
     </div>
   {% else %}
     <div class="event-date">
-      <div class="month">{{ start_date_time|date("F") }}</div>
-      <div class="date">{{ start_date_time|date("j") }}</div>
+      <div class="month">{{ start_date_timestamp|date("F") }}</div>
+      <div class="date">{{ start_date_timestamp|date("j") }}</div>
     </div>
   {% endif %}
   <div class="event-info">


### PR DESCRIPTION

- Google is doing the translation of “Wednesday”. For some reason I don’t understand, if I use date(“l”) instead of just printing the markup, the accented é appears in miércoles

- I think I permanently fixed the gibberish problem on gtranslate pages. At some point I tried using the list of Drupal’s translatable string to the donottranslate list via js. Included in that list are abbreviations for days of the week like “Sa, Su, Mo…” Chaos ensued.

