### PR TITLE
Entity reference unpublished

### DIFF
--- a/composer-manifest.yaml
+++ b/composer-manifest.yaml
@@ -80,6 +80,7 @@ packages:
     drupal/entity: 1.2.0
     drupal/entity_browser: 2.6.0
     drupal/entity_reference_revisions: 1.9.0
+    drupal/entity_reference_unpublished: 1.3.0
     drupal/exif_orientation: 1.1.0
     drupal/externalauth: 1.4.0
     drupal/extlink: 1.6.0
@@ -186,6 +187,7 @@ packages:
     pantheon-systems/drupal-integrations: 8.0.5
     pantheon-systems/quicksilver-pushback: 2.0.2
     paragonie/random_compat: v9.99.99
+    pclzip/pclzip: 2.8.2
     pear/archive_tar: 1.4.14
     pear/console_getopt: v1.4.3
     pear/pear-core-minimal: v1.10.10

--- a/composer-manifest.yaml
+++ b/composer-manifest.yaml
@@ -77,6 +77,7 @@ packages:
     drupal/drupal-driver: v1.4.0
     drupal/drupal-extension: v3.4.1
     drupal/eck: 'dev-1.x:010ca99e7fde8a42d84592828b9506519cf05d98'
+    drupal/embed: 1.4.0
     drupal/entity: 1.2.0
     drupal/entity_browser: 2.6.0
     drupal/entity_reference_revisions: 1.9.0

--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
         "drupal/diff": "^1.0",
         "drupal/eck": "dev-1.x",
         "drupal/entity_browser": "^2.5",
+        "drupal/entity_reference_unpublished": "^1.3",
         "drupal/exif_orientation": "^1.1",
         "drupal/externalauth": "^1.1",
         "drupal/extlink": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,7 @@
         "drupal/date_popup": "^1.1",
         "drupal/diff": "^1.0",
         "drupal/eck": "dev-1.x",
