### PR TITLE
Add "content_lang" property to Amplitude page views

### DIFF
--- a/config/amplitude.amplitude_event.page_view.yml
+++ b/config/amplitude.amplitude_event.page_view.yml
@@ -4,7 +4,15 @@ status: true
 dependencies: {  }
 id: page_view
 label: 'Page view'
-properties: '{"page_title":"[current-page:title]","page_url":"[current-page:url]","content_type":"[node:content-type:name]","department":"[sfgov:field_departments]", "topic":"[sfgov:field_topics]"}'
+properties: |
+  {
+    "page_title": "[current-page:title]",
+    "page_url": "[current-page:url]",
+    "content_lang": "[node:langcode]",
+    "content_type": "[node:content-type:name]",
+    "department": "[sfgov:field_departments]",
+    "topic":"[sfgov:field_topics]"
+  }
 event_trigger: pageLoad
 event_trigger_pages: "/*\r\n<front>"
 event_trigger_scroll_depths: ''


### PR DESCRIPTION
This PR adds a new `content_lang` property to Amplitude page view events via the `[node:langcode]` "token". I've demoed this on test-sfgov and confirmed that it works by modifying the Amplitude configuration there (using the "SF.gov test" project key [here](https://test-sfgov.pantheonsite.io/admin/config/system/amplitude)) and finding my events in Amplitude:

![image](https://user-images.githubusercontent.com/113896/135693120-532f9e40-e6ca-41bc-bbfa-2f949d4d5669.png)

~I also want to test this out on this PR's multidev to confirm that my formatting of JSON-string-in-YAML is legit.~ (It is!)

Another thing I noticed when sifting through my own events in Amplitude is that the Drupal plugin doesn't appear to expand any of the bracketed "tokens" on Drupal admin pages, which creates some noise in our event data:

![image](https://user-images.githubusercontent.com/113896/135693220-fcf7c9b1-4d2a-46e8-aa1d-c73af85bb164.png)

This probably isn't a huge issue since we filter out logged in views in most of our analytics anyway—and if we don't, we should!—but it may show up when we start grouping events by content language.