### PR TITLE
[SG-1430] Do not carry over translations when cloning node

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -223,6 +223,9 @@
             }
         },
         "patches": {
+            "drupal/quick_node_clone": {
+                "Remove translations when cloning nodes": "https://www.drupal.org/files/issues/2021-05-13/remove_translations.patch"
+            },
             "drupal/telephone_validation": {
                 "Allow emergency and short codes.": "https://www.drupal.org/files/issues/2020-04-07/allow_emergency-2976959-6.patch"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -2343,6 +2343,12 @@
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
                     }
+                },
+                "patches_applied": {
+                    "Page scroll depth": "patches/amplitude-scroll-depth.patch",
+                    "Allow setting user properties": "https://www.drupal.org/files/issues/2020-07-05/3157006-user-properties-2.patch",
+                    "JSON parse event property values": "patches/amplitude-parse-event-property-values.patch",
+                    "Auto-capture href for anchors": "patches/auto-capture-anchor-href.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -2492,6 +2498,9 @@
                         "status": "not-covered",
                         "message": "RC releases are not covered by Drupal security advisories."
                     }
+                },
+                "patches_applied": {
+                    "Error when updating block fields": "https://www.drupal.org/files/issues/2019-05-02/block_field-available-blocks-2861670-34.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -3677,6 +3686,14 @@
                         "[web-root]/profiles/README.txt": "assets/scaffold/files/profiles.README.txt",
                         "[web-root]/themes/README.txt": "assets/scaffold/files/themes.README.txt"
                     }
+                },
+                "patches_applied": {
+                    "Entity links ignore language negotiation API": "https://www.drupal.org/files/issues/2019-07-31/3061761-38.patch",
+                    "StringFormatter generates links in wrong language when linking to entity": "patches/stringformatter-ignores-language-negotiation-2648288.patch",
+                    "Use hook_theme_suggestions in views": "https://www.drupal.org/files/issues/2018-04-07/2923634-35.patch",
+                    "Allow for deletion of a single value of a multiple value field": "https://www.drupal.org/files/issues/2019-10-24/1038316-204.patch",
+                    "Node local tasks tabs do not appear on node revisions": "https://www.drupal.org/files/issues/2019-11-12/drupal-node_revision_local_tasks_canonical-2885278-15.patch",
+                    "Correct reporting of MariaDB version": "https://www.drupal.org/files/issues/2021-05-18/3213482-9.patch"
                 }
             },
             "autoload": {
@@ -4314,6 +4331,9 @@
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
                     }
+                },
+                "patches_applied": {
+                    "Delay entity browser modal positioning": "patches/entity_browser-sfgov-modal-position.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -5058,6 +5078,9 @@
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
                     }
+                },
+                "patches_applied": {
+                    "Adds a new option to display links": "patches/gtranslate_sfgov_links.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -6251,6 +6274,9 @@
                         "status": "not-covered",
                         "message": "Project has not opted into security advisory coverage!"
                     }
+                },
+                "patches_applied": {
+                    "Public Preview is Registered as an Admin Route Due to _node_operation_route Usage": "https://www.drupal.org/files/issues/2020-12-22/3189531-node-operation-route.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -6319,6 +6345,9 @@
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
                     }
+                },
+                "patches_applied": {
+                    "Remove translations when cloning nodes": "https://www.drupal.org/files/issues/2021-05-13/remove_translations.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -6658,6 +6687,9 @@
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
                     }
+                },
+                "patches_applied": {
+                    "Widget error when field is overridden - undefined offset 0 in $form['publish_state']": "https://www.drupal.org/files/issues/2020-06-30/3077147-28.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -7406,6 +7438,9 @@
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
                     }
+                },
+                "patches_applied": {
+                    "Allow emergency and short codes.": "https://www.drupal.org/files/issues/2020-04-07/allow_emergency-2976959-6.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -19114,6 +19149,7 @@
                     "type": "github"
                 }
             ],
+            "abandoned": true,
             "time": "2020-11-30T07:30:19+00:00"
         },
         {

--- a/composer.lock
+++ b/composer.lock
@@ -2343,12 +2343,6 @@
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
                     }
-                },
-                "patches_applied": {
-                    "Page scroll depth": "patches/amplitude-scroll-depth.patch",
-                    "Allow setting user properties": "https://www.drupal.org/files/issues/2020-07-05/3157006-user-properties-2.patch",
-                    "JSON parse event property values": "patches/amplitude-parse-event-property-values.patch",
-                    "Auto-capture href for anchors": "patches/auto-capture-anchor-href.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -2498,9 +2492,6 @@
                         "status": "not-covered",
                         "message": "RC releases are not covered by Drupal security advisories."
                     }
