### PR TITLE
SG-1405 - hook_preprocess_page does not have view_mode available in vars

### DIFF
--- a/web/themes/custom/sfgovpl/includes/node.inc
+++ b/web/themes/custom/sfgovpl/includes/node.inc
@@ -786,7 +786,7 @@ function sfgovpl_add_regions_to_node(array $regions, &$variables) {
 function _sfgovpl_negotiate_translation(&$variables) {
   if (!empty($variables['node']) && $variables['node'] instanceof NodeInterface) {
     $node = $variables['node'];
-    $view_mode = $variables['view_mode'];
+    $view_mode = $variables['view_mode'] ?? 'full';
     $variables = array_merge($variables, _sfgovpl_node_notranslate($node, $view_mode));
   }
   return $variables;

--- a/web/themes/custom/sfgovpl/includes/page.inc
+++ b/web/themes/custom/sfgovpl/includes/page.inc
@@ -24,7 +24,7 @@ function sfgovpl_preprocess_page_title(&$variables) {
  * Implements theme_preprocess_page
  * @see node.inc for _sfgovpl_negotiate_translation
  */
-function sfgovpl_preprocess_page(&$variables) {
+function sfgovpl_preprocess_page__node__form_page(&$variables) {
   _sfgovpl_negotiate_translation($variables);
 }
 


### PR DESCRIPTION
Getting this error frequently since #1009:

```
Notice: Undefined index: view_mode in _sfgovpl_negotiate_translation() (line 1102 of themes/custom/sfgovpl/includes/node.inc).
```

This pr narrows the scope of `sfgovpl_preprocess_page` to `sfgovpl_preprocess_page__node__form_page` and provides a default value for the `$view_mode` param in `_sfgovpl_node_notranslate`