### PR TITLE
SG-1572: add drush command for deleting old jobs

### DIFF
--- a/web/modules/custom/sfgov_utilities/sfgov_utilities.services.yml
+++ b/web/modules/custom/sfgov_utilities/sfgov_utilities.services.yml
@@ -3,3 +3,7 @@ services:
     class: Drupal\sfgov_utilities\Routing\RouteSubscriberAlter
     tags:
       - { name: event_subscriber }
+  sfgov_utilities.commands:
+      class: \Drupal\sfgov_utilities\Commands\SfgovDrushCommands
+      tags:
+        - { name: drush.command }

--- a/web/modules/custom/sfgov_utilities/src/Commands/SfgovDrushCommands.php
+++ b/web/modules/custom/sfgov_utilities/src/Commands/SfgovDrushCommands.php
@@ -24,7 +24,7 @@ class SfgovDrushCommands extends DrushCommands {
     // or "complete" (5).
     $ids = \Drupal::entityQuery('tmgmt_job')
       ->condition('state', [4, 5], 'IN')
-      ->condition('translator', 'xtm')
+      ->condition('translator', ['xtm', 'xtm_test'], 'IN')
       ->execute();
     if (!empty($ids)) {
       $storage = \Drupal::entityTypeManager()->getStorage('tmgmt_job');

--- a/web/modules/custom/sfgov_utilities/src/Commands/SfgovDrushCommands.php
+++ b/web/modules/custom/sfgov_utilities/src/Commands/SfgovDrushCommands.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Drupal\sfgov_utilities\Commands;
+
+use Drush\Commands\DrushCommands;use Drupal\tmgmt\Entity\JobItem;
+use Drupal\tmgmt\JobInterface;
+use Drupal\tmgmt\JobItemInterface;
+
+/**
+ * A drush command file for custom commands.
+ *
+ * @package Drupal\sfgov_utilities\Commands
+ */
+class SfgovDrushCommands extends DrushCommands {
+
+  /**
+   * Drush command that deletes completed/aborted tmgmt job items from xtm.
+   *
+   * @command SfgovDrushCommands:tmgmt_clean_xtm
+   * @aliases tmgmt-clean-xtm
+   */
+  public function tmgmt_clean_xtm() {
+    // Find all tmgmt jobs from the xtm provider that are either "aborted" (4)
+    // or "complete" (5).
+    $ids = \Drupal::entityQuery('tmgmt_job')
+      ->condition('state', [4, 5], 'IN')
+      ->condition('translator', 'xtm')
+      ->execute();
+    if (!empty($ids)) {
+      $storage = \Drupal::entityTypeManager()->getStorage('tmgmt_job');
+      $entities = $storage->loadMultiple($ids);
+      foreach ($entities as $entity) {
+        // Double check that the entity is complete or aborted, and delete.
+        if ($entity->isFinished() || $entity->isAborted()) {
+          // Give the entity a valid translator so that it can be deleted.
+          // The tmgmt_contentapi_tmgmt_job_delete hook in
+          // tmgmt_contentapi.module requires a job to have a translator before
+          // deleting.
+          $entity->translator->target_id = 'contentapi';
+          $entity->delete();
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Run `drush tmgmt_clean_xtm` to delete aborted/finished xtm/xtm_test jobs. Note that this will also attempt to delete files associated with these jobs that are not being used anywhere else, see line 670 of web/modules/contrib/lionbridge_translation_provider/tmgmt_contentapi/tmgmt_contentapi.module