### PR TITLE
Accessibility scan errors

### DIFF
--- a/.circleci/scripts/tests/accessibility/accessibility-scan
+++ b/.circleci/scripts/tests/accessibility/accessibility-scan
@@ -4,9 +4,6 @@ set -eo pipefail
 
 npm install @axe-core/cli -g
 
-# get the chromedriver version compatible with this image's google chrome version
-CHROMEDRIVER_PATH="/usr/local/bin"
-
 GI_START_URL="$MULTIDEV_SITE_URL"
 
 if [ -n "$CIRCLE_PULL_REQUEST" ]; then
@@ -30,7 +27,7 @@ while read i; do
   echo $i | jq -r '"\(.test_id) \(.url)"'
   TEST_ID=$(echo $i | jq -r '"\(.test_id)"')
   URL=$(echo $i | jq -r '"\(.url)"')
-  SCAN_JSON_DATA=$(axe --stdout $URL  --chromedriver-path "$CHROMEDRIVER_PATH/chromedriver" | jq ".[0].violations")
+  SCAN_JSON_DATA=$(axe --stdout $URL | jq ".[0].violations")
   URL_PATH=$(echo "/${URL#*://*/}")
   V=$(echo $SCAN_JSON_DATA | jq length)
   A11Y_RESULTS_SLACK+="$URL_PATH ($V violations)\n"

--- a/.circleci/scripts/tests/accessibility/accessibility-scan
+++ b/.circleci/scripts/tests/accessibility/accessibility-scan
@@ -28,9 +28,14 @@ while read i; do
   TEST_ID=$(echo $i | jq -r '"\(.test_id)"')
   URL=$(echo $i | jq -r '"\(.url)"')
   SCAN_JSON_DATA=$(axe --stdout $URL | jq ".[0].violations")
+  SCAN_RESULT=$?
+  if [ $SCAN_RESULT -ne 0 ]; then
+    V="scan error"
+  else
+    V=$(echo $SCAN_JSON_DATA | jq length)" violations"
+  fi
   URL_PATH=$(echo "/${URL#*://*/}")
-  V=$(echo $SCAN_JSON_DATA | jq length)
-  A11Y_RESULTS_SLACK+="$URL_PATH ($V violations)\n"
+  A11Y_RESULTS_SLACK+="$URL_PATH ($V)\n"
   DATA=$(printf '{
     "result_id": "%s",
     "test_id": "%s",

--- a/.circleci/scripts/tests/run-tests
+++ b/.circleci/scripts/tests/run-tests
@@ -17,7 +17,7 @@ echo "GI_PASSING: $GI_PASSING"
 echo "GI_START_URL: $GI_START_URL"
 echo "PR: $PR"
 
-source ./.circleci/scripts/tests/accessibility/accessibility-scan
+source ./.circleci/scripts/tests/accessibility/accessibility-scan || true
 
 # exported vars from accessibility scan script execution
 # A11Y_RESULTS_SLACK


### PR DESCRIPTION
Accessibility scan post-build with [@axe-core/cli](https://www.npmjs.com/package/@axe-core/cli) sometimes fails with the helpful error
```
An error occurred while testing this page.
Please report the problem to: https://github.com/dequelabs/axe-cli/issues/
```
This pr prevents those failures from failing the build in circleci and reports the scan error with the equally helpful `scan error` in slack:

<img width="597" alt="Screen Shot 2021-04-27 at 10 30 03 PM" src="https://user-images.githubusercontent.com/19291154/116351254-332f1500-a7a8-11eb-9e69-a70d6d3319fb.png">
