### PR TITLE
SG-1422 - hide campaign instagram field from form and template display

### DIFF
--- a/config/core.entity_form_display.node.campaign.default.yml
+++ b/config/core.entity_form_display.node.campaign.default.yml
@@ -47,7 +47,7 @@ third_party_settings:
         - field_dept
         - field_links
       parent_name: ''
-      weight: 10
+      weight: 9
       format_type: fieldset
       region: content
       format_settings:
@@ -63,7 +63,7 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 12
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -148,25 +148,6 @@ content:
     third_party_settings: {  }
     type: image_image
     region: content
-  field_social_media_embed:
-    type: paragraphs
-    weight: 8
-    settings:
-      title: Paragraph
-      title_plural: Paragraphs
-      edit_mode: closed
-      closed_mode: summary
-      autocollapse: none
-      closed_mode_threshold: 0
-      add_mode: dropdown
-      form_display_mode: default
-      default_paragraph_type: _none
-      features:
-        add_above: '0'
-        collapse_edit_all: collapse_edit_all
-        duplicate: duplicate
-    third_party_settings: {  }
-    region: content
   field_spotlight:
     weight: 7
     settings:
@@ -214,30 +195,30 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 15
+    weight: 14
     settings: {  }
     region: content
     third_party_settings: {  }
   path:
     type: path
-    weight: 14
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 19
+    weight: 18
     region: content
     settings: {  }
     third_party_settings: {  }
   publish_state:
     type: scheduler_moderation
-    weight: 21
+    weight: 20
     region: content
     settings: {  }
     third_party_settings: {  }
   scheduler_settings:
-    weight: 17
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -245,7 +226,7 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 16
+    weight: 15
     region: content
     third_party_settings: {  }
   title:
@@ -260,13 +241,13 @@ content:
         maxlength_js: 65
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
   translation:
-    weight: 9
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 11
+    weight: 10
     settings:
       match_operator: CONTAINS
       size: 60
@@ -276,21 +257,22 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 20
+    weight: 19
     region: content
     settings: {  }
     third_party_settings: {  }
   unpublish_state:
     type: scheduler_moderation
-    weight: 18
+    weight: 17
     region: content
     settings: {  }
     third_party_settings: {  }
   url_redirects:
-    weight: 13
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_social_media_embed: true
   promote: true
   sticky: true

--- a/config/core.entity_form_display.node.campaign.default.yml
+++ b/config/core.entity_form_display.node.campaign.default.yml
@@ -47,7 +47,7 @@ third_party_settings:
         - field_dept
         - field_links
       parent_name: ''
-      weight: 9
+      weight: 10
       format_type: fieldset
       region: content
       format_settings:
@@ -63,7 +63,7 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 11
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -148,6 +148,24 @@ content:
     third_party_settings: {  }
     type: image_image
     region: content
+  field_social_media_embed:
+    type: paragraphs
+    weight: 9
+    region: content
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: ''
+      features:
+        collapse_edit_all: collapse_edit_all
+        duplicate: duplicate
+    third_party_settings: {  }
   field_spotlight:
     weight: 7
     settings:
@@ -195,30 +213,30 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 14
+    weight: 15
     settings: {  }
     region: content
     third_party_settings: {  }
   path:
     type: path
-    weight: 13
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 18
+    weight: 19
     region: content
     settings: {  }
     third_party_settings: {  }
   publish_state:
     type: scheduler_moderation
-    weight: 20
+    weight: 21
     region: content
     settings: {  }
     third_party_settings: {  }
   scheduler_settings:
-    weight: 16
+    weight: 17
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -226,7 +244,7 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 15
+    weight: 16
     region: content
     third_party_settings: {  }
   title:
@@ -247,7 +265,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 10
+    weight: 11
     settings:
       match_operator: CONTAINS
       size: 60
@@ -257,22 +275,21 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 19
+    weight: 20
     region: content
     settings: {  }
     third_party_settings: {  }
   unpublish_state:
     type: scheduler_moderation
