### PR TITLE
Upgrade form package versions: formio-sfds@9.2.1 + formiojs@4.13.2

### DIFF
--- a/config/sfgov_formio.settings.yml
+++ b/config/sfgov_formio.settings.yml
@@ -1,2 +1,2 @@
-formio_version: 4.12.1
-formio_sfds_version: 9.1.0
+formio_version: 4.13.2
+formio_sfds_version: 9.2.1


### PR DESCRIPTION
See https://github.com/SFDigitalServices/formio-sfds/pull/202 and https://github.com/SFDigitalServices/formio-sfds/pull/205 for `formio-sfds` changes since 9.1.0, and https://github.com/SFDigitalServices/formio-sfds/pull/189 for a summary of updates to `formiojs` since 4.12.1.