### PR TITLE
update /vaccine-sites microservice URL

### DIFF
--- a/config/sfgov_vaccine.settings.yml
+++ b/config/sfgov_vaccine.settings.yml
@@ -1,4 +1,4 @@
-api_url: 'https://vaccination-site-microservice.vercel.app/api/v1/appointments'
+api_url: 'https://sfgov-vaccine-sites.herokuapp.com/api/v1/appointments'
 error_message: 'We are having trouble reaching the service right now. Please try again later.'
 languages:
   all:

--- a/web/modules/custom/sfgov_vaccine/sfgov_vaccine.module
+++ b/web/modules/custom/sfgov_vaccine/sfgov_vaccine.module
@@ -13,7 +13,7 @@ use Drupal\Core\Site\Settings;
 function sfgov_vaccine_update_8001() {
   $config_factory = \Drupal::configFactory();
   $config = $config_factory->getEditable('sfgov_vaccine.settings');
-  $config->set('api_url', 'https://vaccination-site-microservice.vercel.app/api/v1/appointments');
+  $config->set('api_url', 'https://sfgov-vaccine-sites.herokuapp.com/api/v1/appointments');
   $config->save(TRUE);
 }
 

--- a/web/modules/custom/sfgov_vaccine/src/Form/SettingsForm.php
+++ b/web/modules/custom/sfgov_vaccine/src/Form/SettingsForm.php
@@ -89,7 +89,7 @@ class SettingsForm extends ConfigFormBase {
     $form['api_url'] = [
       '#type' => 'url',
       '#title' => $this->t('Microservice URL'),
-      '#description' => $this->t('e.g. https://vaccination-site-microservice.vercel.app/api/v1/appointments, https://vaccination-site-microservice-git-automate-site-data-sfds.vercel.app/api/v1/appointments'),
+      '#description' => $this->t('e.g. https://sfgov-vaccine-sites.herokuapp.com/api/v1/appointments, https://sfgov-vaccine-sites-pr-xxx.herokuapp.com/api/v1/appointments'),
       '#default_value' => $this->vaxValues->settings('api_url'),
     ];
 

--- a/web/themes/custom/sfgovpl/templates/components/vaccine/vaccine-site--booking.twig
+++ b/web/themes/custom/sfgovpl/templates/components/vaccine/vaccine-site--booking.twig
@@ -1,6 +1,6 @@
 {#
   The following values are translated in the API and should not be registered for Drupal translation.
-  @see https://vaccination-site-microservice.vercel.app/api/v1/appointments?lang=es
+  @see https://sfgov-vaccine-sites.herokuapp.com/api/v1/appointments?lang=es
 
   - result.booking.info
   - result.remote_translation.info


### PR DESCRIPTION
The vaccine sites microservice has [moved](https://github.com/SFDigitalServices/vaccination-site-microservice/pull/229) from Vercel to Heroku, so the URL is changing. We should get a proper CNAME (`vaccine-sites.api.sf.gov`?) and nix the `herokuapp.com` part entirely.

@zakiya I noticed that the URL is referenced in two places, so I changed it in both.