-    weight: 17
+    weight: 18
     region: content
     settings: {  }
     third_party_settings: {  }
   url_redirects:
-    weight: 12
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
-  field_social_media_embed: true
   promote: true
   sticky: true

--- a/config/core.entity_view_display.node.campaign.default.yml
+++ b/config/core.entity_view_display.node.campaign.default.yml
@@ -52,7 +52,7 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_campaign_about:
-    weight: 6
+    weight: 7
     type: text_trimmed
     label: above
     settings:
@@ -70,7 +70,7 @@ content:
     region: content
   field_dept:
     type: entity_reference_label
-    weight: 7
+    weight: 8
     region: content
     label: above
     settings:
@@ -87,7 +87,7 @@ content:
     region: content
   field_links:
     type: link
-    weight: 8
+    weight: 9
     region: content
     label: above
     settings:
@@ -105,6 +105,15 @@ content:
     settings:
       image_style: campaign_logo
       image_link: ''
+    third_party_settings: {  }
+  field_social_media_embed:
+    type: entity_reference_revisions_entity_view
+    weight: 6
+    region: content
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
     third_party_settings: {  }
   field_spotlight:
     weight: 5
@@ -126,7 +135,6 @@ content:
     region: content
 hidden:
   field_campaign_theme: true
-  field_social_media_embed: true
   langcode: true
   links: true
   search_api_excerpt: true

--- a/config/core.entity_view_display.node.campaign.default.yml
+++ b/config/core.entity_view_display.node.campaign.default.yml
@@ -52,7 +52,7 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_campaign_about:
-    weight: 7
+    weight: 6
     type: text_trimmed
     label: above
     settings:
@@ -70,7 +70,7 @@ content:
     region: content
   field_dept:
     type: entity_reference_label
-    weight: 8
+    weight: 7
     region: content
     label: above
     settings:
@@ -87,7 +87,7 @@ content:
     region: content
   field_links:
     type: link
-    weight: 9
+    weight: 8
     region: content
     label: above
     settings:
@@ -106,15 +106,6 @@ content:
       image_style: campaign_logo
       image_link: ''
     third_party_settings: {  }
-  field_social_media_embed:
-    type: entity_reference_revisions_entity_view
-    weight: 6
-    label: hidden
-    settings:
-      view_mode: default
-      link: ''
-    third_party_settings: {  }
-    region: content
   field_spotlight:
     weight: 5
     label: hidden
@@ -135,6 +126,7 @@ content:
     region: content
 hidden:
   field_campaign_theme: true
+  field_social_media_embed: true
   langcode: true
   links: true
   search_api_excerpt: true

--- a/config/field.field.node.campaign.field_contents.yml
+++ b/config/field.field.node.campaign.field_contents.yml
@@ -8,7 +8,6 @@ dependencies:
     - paragraphs.paragraphs_type.accordion
     - paragraphs.paragraphs_type.campaign_resources
     - paragraphs.paragraphs_type.image_with_text
-    - paragraphs.paragraphs_type.instagram_embed
     - paragraphs.paragraphs_type.video
   module:
     - entity_reference_revisions
@@ -34,7 +33,6 @@ settings:
       accordion: accordion
       campaign_resources: campaign_resources
       image_with_text: image_with_text
-      instagram_embed: instagram_embed
       video: video
     target_bundles_drag_drop:
       accordion:
@@ -54,6 +52,9 @@ settings:
         enabled: false
       agenda_item:
         weight: 63
+        enabled: false
+      basic_html_section:
+        weight: 66
         enabled: false
       block:
         weight: 58
@@ -131,10 +132,7 @@ settings:
         weight: 84
         enabled: false
       instagram_embed:
-        enabled: true
         weight: 82
-      instagram_feed:
-        weight: 83
         enabled: false
       link:
         weight: 85
@@ -208,4 +206,10 @@ settings:
       video:
         enabled: true
         weight: 106
