### PR TITLE
Add Amplitude event logging for GitHub events

### DIFF
--- a/.github/workflows/amplitude.yml
+++ b/.github/workflows/amplitude.yml
@@ -1,19 +1,15 @@
 name: Amplitude events
 on:
-  # - check_run
-  # - check_suite
   - deployment_status
   - pull_request:
       types:
         - opened
+        - synchronize
+        - edited
         - closed
         - reopened
         - converted_to_draft
-        - ready_for_review
-        - review_request_removed
         - review_requested
-  - push:
-      tags: 'v*'
   - release:
       types:
         - created

--- a/.github/workflows/amplitude.yml
+++ b/.github/workflows/amplitude.yml
@@ -16,12 +16,14 @@ on:
       tags: 'v*'
   - release:
       types:
+        - created
         - published
+        - released
 
 jobs:
   log:
-    runs-on: ubuntu-latest
     if: secrets.AMPLITUDE_API_KEY
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/node@v2

--- a/.github/workflows/amplitude.yml
+++ b/.github/workflows/amplitude.yml
@@ -1,0 +1,35 @@
+name: Amplitude events
+on:
+  # - check_run
+  # - check_suite
+  - deployment_status
+  - pull_request:
+      types:
+        - opened
+        - closed
+        - reopened
+        - converted_to_draft
+        - ready_for_review
+        - review_request_removed
+        - review_requested
+  - push:
+      tags: 'v*'
+  - release:
+      types:
+        - published
+
+jobs:
+  log:
+    runs-on: ubuntu-latest
+    if: secrets.AMPLITUDE_API_KEY
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/node@v2
+        with:
+          node-version: 14
+      - name: npm install
+        run: npm install @actions/{core,github} @amplitude/node
+      - name: log amplitude event
+        env:
+          AMPLITUDE_API_KEY: ${{ secrets.AMPLITUDE_API_KEY }}
+        run: ./scripts/custom/amplitude-event.js

--- a/scripts/custom/amplitude-event.js
+++ b/scripts/custom/amplitude-event.js
@@ -1,0 +1,47 @@
+const actions = require('@actions/core')
+const { context } = require('@actions/github')
+const amplitude = require('@amplitude/node')
+
+const { AMPLITUDE_API_KEY } = process.env
+if (!AMPLITUDE_API_KEY) {
+  actions.setFailed('Missing AMPLITUDE_API_KEY')
+}
+
+const {
+  eventName,
+  action = context.payload.deployment_status?.state,
+  actor,
+  sha,
+  ref
+} = context
+
+const eventType = [
+  'github',
+  eventName,
+  action
+].filter(Boolean).join('.')
+
+const userProperties = {
+  user_id: `github:${actor}`,
+  github: {
+    user: actor,
+    href: `https://github.com/${actor}`
+  }
+}
+
+const eventProperties = {
+  name: eventName,
+  sha,
+  ref,
+  ...context.payload
+}
+
+const amp = amplitude.init(AMPLITUDE_API_KEY)
+
+amp.logEvent({
+  event_type: eventType,
+  ...userProperties,
+  event_properties: eventProperties
+})
+
+amp.flush()


### PR DESCRIPTION
This is the first step of SG-1550.

The idea here is to collect some metrics on our work. I'm particularly interested in how long PRs take to review and merge, but I'm also really interested in how long CI runs and deployment to Pantheon take, so that we can better understand where we can eke out some more speed (so we can work more effectively).

GitHub Actions workflow changes don't run on pull requests, so we will need to merge this PR to start collecting events. We may need to follow up with some tweaks to the Amplitude event data, but I think this will be a good start.