### PR TITLE
VAX-265: Add tags to vaccination sites with kids5to11.allowed === true

### DIFF
--- a/config/sfgov_vaccine.settings.yml
+++ b/config/sfgov_vaccine.settings.yml
@@ -1,4 +1,4 @@
-api_url: 'https://sfgov-vaccine-sites.herokuapp.com/api/v1/appointments'
+api_url: 'https://sfgov-vaccine-sites-pr-252.herokuapp.com/api/v1/appointments'
 error_message: 'We are having trouble reaching the service right now. Please try again later.'
 languages:
   all:

--- a/config/sfgov_vaccine.settings.yml
+++ b/config/sfgov_vaccine.settings.yml
@@ -28,6 +28,8 @@ languages:
   rt:
     site_label: null
     filter_label: 'Other Languages'
+kids5to11:
+  true_text: 'ages 5 to 11'
 minors:
   true_text: '12 and older'
   false_text: '18 and older'

--- a/config/sfgov_vaccine.settings.yml
+++ b/config/sfgov_vaccine.settings.yml
@@ -1,4 +1,4 @@
-api_url: 'https://sfgov-vaccine-sites-pr-252.herokuapp.com/api/v1/appointments'
+api_url: 'https://sfgov-vaccine-sites.herokuapp.com/api/v1/appointments'
 error_message: 'We are having trouble reaching the service right now. Please try again later.'
 languages:
   all:

--- a/config/sfgov_vaccine.settings.yml
+++ b/config/sfgov_vaccine.settings.yml
@@ -29,7 +29,7 @@ languages:
     site_label: null
     filter_label: 'Other Languages'
 kids5to11:
-  true_text: 'ages 5 to 11'
+  true_text: 'age 5 to 11'
 minors:
   true_text: '12 and older'
   false_text: '18 and older'

--- a/web/modules/custom/sfgov_vaccine/src/Controller/VaccineController.php
+++ b/web/modules/custom/sfgov_vaccine/src/Controller/VaccineController.php
@@ -244,14 +244,18 @@ class VaccineController extends ControllerBase {
   /**
    * Prepare each site's eligibility text.
    */
-  private function getSiteEligibilityText($site_data, $group) {
+  private function getSiteEligibilities($site_data, $group) {
 
     $printed = [];
-    if (isset($site_data[$group]['allowed'])) {
-      $site_minor_status = $site_data[$group]['allowed'] ? 'true': 'false';
-      $text = $this->vaxValues->settings($group . '.' . $site_minor_status . '_text');
-      $printed_value = $this->t($text);
-      array_push($printed, $printed_value);
+    foreach (['minors', 'kids5to11'] as $group) {
+      if (isset($site_data[$group]['allowed'])) {
+        $allowed = $site_data[$group]['allowed'] ? 'true': 'false';
+        $text = $this->vaxValues->settings($group . '.' . $allowed . '_text');
+        if ($text) {
+          $printed_value = $this->t($text);
+          array_push($printed, $printed_value);
+        }
+      }
     }
     return $printed;
   }
@@ -281,7 +285,7 @@ class VaccineController extends ControllerBase {
     $results = [];
     foreach ($sites as $site_id => $site_data) {
 
-      $eligibility_text = $this->getSiteEligibilityText($site_data, 'minors');
+      $eligibilities = $this->getSiteEligibilities($site_data);
       $language_keys = $this->getSiteLanguageKeys($site_data['access']);
       $language_text = $this->getSiteLanguageText($site_data['access']);
       $access_mode_keys = $this->getSiteAccessModeKeys($site_data);
@@ -338,7 +342,7 @@ class VaccineController extends ControllerBase {
         'restrictions_text' => $restrictions_text,
         'location' => $location,
         'languages' => $language_text['printed_languages'],
-        'eligibilities' => $eligibility_text,
+        'eligibilities' => $eligibilities,
         'access_modes' => $access_mode_text,
         'info_url' => $info_url,
         'available' => $available,

--- a/web/modules/custom/sfgov_vaccine/src/Controller/VaccineController.php
+++ b/web/modules/custom/sfgov_vaccine/src/Controller/VaccineController.php
@@ -244,10 +244,10 @@ class VaccineController extends ControllerBase {
   /**
    * Prepare each site's eligibility text.
    */
-  private function getSiteEligibilities($site_data, $group) {
+  private function getSiteEligibilities($site_data) {
 
     $printed = [];
-    foreach (['minors', 'kids5to11'] as $group) {
+    foreach (['kids5to11', 'minors'] as $group) {
       if (isset($site_data[$group]['allowed'])) {
         $allowed = $site_data[$group]['allowed'] ? 'true': 'false';
         $text = $this->vaxValues->settings($group . '.' . $allowed . '_text');

--- a/web/modules/custom/sfgov_vaccine/src/Form/SettingsForm.php
+++ b/web/modules/custom/sfgov_vaccine/src/Form/SettingsForm.php
@@ -43,8 +43,8 @@ class SettingsForm extends ConfigFormBase {
    */
   public function __construct(ClientInterface $httpClient, ConfigFactory $configFactory, VaxValues $vaxValues) {
     $this->httpClient = $httpClient;
-      $this->configFactory = $configFactory;
-      $this->vaxValues = $vaxValues;
+    $this->configFactory = $configFactory;
+    $this->vaxValues = $vaxValues;
   }
 
   /**


### PR DESCRIPTION
The goal here is to add a visible "tag" to sites that have vaccine doses for kids age 5 to 11. They should look like this:

![image](https://user-images.githubusercontent.com/113896/140224501-cc896bc1-6080-4133-a685-ad8a080cbb79.png)
