### PR TITLE
[SG-1445] Fix problem with node cloning not starting from node latest revision

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -248,6 +248,9 @@
             "drupal/block_field": {
                 "Error when updating block fields": "https://www.drupal.org/files/issues/2019-05-02/block_field-available-blocks-2861670-34.patch"
             },
+            "drupal/quick_node_clone": {
+                "Node clone does not clone the most recent revision": "https://www.drupal.org/files/issues/2021-08-03/get-correct-revision-3226576-2.patch"
+            },
             "drupal/scheduler_content_moderation_integration": {
                 "Widget error when field is overridden - undefined offset 0 in $form['publish_state']": "https://www.drupal.org/files/issues/2020-06-30/3077147-28.patch"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -19724,5 +19724,5 @@
     "platform-overrides": {
         "php": "7.2"
     },
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "678fb04f234187d561bf41b9413dabd2",
+    "content-hash": "ba5cf96cdbea725bf0271ecb76670774",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -6350,7 +6350,8 @@
                     }
                 },
                 "patches_applied": {
-                    "Remove translations when cloning nodes": "https://www.drupal.org/files/issues/2021-05-13/remove_translations.patch"
+                    "Remove translations when cloning nodes": "https://www.drupal.org/files/issues/2021-05-13/remove_translations.patch",
+                    "Node clone does not clone the most recent revision": "https://www.drupal.org/files/issues/2021-08-03/get-correct-revision-3226576-2.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -19152,6 +19153,7 @@
                     "type": "github"
                 }
             ],
+            "abandoned": true,
             "time": "2020-11-30T07:30:19+00:00"
         },
         {
@@ -19722,5 +19724,5 @@
     "platform-overrides": {
         "php": "7.2"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
I created a new issue in the quick_node_clone issue queue since there were no existing ones that covered this bug:
https://www.drupal.org/project/quick_node_clone/issues/3226576

Here is the patch I wrote to fix the bug:
https://www.drupal.org/files/issues/2021-08-03/get-correct-revision-3226576-2.patch