### PR TITLE
patch - update host value for lionbridge api

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -263,6 +263,9 @@
             },
             "drupal/entity_reference_unpublished": {
                 "Allow reference to unpublished media": "patches/entity_reference_unpublished-media.patch"
+            },
+            "drupal/lionbridge_translation_provider": {
+                "Update host value for lionbridge api": "patches/lionbridge-host-update.patch"
             }
         }
     },

--- a/patches/lionbridge-host-update.patch
+++ b/patches/lionbridge-host-update.patch
@@ -1,0 +1,13 @@
+diff --git a/tmgmt_contentapi/src/Swagger/Client/Configuration.php b/tmgmt_contentapi/src/Swagger/Client/Configuration.php
+index 2838778..6b9f050 100644
+--- a/tmgmt_contentapi/src/Swagger/Client/Configuration.php
++++ b/tmgmt_contentapi/src/Swagger/Client/Configuration.php
+@@ -87,7 +87,7 @@ class Configuration
+      *
+      * @var string
+      */
+-    protected $host = 'https://contentapi.lionbridge.com/v2';
++    protected $host = 'https://content-api.staging.lionbridge.com/v2';
+ 
+     /**
+      * The host_ctt


### PR DESCRIPTION
per instructions in ticket:

> This provider is routing to machine translation for testing purposes.
Please also modify the protected $host value endpoint in lionbridge_translation_provider\tmgmt_contentapi\src\Swagger\Client\Configuration.php to:
https://content-api.staging.lionbridge.com/v2