### PR TITLE
Post deploy profile configs

### DIFF
--- a/config/core.entity_form_display.node.person.default.yml
+++ b/config/core.entity_form_display.node.person.default.yml
@@ -22,14 +22,12 @@ dependencies:
     - field.field.node.person.field_spotlight
     - field.field.node.person.field_sub_title
     - field.field.node.person.field_title
-    - image.style.thumbnail
     - node.type.person
     - workflows.workflow.editorial
   module:
     - content_moderation
     - entity_browser
     - field_group
-    - image
     - link
     - paragraphs
     - path
@@ -45,7 +43,7 @@ third_party_settings:
         - field_phone_numbers
         - field_email
       parent_name: ''
-      weight: 12
+      weight: 11
       format_type: fieldset
       region: content
       format_settings:
@@ -72,7 +70,7 @@ third_party_settings:
       children:
         - group_optional_content
       parent_name: ''
-      weight: 13
+      weight: 12
       format_type: accordion
       region: content
       format_settings:
@@ -89,7 +87,7 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 16
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -109,7 +107,7 @@ content:
     type: entity_browser_entity_reference
     region: content
   field_biography:
-    weight: 8
+    weight: 7
     settings:
       rows: 5
       placeholder: ''
@@ -127,7 +125,7 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_direct_external_url:
-    weight: 14
+    weight: 13
     settings:
       placeholder_url: ''
       placeholder_title: ''
@@ -205,16 +203,8 @@ content:
     third_party_settings: {  }
     type: paragraphs
     region: content
-  field_photo:
-    type: image_image
-    weight: 7
-    region: content
-    settings:
-      progress_indicator: throbber
-      preview_image_style: thumbnail
-    third_party_settings: {  }
   field_primary_email:
-    weight: 9
+    weight: 8
     settings:
       size: 60
       placeholder: ''
@@ -222,7 +212,7 @@ content:
     type: email_default
     region: content
   field_primary_phone_number:
-    weight: 10
+    weight: 9
     settings:
       placeholder: ''
     third_party_settings: {  }
@@ -249,7 +239,7 @@ content:
     type: options_select
     region: content
   field_social_media:
-    weight: 11
+    weight: 10
     settings:
       title: Paragraph
       title_plural: Paragraphs
@@ -303,13 +293,13 @@ content:
     region: content
   moderation_state:
     type: moderation_state_default
-    weight: 20
+    weight: 19
     settings: {  }
     region: content
     third_party_settings: {  }
   path:
     type: path
-    weight: 18
+    weight: 17
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -322,13 +312,13 @@ content:
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 25
+    weight: 24
     region: content
     settings: {  }
     third_party_settings: {  }
   publish_state:
     type: scheduler_moderation
-    weight: 23
+    weight: 22
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -336,7 +326,7 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 21
+    weight: 20
     region: content
     third_party_settings: {  }
   sticky:
@@ -348,20 +338,20 @@ content:
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: 22
+    weight: 21
     region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
   translation:
-    weight: 17
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 15
+    weight: 14
     settings:
       match_operator: CONTAINS
       size: 60
@@ -371,20 +361,21 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 24
+    weight: 23
     region: content
     settings: {  }
     third_party_settings: {  }
   unpublish_state:
     type: scheduler_moderation
-    weight: 26
+    weight: 25
     region: content
     settings: {  }
     third_party_settings: {  }
   url_redirects:
-    weight: 19
+    weight: 18
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_photo: true
   langcode: true

--- a/config/field.field.node.department.field_people.yml
+++ b/config/field.field.node.department.field_people.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - field.storage.node.field_people
     - node.type.department
-    - paragraphs.paragraphs_type.people
     - paragraphs.paragraphs_type.profile_group
   module:
     - entity_reference_revisions
@@ -28,7 +27,6 @@ settings:
   handler_settings:
     negate: 0
     target_bundles:
-      people: people
       profile_group: profile_group
     target_bundles_drag_drop:
       accordion:
@@ -85,6 +83,15 @@ settings:
       custom_section:
         weight: 34
         enabled: false
+      data_story_reference_section:
+        weight: 90
+        enabled: false
+      data_story_reference_subsection:
+        weight: 91
+        enabled: false
+      data_story_section:
+        weight: 92
+        enabled: false
       department_content:
         weight: 81
         enabled: false
@@ -93,6 +100,12 @@ settings:
         enabled: false
       document:
         weight: 36
+        enabled: false
+      document_section:
+        weight: 96
+        enabled: false
+      document_subsection:
+        weight: 97
         enabled: false
       email:
         weight: 37
@@ -123,6 +136,9 @@ settings:
         enabled: false
       help:
         weight: 39
+        enabled: false
+      image:
+        weight: 108
         enabled: false
       image_with_text:
         weight: 94
@@ -155,13 +171,16 @@ settings:
         weight: 103
         enabled: false
       people:
-        enabled: true
         weight: 45
+        enabled: false
       phone:
         weight: 46
         enabled: false
       phone_numbers:
         weight: 106
+        enabled: false
+      powerbi_embed:
+        weight: 122
         enabled: false
       process_step:
         weight: 107
@@ -171,6 +190,12 @@ settings:
         weight: 108
       public_body_profiles:
         weight: 109
