### PR TITLE
Add notranslate classes to vaccine sites header + cards

### DIFF
--- a/web/themes/custom/sfgovpl/templates/components/vaccine/vaccine-site--booking.twig
+++ b/web/themes/custom/sfgovpl/templates/components/vaccine/vaccine-site--booking.twig
@@ -19,7 +19,6 @@
     {% set fancy_text = 'Appointments available as of'|t %}
     {% set btn_classes = [
       'sfgov-cta-button__container',
-      'notranslate',
       'vaccine-site__booking-button'
     ] %}
     {% set btn_text = 'Book an appointment'|t %}
@@ -27,7 +26,6 @@
     {% set fancy_text = 'No appointments as of'|t %}
     {% set btn_classes = [
       'box-item-indented',
-      'notranslate',
       'vaccine-site__booking-link'
     ] %}
     {% set btn_text = 'Visit booking website'|t %}
@@ -35,7 +33,6 @@
 {% elseif result.booking.url or result.booking.info %}
   {% set booking_box_classes = [
     'vaccine-site__booking_box',
-    'notranslate',
     result.booking.dropins ? 'js-dropin'
   ] %}
   {% set btn_classes = [
@@ -53,7 +50,7 @@
 {# Define reusuable blocks of code. #}
 {% set block_info %}
   {% if result.booking.info %}
-    <div class="box-item-indented vaccine-site__booking_info notranslate">
+    <div class="box-item-indented vaccine-site__booking_info">
       {# Raw tag is used here because this field can contain HTML. #}
       {{ result.booking.safe_info|raw }}
     </div>
@@ -82,7 +79,7 @@
   {% if fancy == true %}
     <div {{ field_attributes.addClass(field_classes) }}>
       <strong>
-        <span class="notranslate">{{ fancy_text }}</span>
+        <span>{{ fancy_text }}</span>
         {{ result.last_updated }}
       </strong>
     </div>

--- a/web/themes/custom/sfgovpl/templates/components/vaccine/vaccine-site.twig
+++ b/web/themes/custom/sfgovpl/templates/components/vaccine/vaccine-site.twig
@@ -1,6 +1,6 @@
-<div {{ result.attributes.setAttribute('data-order', loop.index) }}>
+<div {{ result.attributes.addClass('notranslate').setAttribute('data-order', loop.index) }}>
   <div class="vaccine-site__header">
-    <h3 class="vaccine-site__title notranslate">
+    <h3 class="vaccine-site__title">
       {{ result.site_name }}
     </h3>
 
@@ -8,7 +8,7 @@
   </div>
 
   {# Eligibility chicklets. #}
-  <div class="vaccine-site__eligibilities notranslate">
+  <div class="vaccine-site__eligibilities">
     {% for eligibility in result.eligibilities %}
       <span class="vaccine-site__eligibility">{{ eligibility }}</span>
     {% endfor %}
@@ -16,7 +16,7 @@
 
   {# Open to .. #}
   {% if result.restrictions_text %}
-    <div class="vaccine-site__restrictions notranslate">
+    <div class="vaccine-site__restrictions">
       {# Raw tag is used here because this field can contain HTML. #}
       {{ result.restrictions_text|raw }}
     </div>
@@ -24,14 +24,14 @@
 
   {# Address. #}
   {% if result.location.url %}
-    <div class="vaccine-site__address notranslate icon">
+    <div class="vaccine-site__address icon">
       <a href="{{ result.location.url }}">{{ result.location.address }}</a>
     </div>
   {% endif %}
 
   {# Brands - Pfizer, Moderna, etc #}
   {% if result.brands.administered %}
-    <div class="vaccine-site__brands notranslate icon">
+    <div class="vaccine-site__brands icon">
       <label>{{ template_strings.result.brands.label|t }}</label>
       {{ result.brands.administered|join(', ') }}
     </div>
@@ -39,7 +39,7 @@
 
   {# Languages #}
   {% if result.languages %}
-    <div class="vaccine-site__languages notranslate icon">
+    <div class="vaccine-site__languages icon">
       <label>{{ template_strings.result.languages.label|t }}</label>
       <div>
         {{ result.languages|join(', ') }}
@@ -49,14 +49,14 @@
 
   {# Access - Drive thru, walk thru, wheelchair #}
   {% if result.access_modes %}
-    <div class="vaccine-site__access-mode notranslate icon">
+    <div class="vaccine-site__access-mode icon">
       <label>{{ template_strings.result.access_modes.label|t }}</label>
       {{ result.access_modes|join(', ') }}
     </div>
   {% endif %}
 
   {% if result.info_url %}
-    <div class="notranslate">
+    <div>
       <a href="{{ result.info_url }}">
         {{ template_strings.result.info_url.label|t }}
       </a>

--- a/web/themes/custom/sfgovpl/templates/components/vaccine/vaccine-widget--alert.twig
+++ b/web/themes/custom/sfgovpl/templates/components/vaccine/vaccine-widget--alert.twig
@@ -1,5 +1,5 @@
 {% set text %}
-  <p>
+  <p class="notranslate">
     {{ alert|t }}
   </p>
 {% endset %}

--- a/web/themes/custom/sfgovpl/templates/components/vaccine/vaccine-widget--alert.twig
+++ b/web/themes/custom/sfgovpl/templates/components/vaccine/vaccine-widget--alert.twig
@@ -1,7 +1,7 @@
 {% set text %}
-  <p class="notranslate">
+  <div class="notranslate">
     {{ alert|t }}
-  </p>
+  </div>
 {% endset %}
 
 {% include '@theme/alert.twig' with {

--- a/web/themes/custom/sfgovpl/templates/components/vaccine/vaccine-widget--count.twig
+++ b/web/themes/custom/sfgovpl/templates/components/vaccine/vaccine-widget--count.twig
@@ -1,4 +1,4 @@
-<div class="vaccine-filter__count" role="status">
+<div class="vaccine-filter__count notranslate" role="status">
   {{
     'Showing <span>@count</span> results'|t({
       '@count': results|length

--- a/web/themes/custom/sfgovpl/templates/components/vaccine/vaccine-widget--header.twig
+++ b/web/themes/custom/sfgovpl/templates/components/vaccine/vaccine-widget--header.twig
@@ -1,6 +1,6 @@
 <header class="hero-banner color">
   <div class="hero-banner--container">
-    <h1>
+    <h1 class="notranslate">
       {{ template_strings.page.title|t }}
     </h1>
     <div class="lead-paragraph notranslate">


### PR DESCRIPTION
I'm adding two `notranslate` clases to the `/vaccine-sites` page so that translators can more easily identify what needs to be (human) translated:

1. In the header (top blue banner)
2. To the outermost `<div>` for each site card, and removing the `notranslate` classes on children
3. To the "Showing {count} results" text above the sites list
4. Around the alert paragraph