### PR TITLE
Bump formio-sfds to 8.1.0

### DIFF
--- a/config/sfgov_formio.settings.yml
+++ b/config/sfgov_formio.settings.yml
@@ -1,2 +1,2 @@
 formio_version: 4.12.1
-formio_sfds_version: 8.0.0
+formio_sfds_version: 8.1.0


### PR DESCRIPTION
[This release](https://github.com/SFDigitalServices/formio-sfds/releases/tag/v8.1.0) adds a new component class and templates for the form.io `signature` component.

