### PR TITLE
[SG-1478] Fix covid19 Youtube video link

### DIFF
--- a/web/modules/custom/sfgov_video/src/VideoService.php
+++ b/web/modules/custom/sfgov_video/src/VideoService.php
@@ -106,18 +106,24 @@ class VideoService {
    * @throws \GuzzleHttp\Exception\GuzzleException
    */
   public function getYoutubeMetadata($video_id, $languageCode = 'en') {
-    $video_info_url = "https://www.youtube.com/get_video_info?video_id=" . $video_id . "&html5=1";
-    $request = $this->httpClient->request('GET', $video_info_url);
-    $contents = $request->getBody()->getContents();
+    // Retrieve the response from the API.
+    $youtube_api_url = 'https://www.youtube.com/youtubei/v1/player?key=AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8';
+    $ch = curl_init();
+    curl_setopt($ch, CURLOPT_URL, $youtube_api_url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+    curl_setopt($ch, CURLOPT_POST, 1);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, '{  "context": {    "client": {      "hl": "en",      "clientName": "WEB",      "clientVersion": "2.20210721.00.00",      "clientFormFactor": "UNKNOWN_FORM_FACTOR",   "clientScreen": "WATCH",      "mainAppWebInfo": {        "graftUrl": "/watch?v=' . $video_id . '",           }    },    "user": {      "lockedSafetyMode": false    },    "request": {      "useSsl": true,      "internalExperimentFlags": [],      "consistencyTokenJars": []    }  },  "videoId": "' . $video_id . '",  "playbackContext": {    "contentPlaybackContext": {        "vis": 0,      "splay": false,      "autoCaptionsDefaultOn": false,      "autonavState": "STATE_NONE",      "html5Preference": "HTML5_PREF_WANTS",      "lactMilliseconds": "-1"    }  },  "racyCheckOk": false,  "contentCheckOk": false}');
+    curl_setopt($ch, CURLOPT_ENCODING, 'gzip, deflate');
+    $headers = array();
+    $headers[] = 'Content-Type: application/json';
+    curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+    $result = curl_exec($ch);
 
-    parse_str($contents, $video_info_array);
-
-    if ($video_info_array['status'] == 'fail') {
+    if (json_decode($result)->playabilityStatus->status != 'OK') {
       throw new NotFoundHttpException();
     }
 
-    $response = $video_info_array['player_response'];
-    $json = JSON::decode($response);
+    $json = JSON::decode($result);
 
     $caption_tracks = isset($json['captions']) ? $json['captions']['playerCaptionsTracklistRenderer']['captionTracks'] : [];
 


### PR DESCRIPTION
The caption video that can be accessed from the "Open in another tab" link was broken.

Implement new changes from the Youtube API.