### PR TITLE
Allow editor to update vaccine sites header description

### DIFF
--- a/config/sfgov_vaccine.settings.yml
+++ b/config/sfgov_vaccine.settings.yml
@@ -70,7 +70,7 @@ form_strings:
 template_strings:
   page:
     title: 'COVID-19 vaccine sites'
-    description: 'Find out where to get a vaccine. If you need a second dose, contact the location where you got your first dose. If you got a J&J vaccine, we have some supplemental doses. <a href=''https://sf.gov/covid-19-vaccine-san-francisco''>Learn more</a>'
+    description: 'Find out where to get a vaccine. If you need a second dose, contact the location where you got your first dose. <a href=''https://sf.gov/covid-19-vaccine-san-francisco''>Learn more</a>'
     alert:
       value: "<p>You must be eligible in order to get vaccinated. <a href=\"/getvaccinated\">See eligibility criteria</a></p>\r\n"
       format: sf_restricted_html

--- a/config/sfgov_vaccine.settings.yml
+++ b/config/sfgov_vaccine.settings.yml
@@ -70,7 +70,7 @@ form_strings:
 template_strings:
   page:
     title: 'COVID-19 vaccine sites'
-    description: 'Find out where to get a vaccine if you''re eligible. Keep checking for appointments. New locations will be added as they''re available.  If you need a second dose, contact the location where you got your first dose.  <a href=/covid-19-vaccine-san-francisco>Learn more.</a>'
+    description: 'Find out where to get a vaccine. If you need a second dose, contact the location where you got your first dose. If you got a J&J vaccine, we have some supplemental doses. <a href=''https://sf.gov/covid-19-vaccine-san-francisco''>Learn more</a>'
     alert:
       value: "<p>You must be eligible in order to get vaccinated. <a href=\"/getvaccinated\">See eligibility criteria</a></p>\r\n"
       format: sf_restricted_html