+        "drupal/embed": "^1.4",
         "drupal/entity_browser": "^2.5",
         "drupal/entity_reference_unpublished": "^1.3",
         "drupal/exif_orientation": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -255,6 +255,9 @@
             },
             "drupal/public_preview": {
                 "Public Preview is Registered as an Admin Route Due to _node_operation_route Usage" : "https://www.drupal.org/files/issues/2020-12-22/3189531-node-operation-route.patch"
+            },
+            "drupal/entity_reference_unpublished": {
+                "Allow reference to unpublished media": "patches/entity_reference_unpublished-media.patch"
             }
         }
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5d20d37f2ff1fd5dc806d0c000b0fe51",
+    "content-hash": "b70dc9b82d547268777260e2f87560ba",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -4147,6 +4147,70 @@
             "support": {
                 "source": "http://git.drupal.org/project/eck.git",
                 "issues": "https://www.drupal.org/project/issues/eck"
+            }
+        },
+        {
+            "name": "drupal/embed",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/embed.git",
+                "reference": "8.x-1.4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/embed-8.x-1.4.zip",
+                "reference": "8.x-1.4",
+                "shasum": "09a2bda039bfbb3fff01c91964384bf3d924b8c5"
+            },
+            "require": {
+                "drupal/core": "^8.7.7 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.4",
+                    "datestamp": "1590176831",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Dave Reid",
+                    "homepage": "https://www.drupal.org/user/53892"
+                },
+                {
+                    "name": "Devin Carlson",
+                    "homepage": "https://www.drupal.org/user/290182"
+                },
+                {
+                    "name": "Drupal Media Team",
+                    "homepage": "https://www.drupal.org/user/3260690"
+                },
+                {
+                    "name": "cs_shadow",
+                    "homepage": "https://www.drupal.org/user/2828287"
+                },
+                {
+                    "name": "phenaproxima",
+                    "homepage": "https://www.drupal.org/user/205645"
+                },
+                {
+                    "name": "slashrsm",
+                    "homepage": "https://www.drupal.org/user/744628"
+                }
+            ],
+            "description": "Provides a framework for different types of embeds in text editors.",
+            "homepage": "https://www.drupal.org/project/embed",
+            "support": {
+                "source": "https://git.drupalcode.org/project/embed"
             }
         },
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b70dc9b82d547268777260e2f87560ba",
+    "content-hash": "ada725bd46fff733c3388c59e4d23a72",
     "packages": [
         {
             "name": "alchemy/zippy",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3b28b089354164e390023a5acd3bbfa2",
+    "content-hash": "5d20d37f2ff1fd5dc806d0c000b0fe51",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -4360,6 +4360,50 @@
             "homepage": "https://www.drupal.org/project/entity_reference_revisions",
             "support": {
                 "source": "https://git.drupalcode.org/project/entity_reference_revisions"
+            }
+        },
+        {
+            "name": "drupal/entity_reference_unpublished",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/entity_reference_unpublished.git",
+                "reference": "8.x-1.3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/entity_reference_unpublished-8.x-1.3.zip",
+                "reference": "8.x-1.3",
+                "shasum": "629f27c43d90441cebcf052b52fd631164c5a5bc"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.3",
+                    "datestamp": "1618255157",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "lahoosascoots",
+                    "homepage": "https://www.drupal.org/user/1933614"
+                }
+            ],
+            "description": "Allows unpublished content to be referenced in an entity reference.",
+            "homepage": "https://www.drupal.org/project/entity_reference_unpublished",
+            "support": {
+                "source": "https://git.drupalcode.org/project/entity_reference_unpublished"
             }
         },
         {
@@ -19620,5 +19664,5 @@
     "platform-overrides": {
         "php": "7.2"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -36,6 +36,7 @@ module:
   dynamic_page_cache: 0
   eck: 0
   editor: 0
+  embed: 0
   entity: 0
   entity_browser: 0
   entity_browser_entity_form: 0

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -40,6 +40,7 @@ module:
   entity_browser: 0
   entity_browser_entity_form: 0
   entity_reference_revisions: 0
+  entity_reference_unpublished: 0
   exif_orientation: 0
   fancy_file_delete: 0
   field: 0

--- a/config/embed.settings.yml
+++ b/config/embed.settings.yml
@@ -1,0 +1,4 @@
+file_scheme: public
+upload_directory: embed_buttons
+_core:
+  default_config_hash: Ed6LXVlKotwVS4tx7_rnsL-6NlBoD-PLu3KFPAvpNMc

--- a/config/field.field.node.meeting.field_public_body.yml
+++ b/config/field.field.node.meeting.field_public_body.yml
@@ -23,13 +23,13 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  handler: 'default:node'
+  handler: unpublished
   handler_settings:
     target_bundles:
       department: department
       public_body: public_body
     sort:
       field: _none
-    auto_create: false
-    auto_create_bundle: ''
+    auto_create: 0
+    auto_create_bundle: department
 field_type: entity_reference

--- a/config/field.field.node.public_body.field_subcommittees.yml
+++ b/config/field.field.node.public_body.field_subcommittees.yml
@@ -21,12 +21,12 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  handler: 'default:node'
+  handler: unpublished
   handler_settings:
     target_bundles:
       public_body: public_body
     sort:
       field: _none
-    auto_create: false
+    auto_create: 0
     auto_create_bundle: ''
 field_type: entity_reference

--- a/config/field.field.paragraph.other_info_document.field_file.yml
+++ b/config/field.field.paragraph.other_info_document.field_file.yml
@@ -22,12 +22,12 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  handler: 'default:media'
+  handler: unpublished_media
   handler_settings:
     target_bundles:
       file: file
     sort:
       field: _none
-    auto_create: false
+    auto_create: 0
     auto_create_bundle: ''
 field_type: entity_reference

--- a/config/language/es/core.date_format.html_datetime.yml
+++ b/config/language/es/core.date_format.html_datetime.yml
@@ -1,1 +1,0 @@
-label: 'HTML Datetime'

--- a/config/language/es/core.entity_view_mode.node.rss.yml
+++ b/config/language/es/core.entity_view_mode.node.rss.yml
@@ -1,1 +1,0 @@
-label: RSS

--- a/config/language/es/metatag.metatag_defaults.global.yml
+++ b/config/language/es/metatag.metatag_defaults.global.yml
@@ -1,3 +1,0 @@
-label: Global
-tags:
-  title: '[current-page:title] | [site:name]'

--- a/config/language/fil/core.entity_view_mode.node.rss.yml
+++ b/config/language/fil/core.entity_view_mode.node.rss.yml
@@ -1,1 +1,0 @@
-label: RSS

--- a/config/language/fil/workflows.workflow.editorial.yml
+++ b/config/language/fil/workflows.workflow.editorial.yml
@@ -1,4 +1,0 @@
-type_settings:
-  states:
-    published:
-      label: Published

--- a/config/language/zh-hant/core.entity_view_mode.node.rss.yml
+++ b/config/language/zh-hant/core.entity_view_mode.node.rss.yml
@@ -1,1 +1,0 @@
-label: RSS

--- a/config/language/zh-hant/field.field.node.article.field_tags.yml
+++ b/config/language/zh-hant/field.field.node.article.field_tags.yml
@@ -1,2 +1,2 @@
-label: '標籤 (Tags)'
+label: Tags
 description: '輸入一個以逗號分隔的列表。例如：阿姆斯特丹, 墨西哥市, "克利夫蘭, 俄亥俄州"'

--- a/config/language/zh-hant/metatag.metatag_defaults.node.yml
+++ b/config/language/zh-hant/metatag.metatag_defaults.node.yml
@@ -1,1 +1,3 @@
 label: 內容
+tags:
+  description: '[node:field_description]'

--- a/config/language/zh-hant/taxonomy.vocabulary.tags.yml
+++ b/config/language/zh-hant/taxonomy.vocabulary.tags.yml
@@ -1,2 +1,2 @@
-name: '標籤 (Tags)'
+name: Tags
 description: '透過標籤 (tags) 來為相似的主題文章做分群、分類。'

--- a/config/language/zh-hant/views.view.redirect.yml
+++ b/config/language/zh-hant/views.view.redirect.yml
@@ -17,6 +17,6 @@ display:
       filters:
         redirect_redirect__uri:
           expose:
-            label: 收件人
+            label: To
   page_1:
     display_title: 頁面

--- a/config/system.action.bulk_update_fields_on_embed_button.yml
+++ b/config/system.action.bulk_update_fields_on_embed_button.yml
@@ -1,0 +1,11 @@
+uuid: c3a0b9a7-10bf-4b5f-9e1a-a61361976ac2
+langcode: en
+status: true
+dependencies:
+  module:
+    - bulk_update_fields
+id: bulk_update_fields_on_embed_button
+label: 'Bulk Update Embed button Fields'
+type: embed_button
+plugin: bulk_update_fields_action_base
+configuration: {  }

--- a/pantheon.yml
+++ b/pantheon.yml
@@ -22,6 +22,9 @@ workflows:
       - type: webphp
         description: 'Multidev created'
         script: private/scripts/test/test_hook.php
+      - type: webphp
+        description: 'Create test users'
+        script: private/scripts/drush_create_users/create_users.php
         
   sync_code: # push code via git (dev/multidev)
     after:
@@ -37,6 +40,9 @@ workflows:
       - type: webphp
         description: 'Import configuration from .yml files'
         script: private/scripts/drush_config_import/drush_config_import.php
+      - type: webphp
+        description: 'Create test users'
+        script: private/scripts/drush_create_users/create_users.php
 
   deploy: # deploy code to test or live
     after:

--- a/patches/entity_reference_unpublished-media.patch
+++ b/patches/entity_reference_unpublished-media.patch
@@ -1,0 +1,43 @@
+diff --git a/src/Plugin/EntityReferenceSelection/UnpublishedMediaSelection.php b/src/Plugin/EntityReferenceSelection/UnpublishedMediaSelection.php
+new file mode 100644
+index 0000000..6e30258
+--- /dev/null
++++ b/src/Plugin/EntityReferenceSelection/UnpublishedMediaSelection.php
+@@ -0,0 +1,37 @@
++<?php
++
++namespace Drupal\entity_reference_unpublished\Plugin\EntityReferenceSelection;
++
++use Drupal\Core\Form\FormStateInterface;
++use Drupal\Core\Entity\Plugin\EntityReferenceSelection\DefaultSelection;
++
++/**
++ * Unpublished media plugin of the Entity Reference Selection plugin.
++ *
++ * @see \Drupal\Core\Entity\EntityReferenceSelection\SelectionPluginManager
++ * @see \Drupal\Core\Entity\Annotation\EntityReferenceSelection
++ * @see \Drupal\Core\Entity\EntityReferenceSelection\SelectionInterface
++ * @see \Drupal\Core\Entity\Plugin\Derivative\DefaultSelectionDeriver
++ * @see plugin_api
++ *
++ * @EntityReferenceSelection(
++ *   id = "unpublished_media",
++ *   label = @Translation("Unpublished Media"),
++ *   entity_types = {"media"},
++ *   group = "unpublished_media",
++ *   weight = 0,
++ * )
++ */
++class UnpublishedMediaSelection extends DefaultSelection {
++
++  /**
++   * {@inheritdoc}
++   */
++  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
++    $form = parent::buildConfigurationForm($form, $form_state);
++    $form['target_bundles']['#title'] = $this->t('Media');
++
++    return $form;
++  }
++
++}

--- a/web/private/scripts/drush_create_users/create_users.php
+++ b/web/private/scripts/drush_create_users/create_users.php
@@ -27,5 +27,3 @@
   }  
 
   _test_hook_slack_notification("create users: \n" . (strlen($debug) > 0 ? $debug : '  no users created'));