+      video_external:
+        weight: 118
+        enabled: false
+      videos:
+        weight: 117
+        enabled: false
 field_type: entity_reference_revisions

--- a/config/field.field.node.campaign.field_contents.yml
+++ b/config/field.field.node.campaign.field_contents.yml
@@ -8,6 +8,7 @@ dependencies:
     - paragraphs.paragraphs_type.accordion
     - paragraphs.paragraphs_type.campaign_resources
     - paragraphs.paragraphs_type.image_with_text
+    - paragraphs.paragraphs_type.instagram_embed
     - paragraphs.paragraphs_type.video
   module:
     - entity_reference_revisions
@@ -33,6 +34,7 @@ settings:
       accordion: accordion
       campaign_resources: campaign_resources
       image_with_text: image_with_text
+      instagram_embed: instagram_embed
       video: video
     target_bundles_drag_drop:
       accordion:
@@ -52,9 +54,6 @@ settings:
         enabled: false
       agenda_item:
         weight: 63
-        enabled: false
-      basic_html_section:
-        weight: 66
         enabled: false
       block:
         weight: 58
@@ -132,7 +131,10 @@ settings:
         weight: 84
         enabled: false
       instagram_embed:
+        enabled: true
         weight: 82
+      instagram_feed:
+        weight: 83
         enabled: false
       link:
         weight: 85
@@ -206,10 +208,4 @@ settings:
       video:
         enabled: true
         weight: 106
-      video_external:
-        weight: 118
-        enabled: false
-      videos:
-        weight: 117
-        enabled: false
 field_type: entity_reference_revisions

--- a/config/field.field.node.campaign.field_social_media_embed.yml
+++ b/config/field.field.node.campaign.field_social_media_embed.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - field.storage.node.field_social_media_embed
     - node.type.campaign
-    - paragraphs.paragraphs_type.instagram_embed
     - paragraphs.paragraphs_type.twitter_embed
   module:
     - entity_reference_revisions
@@ -28,7 +27,6 @@ settings:
   handler_settings:
     negate: 0
     target_bundles:
-      instagram_embed: instagram_embed
       twitter_embed: twitter_embed
     target_bundles_drag_drop:
       accordion:
@@ -37,11 +35,20 @@ settings:
       accordion_item:
         weight: 52
         enabled: false
+      accordion_item_simple:
+        weight: 62
+        enabled: false
       acuity_embed:
         weight: 53
         enabled: false
       additional_info:
         weight: 54
+        enabled: false
+      agenda_item:
+        weight: 65
+        enabled: false
+      basic_html_section:
+        weight: 66
         enabled: false
       block:
         weight: 55
@@ -119,8 +126,8 @@ settings:
         weight: 79
         enabled: false
       instagram_embed:
-        enabled: true
         weight: 80
+        enabled: false
       link:
         weight: 80
         enabled: false
@@ -135,6 +142,12 @@ settings:
         enabled: false
       news:
         weight: 84
+        enabled: false
+      other_info_card:
+        weight: 98
+        enabled: false
+      other_info_document:
+        weight: 99
         enabled: false
       people:
         weight: 85
@@ -184,4 +197,13 @@ settings:
       twitter_embed:
         enabled: true
         weight: 100
+      video:
+        weight: 116
+        enabled: false
+      video_external:
+        weight: 118
+        enabled: false
+      videos:
+        weight: 117
+        enabled: false
 field_type: entity_reference_revisions

--- a/config/field.field.node.campaign.field_social_media_embed.yml
+++ b/config/field.field.node.campaign.field_social_media_embed.yml
@@ -201,9 +201,9 @@ settings:
         weight: 116
         enabled: false
       video_external:
-        weight: 118
+        weight: 117
         enabled: false
       videos:
-        weight: 117
+        weight: 118
         enabled: false
 field_type: entity_reference_revisions


### PR DESCRIPTION
Hides the instagram feed option from "Additional content" and "Social media embed" fields on the Campaign content type