### PR TITLE
[SG-1363] Fix multiple phone numbers in paragraph

### DIFF
--- a/web/modules/custom/sfgov_admin/js/dist/sfgov-admin.js
+++ b/web/modules/custom/sfgov_admin/js/dist/sfgov-admin.js
@@ -85,19 +85,21 @@
   Drupal.behaviors.sfgovFormatTelephone = {
     attach: function (context, settings) {
       $('#edit-submit').once().on('click', function (e) {
-        var phoneField = $('.form-tel');
+        $('.form-tel').each(function () {
+          var phoneField = $(this);
 
-        if (phoneField.length > 0) {
-          var regex = new RegExp("\\d+", "g");
+          if (phoneField.length > 0) {
+            var regex = new RegExp("\\d+", "g");
 
-          if (phoneField.val().length > 0) {
-            var number = phoneField.val().match(regex).join("");
+            if (phoneField.val().length > 0) {
+              var number = phoneField.val().match(regex).join("");
 
-            if (number.length == 10) {
-              phoneField.val(number.slice(0, 3) + "-" + number.slice(3, 6) + "-" + number.slice(6));
+              if (number.length == 10) {
+                phoneField.val(number.slice(0, 3) + "-" + number.slice(3, 6) + "-" + number.slice(6));
+              }
             }
           }
-        }
+        });
       });
     }
   }; // populate the sort title for transactions based on the title (excluding stop words at the beginning of a title)

--- a/web/modules/custom/sfgov_admin/js/src/sfgov-admin.js
+++ b/web/modules/custom/sfgov_admin/js/src/sfgov-admin.js
@@ -93,18 +93,22 @@
 
   // Enforce telephone numbers have format XXX-XXX-XXXX
   Drupal.behaviors.sfgovFormatTelephone = {
-    attach: function(context, settings) {
-      $('#edit-submit').once().on('click', function(e) {
-        var phoneField = $('.form-tel');
-        if (phoneField.length > 0) {
-          var regex = new RegExp("\\d+", "g");
-          if(phoneField.val().length > 0) {
-            var number = phoneField.val().match(regex).join("");
-            if (number.length == 10) {
-              phoneField.val(number.slice(0,3) + "-" + number.slice(3,6) + "-" + number.slice(6));
+    attach: function (context, settings) {
+      $('#edit-submit').once().on('click', function (e) {
+        $('.form-tel').each(function() {
+          var phoneField = $(this);
+          if (phoneField.length > 0) {
+            var regex = new RegExp("\\d+", "g");
+
+            if (phoneField.val().length > 0) {
+              var number = phoneField.val().match(regex).join("");
+
+              if (number.length == 10) {
+                phoneField.val(number.slice(0, 3) + "-" + number.slice(3, 6) + "-" + number.slice(6));
+              }
             }
           }
-        }
+        })
       })
     }
   }


### PR DESCRIPTION
Phone formatter didn't handle multiple phone numbers in same paragraph, so the first number would always overwrite the others.