### PR TITLE
[SG-1471] Add a warning for editors about remove button not working

### DIFF
--- a/web/modules/custom/sfgov_utilities/js/remove-button-warning.js
+++ b/web/modules/custom/sfgov_utilities/js/remove-button-warning.js
@@ -1,0 +1,7 @@
+(function($) {
+  var removeButton = $('.remove-field-delta--0');
+  if (removeButton.length > 0) {
+    var relatedField = $('div.js-form-item-field-related-content-0-target-id');
+    relatedField.append('<p class="remove-button-warning">To remove a related item, remove the text and save the page.</p>');
+  }
+}(jQuery));

--- a/web/modules/custom/sfgov_utilities/sfgov_utilities.libraries.yml
+++ b/web/modules/custom/sfgov_utilities/sfgov_utilities.libraries.yml
@@ -1,3 +1,9 @@
+remove_button_warning:
+  js:
+    js/remove-button-warning.js: {}
+  dependencies:
+    - core/drupal
+    - core/jquery
 services:
   js:
     js/sfgov_utilities_services.js: {}

--- a/web/modules/custom/sfgov_utilities/sfgov_utilities.module
+++ b/web/modules/custom/sfgov_utilities/sfgov_utilities.module
@@ -151,6 +151,11 @@ function sfgov_utilities_entity_type_alter(array &$entity_types) {
 }
 
 function sfgov_utilities_page_attachments(array &$page) {
+  // Workaround for remove button not working for entity reference fields.
+  $node = \Drupal::routeMatch()->getParameter('node');
+  if (!empty($node) && $node instanceOf NodeInterface) {
+    $page['#attached']['library'][] = 'sfgov_utilities/remove_button_warning';
+  }
   // Don't run on admin pages
   if (!\Drupal::service('router.admin_context')->isAdminRoute()) {
     $node = \Drupal::routeMatch()->getParameter('node');


### PR DESCRIPTION
For the related field which is an entity reference. The other fields in the node edit view can be removed for some reason.