### PR TITLE
Delete bad form button hack

### DIFF
--- a/web/themes/custom/sfgovpl/src/sass/node/_node-form-page.scss
+++ b/web/themes/custom/sfgovpl/src/sass/node/_node-form-page.scss
@@ -50,15 +50,15 @@
 
   .form-page {
     @include contain-1090;
-    button:hover {
-      border-bottom: 3px solid;
-    }
   }
+
+  // FIXME: this should not be here
   .formio-sfds {
-    .flex-auto{
+    .flex-auto {
       flex: 0 1 auto;
     }
   }
+  
   .hero-banner--border{
     margin-bottom: 20px;
     .hero-banner--border-contain {


### PR DESCRIPTION
This particular bit of CSS is breaking buttons on our forms, and there's no simple way to work around it:

https://github.com/SFDigitalServices/sfgov/blob/7d2a61e4688072b53bbed96959ca09efc79a452f/web/themes/custom/sfgovpl/src/sass/node/_node-form-page.scss#L53-L55

@henryjiang-sfgov I'm also curious about [this bit of CSS](https://github.com/SFDigitalServices/sfgov/blame/4fe838fbde04d37ab32ad19e8f596567270f70aa/web/themes/custom/sfgovpl/src/sass/node/_node-form-page.scss#L14-L15) that conflicts with formio-sfds's styles:

```css
.formio-sfds .flex-auto {
  flex: 1 1 auto;
}
```

Any idea what 6798c2280ef329eec7bb5ee1a48d3003caa4a5d3 (part of #579) was all about?