### PR TITLE
Safelist margin + padding CSS utilities

### DIFF
--- a/web/themes/custom/sfgovpl/purgecss.config.js
+++ b/web/themes/custom/sfgovpl/purgecss.config.js
@@ -8,7 +8,11 @@ module.exports = {
   safelist: {
     greedy: [
       // preserve all "basic" margin and padding utilities (for forms)
-      /\b[mp][trblxy]?-\d+/
+      /\b[mp][trblxy]?-\d+/,
+      // background color utilities
+      /bg-(black|white|slate|blue|green|red|purple|yellow|grey)/,
+      // text color utilities
+      /text-(black|white|slate|blue|green|red|purple|yellow|grey|secondary)/,
     ]
   }
 }

--- a/web/themes/custom/sfgovpl/purgecss.config.js
+++ b/web/themes/custom/sfgovpl/purgecss.config.js
@@ -4,5 +4,11 @@ module.exports = {
     'templates/**/*.{twig,html}',
     'src/**/*.js',
     '../../../modules/custom/**/*.{html,inc,js,php,theme,twig}'
-  ]
+  ],
+  safelist: {
+    patterns: [
+      // preserve all "basic" margin and padding utilities (for forms)
+      /[mp][trblxy]*-\d+/
+    ]
+  }
 }

--- a/web/themes/custom/sfgovpl/purgecss.config.js
+++ b/web/themes/custom/sfgovpl/purgecss.config.js
@@ -6,9 +6,9 @@ module.exports = {
     '../../../modules/custom/**/*.{html,inc,js,php,theme,twig}'
   ],
   safelist: {
-    patterns: [
+    greedy: [
       // preserve all "basic" margin and padding utilities (for forms)
-      /[mp][trblxy]*-\d+/
+      /\b[mp][trblxy]?-\d+/
     ]
   }
 }


### PR DESCRIPTION
In #1000 we started purging "unused" code from our generated CSS, which saves our users from downloading a bunch of code. Some forms (Shared Spaces in particular, cc: @JimBrodbeck) have already adopted the new spacing utilities, but they're not currently taken into account in the "content" we provide to PurgeCSS to detect which CSS is used, so they're being removed.

This PR adds a [PurgeCSS safe list](https://purgecss.com/safelisting.html) to our config that preserves the "basic" spacing utilities: any class beginning with `m` or `p`, followed by an optional direction (`t`, `r`, `b`, `l`, `x`, or `y`), then `-` and one or more digits. This matches the utilities I found in the Shared Spaces form:

```
mb-10
mr-20
mt-40
my-40
p-40
```

The regular expression is not "anchored" with `^` or `$`, so this will also preserve responsive variants like `lg:mx-40`.

This should be a temporary fix, and I'd like to see what it does to the size of our CSS bundle before merging so that we can adjust the regular expression to avoid matching a ton of unused classes. But in this case I'm inclined to be more permissive so that we can use the whole suite of spacing utilities in our system.