### PR TITLE
update php, db, and drush in pantheon yml

### DIFF
--- a/.circleci/scripts/pantheon/02-init-site-under-test-clone-existing
+++ b/.circleci/scripts/pantheon/02-init-site-under-test-clone-existing
@@ -19,15 +19,18 @@ else
   terminus -n build:env:push "$TERMINUS_SITE.$TERMINUS_ENV"
 fi
 
-# drush deploy will execute the following:
-# drush updatedb --no-cache-clear
-# drush cache:rebuild
-# drush config:import
-# drush cache:rebuild
-# drush deploy:hook
-terminus -n drush "$TERMINUS_SITE.$TERMINUS_ENV" -- deploy --yes
+terminus -n drush "$TERMINUS_SITE.$TERMINUS_ENV" cache-rebuild
+
+# Run updatedb to ensure that the cloned database is updated for the new code.
+terminus -n drush "$TERMINUS_SITE.$TERMINUS_ENV" -- updatedb -y
+
+# If any modules, or theme files have been moved around or reorganized, in order to avoid
+# "The website encountered an unexpected error. Please try again later." error on First Visit
+terminus -n drush "$TERMINUS_SITE.$TERMINUS_ENV" cache-rebuild
 
 # If exported configuration is available, then import it.
 if [ -f "config/system.site.yml" ] ; then
   terminus -n drush "$TERMINUS_SITE.$TERMINUS_ENV" -- config-import --yes
 fi
+
+terminus -n drush "$TERMINUS_SITE.$TERMINUS_ENV" -- deploy:hook --yes

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         }
     },
     "require": {
-        "php": ">=7.2",
+        "php": ">=7.4",
         "composer/installers": "^1.9",
         "cweagans/composer-patches": "^1.7",
         "drupal/address": "^1.3",
@@ -272,7 +272,7 @@
         "preferred-install": "dist",
         "sort-packages": true,
         "platform": {
-            "php": "7.2"
+            "php": "7.4"
         }
     }
 }

--- a/pantheon.yml
+++ b/pantheon.yml
@@ -1,6 +1,9 @@
 api_version: 1
 web_docroot: true
-php_version: 7.2
+php_version: 7.4
+database:
+  version: 10.4
+drush_version: 10
 workflows:
   deploy_product: # create site (dev)
     after:

--- a/pantheon.yml
+++ b/pantheon.yml
@@ -1,3 +1,5 @@
+# note: changes to pantheon.yml will not be processed when first creating the branch for multidevs
+# more: https://pantheon.io/docs/pantheon-yml#deploying-configuration-changes-to-multidev
 api_version: 1
 web_docroot: true
 php_version: 7.4


### PR DESCRIPTION
as part of drupal 9 upgrade, attempt to update php, db, and drush versions on pantheon via pantheon.yml first, then do the other upgrade related things (composer, configs, deprecated code, etc).