### PR TITLE
Upgrade to sfgov-design-system@1.2.0

### DIFF
--- a/web/themes/custom/sfgovpl/package-lock.json
+++ b/web/themes/custom/sfgovpl/package-lock.json
@@ -1458,14 +1458,25 @@
       },
       "dependencies": {
         "postcss": {
-          "version": "7.0.32",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
-          "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
+          "version": "7.0.36",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+          "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",
             "source-map": "^0.6.1",
             "supports-color": "^6.1.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+              "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         }
       }
@@ -2092,16 +2103,30 @@
       }
     },
     "browserslist": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
-      "integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
+      "version": "4.16.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+      "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001181",
-        "colorette": "^1.2.1",
-        "electron-to-chromium": "^1.3.649",
+        "caniuse-lite": "^1.0.30001219",
+        "colorette": "^1.2.2",
+        "electron-to-chromium": "^1.3.723",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.70"
+        "node-releases": "^1.1.71"
+      },
+      "dependencies": {
+        "caniuse-lite": {
+          "version": "1.0.30001245",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001245.tgz",
+          "integrity": "sha512-768fM9j1PKXpOCKws6eTo3RHmvTUsG9UrpT4WoREFeZgJBTi4/X9g565azS/rVUGtqb8nt7FjLeF5u4kukERnA==",
+          "dev": true
+        },
+        "colorette": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+          "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
+          "dev": true
+        }
       }
     },
     "bs-recipes": {
@@ -2604,9 +2629,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.663",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.663.tgz",
-      "integrity": "sha512-xkVkzHj6k3oRRGlmdgUCCLSLhtFYHDCTH7SeK+LJdJjnsLcrdbpr8EYmfMQhez3V/KPO5UScSpzQ0feYX6Qoyw==",
+      "version": "1.3.779",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.779.tgz",
+      "integrity": "sha512-nreave0y/1Qhmo8XtO6C/LpawNyC6U26+q7d814/e+tIqUK073pM+4xW7WUXyqCRa5K4wdxHmNMBAi8ap9nEew==",
       "dev": true
     },
     "emoji-regex": {
@@ -4569,9 +4594,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.70",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.70.tgz",
-      "integrity": "sha512-Slf2s69+2/uAD79pVVQo8uSiC34+g8GWY8UH2Qtqv34ZfhYrxpYpfzs9Js9d6O0mbDmALuxaTlplnBTnSELcrw==",
+      "version": "1.1.73",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
+      "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
       "dev": true
     },
     "node-sass": {
@@ -6604,9 +6629,9 @@
       "dev": true
     },
     "sfgov-design-system": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/sfgov-design-system/-/sfgov-design-system-1.1.1.tgz",
-      "integrity": "sha512-zJgSygMP4kS85mN7uaULdvAyr67syqDhF4/rFbqYZwEVt8NiZGmnWW0/EJ6d0652ABhaLtHBG2Gv9IzwGMuD2g==",
+      "version": "0.0.0-7fb5df5",
+      "resolved": "https://registry.npmjs.org/sfgov-design-system/-/sfgov-design-system-0.0.0-7fb5df5.tgz",
+      "integrity": "sha512-Mfdv8f28RjzxjE4ogPHUfjJKQQIDJG1z/izSfSJdbb7WbQgIl2XeG44AaLAriuymIRYrLLObpbHQaBE0Ep+kHg==",
       "dev": true
     },
     "shebang-command": {
@@ -7131,15 +7156,6 @@
       "dev": true,
       "requires": {
         "min-indent": "^1.0.0"
-      }
-    },
-    "supports-color": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-      "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-      "dev": true,
-      "requires": {
-        "has-flag": "^3.0.0"
       }
     },
     "symbol-observable": {

--- a/web/themes/custom/sfgovpl/package-lock.json
+++ b/web/themes/custom/sfgovpl/package-lock.json
@@ -6629,9 +6629,9 @@
       "dev": true
     },
     "sfgov-design-system": {
-      "version": "0.0.0-7fb5df5",
-      "resolved": "https://registry.npmjs.org/sfgov-design-system/-/sfgov-design-system-0.0.0-7fb5df5.tgz",
-      "integrity": "sha512-Mfdv8f28RjzxjE4ogPHUfjJKQQIDJG1z/izSfSJdbb7WbQgIl2XeG44AaLAriuymIRYrLLObpbHQaBE0Ep+kHg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/sfgov-design-system/-/sfgov-design-system-1.2.0.tgz",
+      "integrity": "sha512-muz7xfgtiyDSWW49xBYfNYa6OqIXItB8ehVj1SKiUbDb5XCMEwAjGT+LSLKWA11z+RW2jex04USILNw3X+F6Nw==",
       "dev": true
     },
     "shebang-command": {

--- a/web/themes/custom/sfgovpl/package.json
+++ b/web/themes/custom/sfgovpl/package.json
@@ -29,6 +29,6 @@
     "postcss-scss": "^4.0.0",
     "prettier": "^2.2.1",
     "prettier-plugin-twig-melody": "^0.4.6",
-    "sfgov-design-system": "^1.1.1"
+    "sfgov-design-system": "0.0.0-7fb5df5"
   }
 }

--- a/web/themes/custom/sfgovpl/package.json
+++ b/web/themes/custom/sfgovpl/package.json
@@ -29,6 +29,6 @@
     "postcss-scss": "^4.0.0",
     "prettier": "^2.2.1",
     "prettier-plugin-twig-melody": "^0.4.6",
-    "sfgov-design-system": "0.0.0-7fb5df5"
+    "sfgov-design-system": "^1.2.0"
   }
 }


### PR DESCRIPTION
This is a test of the new `btn-link` styles in https://github.com/SFDigitalServices/design-system/pull/33. I'm going to keep this as a draft until we:

- [x] Merge https://github.com/SFDigitalServices/design-system/pull/33
- [x] Merge https://github.com/SFDigitalServices/design-system/pull/32
- [x] Publish version `1.2.0`
- [x] `npm install sfgov-design-system@1.2.0` here
- [x] Test it!