-                },
-                "patches_applied": {
-                    "Error when updating block fields": "https://www.drupal.org/files/issues/2019-05-02/block_field-available-blocks-2861670-34.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -2889,8 +2880,7 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/config_exclude",
                 "issues": "https://www.drupal.org/project/issues/config_exclude"
-            },
-            "time": "2017-12-07T21:31:19+00:00"
+            }
         },
         {
             "name": "drupal/config_filter",
@@ -3686,14 +3676,6 @@
                         "[web-root]/profiles/README.txt": "assets/scaffold/files/profiles.README.txt",
                         "[web-root]/themes/README.txt": "assets/scaffold/files/themes.README.txt"
                     }
-                },
-                "patches_applied": {
-                    "Entity links ignore language negotiation API": "https://www.drupal.org/files/issues/2019-07-31/3061761-38.patch",
-                    "StringFormatter generates links in wrong language when linking to entity": "patches/stringformatter-ignores-language-negotiation-2648288.patch",
-                    "Use hook_theme_suggestions in views": "https://www.drupal.org/files/issues/2018-04-07/2923634-35.patch",
-                    "Allow for deletion of a single value of a multiple value field": "https://www.drupal.org/files/issues/2019-10-24/1038316-204.patch",
-                    "Node local tasks tabs do not appear on node revisions": "https://www.drupal.org/files/issues/2019-11-12/drupal-node_revision_local_tasks_canonical-2885278-15.patch",
-                    "Correct reporting of MariaDB version": "https://www.drupal.org/files/issues/2021-05-18/3213482-9.patch"
                 }
             },
             "autoload": {
@@ -4165,8 +4147,7 @@
             "support": {
                 "source": "http://git.drupal.org/project/eck.git",
                 "issues": "https://www.drupal.org/project/issues/eck"
-            },
-            "time": "2021-06-20T17:38:39+00:00"
+            }
         },
         {
             "name": "drupal/embed",
@@ -4331,9 +4312,6 @@
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
                     }
-                },
-                "patches_applied": {
-                    "Delay entity browser modal positioning": "patches/entity_browser-sfgov-modal-position.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -5009,27 +4987,29 @@
             }
         },
         {
-            "name": "drupal/google_tag",
-            "version": "1.4.0",
+            "name": "drupal/group",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
-                "url": "https://git.drupalcode.org/project/google_tag.git",
-                "reference": "8.x-1.4"
+                "url": "https://git.drupalcode.org/project/group.git",
+                "reference": "8.x-1.3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/google_tag-8.x-1.4.zip",
-                "reference": "8.x-1.4",
-                "shasum": "1bdc6f93d1c79c27738320597f2185f5de37432f"
+                "url": "https://ftp.drupal.org/files/projects/group-8.x-1.3.zip",
+                "reference": "8.x-1.3",
+                "shasum": "167129a35353800e7ec1dc3302a4de7da1dae837"
             },
             "require": {
-                "drupal/core": "^8.8 || ^9"
+                "drupal/core": "^8.9 || ^9",
+                "drupal/entity": "^1.0",
+                "drupal/variationcache": "^1.0"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.4",
-                    "datestamp": "1593179846",
+                    "version": "8.x-1.3",
+                    "datestamp": "1601990196",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -5042,17 +5022,20 @@
             ],
             "authors": [
                 {
-                    "name": "solotandem",
-                    "homepage": "https://www.drupal.org/user/240748"
+                    "name": "Kristiaan Van den Eynde",
+                    "homepage": "https://www.drupal.org/u/kristiaanvandeneynde",
+                    "role": "Maintainer"
                 }
             ],
-            "description": "Allows your website analytics to be managed using Google Tag Manager.",
-            "homepage": "https://www.drupal.org/project/google_tag",
+            "description": "This module allows you to group users, content and other entities",
+            "homepage": "http://drupal.org/project/group",
             "support": {
-                "source": "https://git.drupalcode.org/project/google_tag"
+                "source": "https://git.drupalcode.org/project/group",
+                "issues": "https://drupal.org/project/issues/group"
             }
         },
         {
+>>>>>>> 7068bf2e (Remove all the extra stuff in the composer lock file)
             "name": "drupal/gtranslate",
             "version": "1.13.0",
             "source": {
@@ -5078,9 +5061,6 @@
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
                     }
-                },
-                "patches_applied": {
-                    "Adds a new option to display links": "patches/gtranslate_sfgov_links.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -5538,8 +5518,7 @@
             "homepage": "https://www.drupal.org/project/maxlength",
             "support": {
                 "source": "https://git.drupalcode.org/project/maxlength"
-            },
-            "time": "2020-04-11T06:46:46+00:00"
+            }
         },
         {
             "name": "drupal/media_entity_file_replace",
@@ -5857,8 +5836,7 @@
             "homepage": "https://www.drupal.org/project/node_edit_protection",
             "support": {
                 "source": "https://git.drupalcode.org/project/node_edit_protection"
-            },
-            "time": "2020-09-01T11:30:50+00:00"
+            }
         },
         {
             "name": "drupal/office_hours",
@@ -6274,9 +6252,6 @@
                         "status": "not-covered",
                         "message": "Project has not opted into security advisory coverage!"
                     }