+        enabled: false
+      resource_section:
+        weight: 127
+        enabled: false
+      resource_subsection:
+        weight: 128
         enabled: false
       resources:
         weight: 47

--- a/config/field.field.node.location.field_people.yml
+++ b/config/field.field.node.location.field_people.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - field.storage.node.field_people
     - node.type.location
-    - paragraphs.paragraphs_type.people
     - paragraphs.paragraphs_type.profile_group
   module:
     - entity_reference_revisions
@@ -28,7 +27,6 @@ settings:
   handler_settings:
     negate: 0
     target_bundles:
-      people: people
       profile_group: profile_group
     target_bundles_drag_drop:
       accordion:
@@ -173,8 +171,8 @@ settings:
         weight: 95
         enabled: false
       people:
-        enabled: true
         weight: 96
+        enabled: false
       phone:
         weight: 97
         enabled: false

--- a/config/field.field.node.person.field_city_department.yml
+++ b/config/field.field.node.person.field_city_department.yml
@@ -17,7 +17,7 @@ field_name: field_city_department
 entity_type: node
 bundle: person
 label: 'City department or public body'
-description: ''
+description: 'Profile will show contact information from department or public body (unless you enter another address)'
 required: false
 translatable: false
 default_value: {  }

--- a/config/field.field.node.public_body.field_board_members.yml
+++ b/config/field.field.node.public_body.field_board_members.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - field.storage.node.field_board_members
     - node.type.public_body
-    - paragraphs.paragraphs_type.people
     - paragraphs.paragraphs_type.profile_group
   module:
     - entity_reference_revisions
@@ -28,7 +27,6 @@ settings:
   handler_settings:
     negate: 0
     target_bundles:
-      people: people
       profile_group: profile_group
     target_bundles_drag_drop:
       accordion:
@@ -85,6 +83,15 @@ settings:
       custom_section:
         weight: 72
         enabled: false
+      data_story_reference_section:
+        weight: 90
+        enabled: false
+      data_story_reference_subsection:
+        weight: 91
+        enabled: false
+      data_story_section:
+        weight: 92
+        enabled: false
       department_content:
         weight: 73
         enabled: false
@@ -93,6 +100,12 @@ settings:
         enabled: false
       document:
         weight: 75
+        enabled: false
+      document_section:
+        weight: 96
+        enabled: false
+      document_subsection:
+        weight: 97
         enabled: false
       email:
         weight: 76
@@ -123,6 +136,9 @@ settings:
         enabled: false
       help:
         weight: 84
+        enabled: false
+      image:
+        weight: 108
         enabled: false
       image_with_text:
         weight: 85
@@ -155,13 +171,16 @@ settings:
         weight: 95
         enabled: false
       people:
-        enabled: true
         weight: 96
+        enabled: false
       phone:
         weight: 97
         enabled: false
       phone_numbers:
         weight: 98
+        enabled: false
+      powerbi_embed:
+        weight: 122
         enabled: false
       process_step:
         weight: 99
@@ -171,6 +190,12 @@ settings:
         weight: 108
       public_body_profiles:
         weight: 109
+        enabled: false
+      resource_section:
+        weight: 127
+        enabled: false
+      resource_subsection:
+        weight: 128
         enabled: false
       resources:
         weight: 100

--- a/config/field.field.paragraph.section.field_content.yml
+++ b/config/field.field.paragraph.section.field_content.yml
@@ -14,7 +14,6 @@ dependencies:
     - paragraphs.paragraphs_type.events
     - paragraphs.paragraphs_type.list
     - paragraphs.paragraphs_type.news
-    - paragraphs.paragraphs_type.people
     - paragraphs.paragraphs_type.phone
     - paragraphs.paragraphs_type.profile_group
     - paragraphs.paragraphs_type.resource_section
@@ -45,7 +44,6 @@ settings:
   handler_settings:
     negate: 0
     target_bundles:
-      people: people
       top_search_suggestion: top_search_suggestion
       block: block
       button: button
@@ -207,8 +205,8 @@ settings:
         weight: 79
         enabled: false
       people:
-        enabled: true
         weight: 21
+        enabled: false
       phone:
         enabled: true
         weight: 39

--- a/config/pathauto.pattern.person.yml
+++ b/config/pathauto.pattern.person.yml
@@ -5,18 +5,18 @@ dependencies:
   module:
     - node
 id: person
-label: Person
+label: Person/Profile
 type: 'canonical_entities:node'
-pattern: 'person/[node:source:title]'
+pattern: 'profile/[node:source:title]'
 selection_criteria:
-  6dc6d8d3-2ff1-49d0-b0b9-fdbceabd01ae:
+  0edcb641-3039-4516-bdac-c757e8871be4:
     id: node_type
     bundles:
       person: person
     negate: false
     context_mapping:
       node: node
-    uuid: 6dc6d8d3-2ff1-49d0-b0b9-fdbceabd01ae
+    uuid: 0edcb641-3039-4516-bdac-c757e8871be4
 selection_logic: and
 weight: -5
 relationships: {  }


### PR DESCRIPTION
- disable old profile photo field
- remove profile from front page, public body, location, department (keep profile group)
- update path alias to use /profile instead of /person
- add help text to field_city_department to say “Profile will show contact information from department or public body (unless you enter another address)”