### PR TITLE
SG-1506 Fix resource tile widths when tile content is small

### DIFF
--- a/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-campaign-resource-section.scss
+++ b/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-campaign-resource-section.scss
@@ -5,6 +5,7 @@ $rhythm: 0.5882rem;
 
 .paragraph--type--campaign-resource-section {
   margin-bottom: 57px;
+  width: 100%;
   > .title {
     @include fs-big-description;
     margin-bottom: 13px;


### PR DESCRIPTION
If tiles are small, they don't force parent to be 100% width. So force it.