-                },
-                "patches_applied": {
-                    "Public Preview is Registered as an Admin Route Due to _node_operation_route Usage": "https://www.drupal.org/files/issues/2020-12-22/3189531-node-operation-route.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -6687,9 +6662,6 @@
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
                     }
-                },
-                "patches_applied": {
-                    "Widget error when field is overridden - undefined offset 0 in $form['publish_state']": "https://www.drupal.org/files/issues/2020-06-30/3077147-28.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -7438,9 +7410,6 @@
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
                     }
-                },
-                "patches_applied": {
-                    "Allow emergency and short codes.": "https://www.drupal.org/files/issues/2020-04-07/allow_emergency-2976959-6.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -19149,7 +19118,6 @@
                     "type": "github"
                 }
             ],
-            "abandoned": true,
             "time": "2020-11-30T07:30:19+00:00"
         },
         {

--- a/composer.lock
+++ b/composer.lock
@@ -5012,6 +5012,50 @@
             }
         },
         {
+            "name": "drupal/google_tag",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/google_tag.git",
+                "reference": "8.x-1.4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/google_tag-8.x-1.4.zip",
+                "reference": "8.x-1.4",
+                "shasum": "1bdc6f93d1c79c27738320597f2185f5de37432f"
+            },
+            "require": {
+                "drupal/core": "^8.8 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.4",
+                    "datestamp": "1593179846",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "solotandem",
+                    "homepage": "https://www.drupal.org/user/240748"
+                }
+            ],
+            "description": "Allows your website analytics to be managed using Google Tag Manager.",
+            "homepage": "https://www.drupal.org/project/google_tag",
+            "support": {
+                "source": "https://git.drupalcode.org/project/google_tag"
+            }
+        },
+        {
             "name": "drupal/gtranslate",
             "version": "1.13.0",
             "source": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "82f808ec42c90b572c8c9f7d0192c18d",
+    "content-hash": "678fb04f234187d561bf41b9413dabd2",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -2343,6 +2343,12 @@
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
                     }
+                },
+                "patches_applied": {
+                    "Page scroll depth": "patches/amplitude-scroll-depth.patch",
+                    "Allow setting user properties": "https://www.drupal.org/files/issues/2020-07-05/3157006-user-properties-2.patch",
+                    "JSON parse event property values": "patches/amplitude-parse-event-property-values.patch",
+                    "Auto-capture href for anchors": "patches/auto-capture-anchor-href.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -2492,6 +2498,9 @@
                         "status": "not-covered",
                         "message": "RC releases are not covered by Drupal security advisories."
                     }
+                },
+                "patches_applied": {
+                    "Error when updating block fields": "https://www.drupal.org/files/issues/2019-05-02/block_field-available-blocks-2861670-34.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -2880,7 +2889,8 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/config_exclude",
                 "issues": "https://www.drupal.org/project/issues/config_exclude"
-            }
+            },
+            "time": "2017-12-07T21:31:19+00:00"
         },
         {
             "name": "drupal/config_filter",
@@ -3676,6 +3686,14 @@
                         "[web-root]/profiles/README.txt": "assets/scaffold/files/profiles.README.txt",
                         "[web-root]/themes/README.txt": "assets/scaffold/files/themes.README.txt"
                     }
+                },
+                "patches_applied": {
+                    "Entity links ignore language negotiation API": "https://www.drupal.org/files/issues/2019-07-31/3061761-38.patch",
+                    "StringFormatter generates links in wrong language when linking to entity": "patches/stringformatter-ignores-language-negotiation-2648288.patch",
+                    "Use hook_theme_suggestions in views": "https://www.drupal.org/files/issues/2018-04-07/2923634-35.patch",
+                    "Allow for deletion of a single value of a multiple value field": "https://www.drupal.org/files/issues/2019-10-24/1038316-204.patch",
+                    "Node local tasks tabs do not appear on node revisions": "https://www.drupal.org/files/issues/2019-11-12/drupal-node_revision_local_tasks_canonical-2885278-15.patch",
+                    "Correct reporting of MariaDB version": "https://www.drupal.org/files/issues/2021-05-18/3213482-9.patch"
                 }
             },
             "autoload": {
@@ -4147,7 +4165,8 @@
             "support": {
                 "source": "http://git.drupal.org/project/eck.git",
                 "issues": "https://www.drupal.org/project/issues/eck"
-            }
+            },
+            "time": "2021-06-20T17:38:39+00:00"
         },
         {
             "name": "drupal/embed",
@@ -4312,6 +4331,9 @@
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
                     }
