### PR TITLE
Nix Rubik 700 weight

### DIFF
--- a/web/themes/custom/sfgovpl/sfgovpl.libraries.yml
+++ b/web/themes/custom/sfgovpl/sfgovpl.libraries.yml
@@ -19,7 +19,7 @@ google-fonts:
   header: true
   css:
     theme:
-      '//fonts.googleapis.com/css?family=Rubik:300,400,500,700': { type: external }
+      '//fonts.googleapis.com/css?family=Rubik:300,400,500': { type: external }
       '//fonts.googleapis.com/css?family=Noto+Sans+TC:300,400,500,700&display=swap&subset=chinese-traditional' : { type: external }
 
 # styles

--- a/web/themes/custom/sfgovpl/src/sass/_mixins-fs.scss
+++ b/web/themes/custom/sfgovpl/src/sass/_mixins-fs.scss
@@ -356,12 +356,6 @@
   line-height: 20px;
 }
 
-@mixin fs-news-type {
-  font-size: 16px;
-  font-weight: $fw-bold;
-  line-height: 28px;
-}
-
 @mixin fs-nav-item {
   font-size: 17px;
   font-weight: $fw-medium;

--- a/web/themes/custom/sfgovpl/src/sass/_variables.scss
+++ b/web/themes/custom/sfgovpl/src/sass/_variables.scss
@@ -45,7 +45,6 @@ $fw-light: 300;
 $fw-regular: 400;
 $fw-medium: 500;
 $fw-bold: 700;
-$fw-black: 900;
 
 $w-news-body: 699px;
 $w-news-sidebar: 349px;


### PR DESCRIPTION
This PR deletes the unused 700 weight from our Google Fonts URL for the Rubik typeface. Due diligence:

1. The only instance of `700` that I found which seems relevant to font weight is the `$fw-bold` Sass variable
2. With one exception, `$fw-bold` is used only to increase the boldness of Chinese titles
3. The only exception to the above is a typography mixin named `fs-news-type`
4. There are no references to the `fs-news-type` mixin in our Sass files

I've deleted the `fs-news-type` mixin so that the only places we use `$fw-bold` are to increase the boldness of Chinese titles. See #940 for an experiment demonstrating what it would look like to normalize font weights in Rubik and Noto Sans TC, and https://github.com/SFDigitalServices/design-system/pull/16 for the first pass at bundling the custom fonts in our design system.

For good measure, I've also deleted the unused `$fw-black` variable (value: `900`).