### PR TITLE
Remove unused 700 font-weight, $fw-bold variable

### DIFF
--- a/web/themes/custom/sfgovpl/sfgovpl.libraries.yml
+++ b/web/themes/custom/sfgovpl/sfgovpl.libraries.yml
@@ -19,8 +19,8 @@ google-fonts:
   header: true
   css:
     theme:
-      '//fonts.googleapis.com/css?family=Rubik:300,400,500,700': { type: external }
-      '//fonts.googleapis.com/css?family=Noto+Sans+TC:300,400,500,700&display=swap&subset=chinese-traditional' : { type: external }
+      '//fonts.googleapis.com/css?family=Rubik:300,400,500': { type: external }
+      '//fonts.googleapis.com/css?family=Noto+Sans+TC:300,400,500&display=swap&subset=chinese-traditional' : { type: external }
 
 # styles
 sfgov-drupal-specific-styles:

--- a/web/themes/custom/sfgovpl/src/sass/_mixins-fs.scss
+++ b/web/themes/custom/sfgovpl/src/sass/_mixins-fs.scss
@@ -96,7 +96,6 @@
       font-size: 62px;
       line-height: 80px;
       letter-spacing: 2px;
-      font-weight: $fw-bold;
       @include antialiasing;
     }
   }
@@ -165,7 +164,6 @@
   font-weight: $fw-medium;
   line-height: 27px;
   &.sfgov-translate-lang-zh-TW {
-    font-weight: $fw-bold;
     line-height: 30px;
     letter-spacing: 2px;
     @include antialiasing;
@@ -180,7 +178,6 @@
     font-size: 18px;
     line-height: 26px;
     letter-spacing: 1px;
-    font-weight: $fw-bold;
     @include antialiasing;
   }
 }
@@ -215,7 +212,6 @@
     font-size: 30px;
     line-height: 42px;
     letter-spacing: 2px;
-    font-weight: $fw-bold;
     @include antialiasing;
   }
 }
@@ -250,7 +246,6 @@
     font-size: 24px;
     line-height: 36px;
     letter-spacing: 2px;
-    font-weight: $fw-bold;
     @include antialiasing;
   }
 }
@@ -358,7 +353,6 @@
 
 @mixin fs-news-type {
   font-size: 16px;
-  font-weight: $fw-bold;
   line-height: 28px;
 }
 

--- a/web/themes/custom/sfgovpl/src/sass/_mixins-fs.scss
+++ b/web/themes/custom/sfgovpl/src/sass/_mixins-fs.scss
@@ -353,6 +353,7 @@
 
 @mixin fs-news-type {
   font-size: 16px;
+  font-weight: $fw-medium;
   line-height: 28px;
 }
 

--- a/web/themes/custom/sfgovpl/src/sass/_variables.scss
+++ b/web/themes/custom/sfgovpl/src/sass/_variables.scss
@@ -44,8 +44,6 @@ $c-border: rgba(28, 62, 87, 0.1);
 $fw-light: 300;
 $fw-regular: 400;
 $fw-medium: 500;
-$fw-bold: 700;
-$fw-black: 900;
 
 $w-news-body: 699px;
 $w-news-sidebar: 349px;


### PR DESCRIPTION
As far as I can tell, we're only using the `$fw-bold` variable (`700` font-weight) to make Chinese titles more bold in Noto Sans TC than they are in Rubik. This PR shows what it would look like if we deleted that weight entirely.

Screenshots for posterity:

| Before (sf.gov) | After (this PR)
:--- | :---
![image](https://user-images.githubusercontent.com/113896/124682412-86e06d80-de7f-11eb-9eb5-987a9cff3008.png) | ![image](https://user-images.githubusercontent.com/113896/124682426-8ea01200-de7f-11eb-97e2-2e142df92118.png)