+                },
+                "patches_applied": {
+                    "Delay entity browser modal positioning": "patches/entity_browser-sfgov-modal-position.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -4452,6 +4474,9 @@
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
                     }
+                },
+                "patches_applied": {
+                    "Allow reference to unpublished media": "patches/entity_reference_unpublished-media.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -5014,6 +5039,9 @@
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
                     }
+                },
+                "patches_applied": {
+                    "Enable content moderation for groups.": "https://www.drupal.org/files/issues/2020-06-09/group-content_moderation-2906085-74.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -5061,6 +5089,9 @@
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
                     }
+                },
+                "patches_applied": {
+                    "Adds a new option to display links": "patches/gtranslate_sfgov_links.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -5518,7 +5549,8 @@
             "homepage": "https://www.drupal.org/project/maxlength",
             "support": {
                 "source": "https://git.drupalcode.org/project/maxlength"
-            }
+            },
+            "time": "2020-04-11T06:46:46+00:00"
         },
         {
             "name": "drupal/media_entity_file_replace",
@@ -5836,7 +5868,8 @@
             "homepage": "https://www.drupal.org/project/node_edit_protection",
             "support": {
                 "source": "https://git.drupalcode.org/project/node_edit_protection"
-            }
+            },
+            "time": "2020-09-01T11:30:50+00:00"
         },
         {
             "name": "drupal/office_hours",
@@ -6252,6 +6285,9 @@
                         "status": "not-covered",
                         "message": "Project has not opted into security advisory coverage!"
                     }
+                },
+                "patches_applied": {
+                    "Public Preview is Registered as an Admin Route Due to _node_operation_route Usage": "https://www.drupal.org/files/issues/2020-12-22/3189531-node-operation-route.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -6662,6 +6698,9 @@
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
                     }
+                },
+                "patches_applied": {
+                    "Widget error when field is overridden - undefined offset 0 in $form['publish_state']": "https://www.drupal.org/files/issues/2020-06-30/3077147-28.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -7410,6 +7449,9 @@
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
                     }
+                },
+                "patches_applied": {
+                    "Allow emergency and short codes.": "https://www.drupal.org/files/issues/2020-04-07/allow_emergency-2976959-6.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -17309,7 +17351,7 @@
             "extra": {
                 "drupal": {
                     "version": "8.x-1.1",
-                    "datestamp": "1601040759",
+                    "datestamp": "1601040732",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/composer.lock
+++ b/composer.lock
@@ -5012,58 +5012,6 @@
             }
         },
         {
-            "name": "drupal/group",
-            "version": "1.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/group.git",
-                "reference": "8.x-1.3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/group-8.x-1.3.zip",
-                "reference": "8.x-1.3",
-                "shasum": "167129a35353800e7ec1dc3302a4de7da1dae837"
-            },
-            "require": {
-                "drupal/core": "^8.9 || ^9",
-                "drupal/entity": "^1.0",
-                "drupal/variationcache": "^1.0"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "drupal": {
-                    "version": "8.x-1.3",
-                    "datestamp": "1601990196",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
-                },
-                "patches_applied": {
-                    "Enable content moderation for groups.": "https://www.drupal.org/files/issues/2020-06-09/group-content_moderation-2906085-74.patch"
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Kristiaan Van den Eynde",
-                    "homepage": "https://www.drupal.org/u/kristiaanvandeneynde",
-                    "role": "Maintainer"
-                }
-            ],
-            "description": "This module allows you to group users, content and other entities",
-            "homepage": "http://drupal.org/project/group",
-            "support": {
-                "source": "https://git.drupalcode.org/project/group",
-                "issues": "https://drupal.org/project/issues/group"
-            }
-        },
-        {
->>>>>>> 7068bf2e (Remove all the extra stuff in the composer lock file)
             "name": "drupal/gtranslate",
             "version": "1.13.0",
             "source": {


### PR DESCRIPTION
Apply patch from issue 3049127 for the Quick Node Clone project:
https://www.drupal.org/project/quick_node_clone/issues/3049127

This patch removes translations when in the process of cloning a node so that the new node created does not contain all the translation content.