--- a/web/modules/custom/sfgov_vaccine/sfgov_vaccine.module
+++ b/web/modules/custom/sfgov_vaccine/sfgov_vaccine.module
@@ -35,6 +35,7 @@ function sfgov_vaccine_theme() {
     'vaccine_widget' => [
       'variables' => [
         'alert' => NULL,
+        'header_description' => NULL,
         'template_strings' => NULL,
         'filters' => NULL,
         'results' => NULL,

--- a/web/modules/custom/sfgov_vaccine/sfgov_vaccine.services.yml
+++ b/web/modules/custom/sfgov_vaccine/sfgov_vaccine.services.yml
@@ -1,4 +1,5 @@
 services:
   sfgov_vaccine.values:
     class: Drupal\sfgov_vaccine\Services\VaxValues
-    arguments: ['@state', '@config.factory']
+    arguments: ['@state', '@config.factory', '@string_translation']
+    

--- a/web/modules/custom/sfgov_vaccine/src/Controller/VaccineController.php
+++ b/web/modules/custom/sfgov_vaccine/src/Controller/VaccineController.php
@@ -359,6 +359,7 @@ class VaccineController extends ControllerBase {
       '#cache' => ['max-age' => 0],
       '#theme' => 'vaccine_widget',
       '#alert' => $this->vaxValues->getAlert(),
+      '#header_description' => $this->vaxValues->getHeaderDescription(),
       '#template_strings' => $this->vaxValues->settings('template_strings'),
       '#api_data' => $this->makeAPIData($this->allData),
       '#filters' => $this->makeFilters($this->allData),

--- a/web/modules/custom/sfgov_vaccine/src/Form/SettingsForm.php
+++ b/web/modules/custom/sfgov_vaccine/src/Form/SettingsForm.php
@@ -102,6 +102,15 @@ class SettingsForm extends ConfigFormBase {
       '#allowed_formats' => ['sf_restricted_html'],
     ];
 
+    $form['header_description'] = [
+      '#type' => 'text_format',
+      '#title' => $this->t('Vaccine Page Header Description Text'),
+      '#description' => $this->t('Enter the description for the light blue header'),
+      '#default_value' => $this->vaxValues->getHeaderDescription(),
+      '#format' => 'sf_restricted_html',
+      '#allowed_formats' => ['sf_restricted_html'],
+    ];
+
     $form['submit'] = [
       '#type' => 'submit',
       '#value' => $this->t('Submit'),
@@ -144,6 +153,7 @@ class SettingsForm extends ConfigFormBase {
       ->save();
 
     $this->vaxValues->setAlert($form_state->getValue('alert'));
+    $this->vaxValues->setHeaderDescription($form_state->getValue('header_description'));
   }
 
 }

--- a/web/modules/custom/sfgov_vaccine/src/Services/VaxValues.php
+++ b/web/modules/custom/sfgov_vaccine/src/Services/VaxValues.php
@@ -59,5 +59,16 @@ class VaxValues {
   public function setAlert($value) {
     $this->state->set('vaccine_alert', $value);
   }
+
+  public function getHeaderDescription() {
+    $header_db = $this->state->get('header_description');
+    $header_db_val = $header_db['value'];
+    $header_config_val = $this->settings('template_strings.page.description');
+    return isset($header_db) ? $header_db_val : $header_config_val;
+  }
+
+  public function setHeaderDescription($value) {
+    $this->state->set('header_description', $value);
+  }
 }
 

--- a/web/modules/custom/sfgov_vaccine/src/Services/VaxValues.php
+++ b/web/modules/custom/sfgov_vaccine/src/Services/VaxValues.php
@@ -4,9 +4,13 @@ namespace Drupal\sfgov_vaccine\Services;
 
 use Drupal\Core\State\State;
 use Drupal\Core\Config\ConfigFactory;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class VaxValues {
+  use StringTranslationTrait;
+
   /**
    * State object.
    *
@@ -22,17 +26,26 @@ class VaxValues {
   protected $configFactory;
 
   /**
+   * The string translation service
+   * 
+   * @var \Drupal\Core\StringTranslation\TranslationInterface
+   */
+  protected $stringTranslation;
+
+  /**
    * Class constructor.
    */
-  public function __construct(State $state, ConfigFactory $configFactory) {
+  public function __construct(State $state, ConfigFactory $configFactory, TranslationInterface $stringTranslation) {
     $this->state = $state;
     $this->configFactory = $configFactory;
+    $this->stringTranslation = $stringTranslation;
   }
 
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('state'),
-      $container->get('config.factory')
+      $container->get('config.factory'),
+      $container->get('string_translation')
     );
   }
 
@@ -65,7 +78,7 @@ class VaxValues {
     $header_db_val = $header_db['value'];
     $header_config_val = $this->settings('template_strings.page.description');
     $headerDescription = isset($header_db) ? $header_db_val : $header_config_val;
-    return t($headerDescription);
+    return $this->t($headerDescription);
   }
 
   public function setHeaderDescription($value) {

--- a/web/modules/custom/sfgov_vaccine/src/Services/VaxValues.php
+++ b/web/modules/custom/sfgov_vaccine/src/Services/VaxValues.php
@@ -64,7 +64,8 @@ class VaxValues {
     $header_db = $this->state->get('header_description');
     $header_db_val = $header_db['value'];
     $header_config_val = $this->settings('template_strings.page.description');
-    return isset($header_db) ? $header_db_val : $header_config_val;
+    $headerDescription = isset($header_db) ? $header_db_val : $header_config_val;
+    return t($headerDescription);
   }
 
   public function setHeaderDescription($value) {

--- a/web/themes/custom/sfgovpl/templates/components/vaccine/vaccine-widget--header.twig
+++ b/web/themes/custom/sfgovpl/templates/components/vaccine/vaccine-widget--header.twig
@@ -3,8 +3,8 @@
     <h1>
       {{ template_strings.page.title|t }}
     </h1>
-    <p class="lead-paragraph notranslate">
+    <div class="lead-paragraph notranslate">
       {{ header_description | raw }}
-    </p>
+    </div>
   </div>
 </header>

--- a/web/themes/custom/sfgovpl/templates/components/vaccine/vaccine-widget--header.twig
+++ b/web/themes/custom/sfgovpl/templates/components/vaccine/vaccine-widget--header.twig
@@ -4,7 +4,7 @@
       {{ template_strings.page.title|t }}
     </h1>
     <p class="lead-paragraph notranslate">
-      {{ template_strings.page.description|t }}
+      {{ header_description | raw }}
     </p>
   </div>
 </header>


### PR DESCRIPTION
Exposes the header description text to be user-editable.

Also updates config to match what's currently on production, which is probably unnecessary now that the header text is coming from state