-
-  

--- a/web/private/scripts/drush_create_users/create_users.php
+++ b/web/private/scripts/drush_create_users/create_users.php
@@ -8,7 +8,7 @@
   ob_end_clean();
   $json = json_decode($roles);
 
-  $pw = _get_secrets(['drush_pw']);
+  $pw = _get_secrets(['drush_pw'])['drush_pw'];
   $debug = '';
 
   foreach ($json as $role => $val) {

--- a/web/private/scripts/drush_create_users/create_users.php
+++ b/web/private/scripts/drush_create_users/create_users.php
@@ -8,6 +8,7 @@
   ob_end_clean();
   $json = json_decode($roles);
 
+  $pw = _get_secrets(['drush_pw']);
   $debug = '';
 
   foreach ($json as $role => $val) {
@@ -18,7 +19,7 @@
       $email = $user . '@test.com';
       $exitStatus = null;
       $output = null;
-      exec("drush user:create ${user} --mail=\"${email}\" --password=\"password\"", $output, $exitStatus);
+      exec("drush user:create ${user} --mail=\"${email}\" --password=\"${pw}\"", $output, $exitStatus);
       if ($exitStatus == 0) {
         exec("drush user-add-role \"${machineNameRole}\" ${user}");
         $debug .= "  - user ${user} created with role {$machineNameRole}\n";

--- a/web/private/scripts/drush_create_users/create_users.php
+++ b/web/private/scripts/drush_create_users/create_users.php
@@ -1,0 +1,31 @@
+<?php
+  require dirname(__DIR__) . '/../shared.php';
+
+  // get the roles
+  ob_start();
+  passthru('drush role:list --fields=label --format=json');
+  $roles = ob_get_contents();
+  ob_end_clean();
+  $json = json_decode($roles);
+
+  $debug = '';
+
+  foreach ($json as $role => $val) {
+    if ($role !== 'authenticated' && $role !== 'anonymous') {
+      $machineNameRole = $role; 
+      $normalizedRole = strtolower(str_replace('_', '', $role));
+      $user = 'test.' . $normalizedRole;
+      $email = $user . '@test.com';
+      $exitStatus = null;
+      $output = null;
+      exec("drush user:create ${user} --mail=\"${email}\" --password=\"password\"", $output, $exitStatus);
+      if ($exitStatus == 0) {
+        exec("drush user-add-role \"${machineNameRole}\" ${user}");
+        $debug .= "  - user ${user} created with role {$machineNameRole}\n";
+      }
+    }
+  }  
+
+  _test_hook_slack_notification("create users: \n" . (strlen($debug) > 0 ? $debug : '  no users created'));
+
+  


### PR DESCRIPTION
This pr adds the [Entity Reference Unpublished](https://www.drupal.org/project/entity_reference_unpublished) and the [Embed](https://www.drupal.org/project/embed) modules in order to allow users without the permission `Bypass content access control` to reference the following unpublished content:

- content types
- taxonomy terms
- media (required manual patch)

We will also need to update the reference method for every field to `Unpublished Default` or `Unpublished Media` where appropriate.

I also snuck in a script to `drush user:create` and `drush user-add-role` to create a user for each role we have to facilitate testing in our multidev environments 😅 