### PR TITLE
Make Amplitude releases end, add more info

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,7 @@ workflows:
               only:
                 - main
                 - develop
-                - amplitude-release*
+                - /amplitude-release/
   create_gh_release_from_tag:
     jobs:
       - create_gh_release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,10 +178,7 @@ workflows:
             - build_deploy_and_test
           filters:
             branches:
-              only:
-                - main
-                - develop
-                - /amplitude-release.*/
+              only: /^(main|develop|amplitude-release.*)$/
   create_gh_release_from_tag:
     jobs:
       - create_gh_release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,7 @@ workflows:
               only:
                 - main
                 - develop
-                - amplitude-release
+                - amplitude-release*
   create_gh_release_from_tag:
     jobs:
       - create_gh_release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,7 @@ workflows:
               only:
                 - main
                 - develop
-                - /amplitude-release/
+                - /amplitude-release.*/
   create_gh_release_from_tag:
     jobs:
       - create_gh_release:

--- a/scripts/custom/create-amplitude-release.sh
+++ b/scripts/custom/create-amplitude-release.sh
@@ -7,19 +7,26 @@ elif [[ "$AMPLITUDE_AUTH" =~ (^:|:$) ]]; then
   echo "Skipping Amplitude release because AMPLITUDE_AUTH is malformed (missing either API or secret)"
   exit 0
 fi
-  
-# see: https://developers.amplitude.com/docs/releases-api
-release_start=$(date +"%Y-%m-%d %H:%M:00")
-# version tag?
-version="$release_start"
-title="Automated release from deployment at $release_start"
-# commit message?
-description=""
-# merge commit author?
-created_by=""
 
+# our base timestamp is up to the minute so that we can tweak the start and end
+timestamp=$(date +"%Y-%m-%d %H:%M")
+# releases without an end "stack" on top of one another in the Amplitude UI, so
+# we "end" our releases a second after they start
+release_start="$timestamp:00"
+release_end="$timestamp:01"
+# our version is just the timestamp rounded to the hour (YYYYMMDDHH), since it's
+# (currently) impossible to release more frequently
+version=$(date +"%Y%m%d%H")
+title=$(date)
+# commit message
+description="Automated release from CI. Git commit:\n\n$(git log -1)"
+# commit author
+created_by=$(git log -1 --format='%ae')
+
+# API docs: https://developers.amplitude.com/docs/releases-api
 curl -u "$AMPLITUDE_AUTH" -X POST \
   -F release_start="$release_start" \
+  -F release_end="$release_end" \
   -F version="$version" \
   -F title="$title" \
   -F description="$description" \

--- a/scripts/custom/create-amplitude-release.sh
+++ b/scripts/custom/create-amplitude-release.sh
@@ -19,7 +19,7 @@ release_end="$timestamp:01"
 version=$(date +"%Y%m%d%H")
 title=$(date)
 # commit message
-description="Automated release from CI. Git commit:\n\n$(git log -1)"
+description="Automated release from CI: $(git log -1)"
 # commit author
 created_by=$(git log -1 --format='%ae')
 

--- a/scripts/custom/create-amplitude-release.sh
+++ b/scripts/custom/create-amplitude-release.sh
@@ -9,19 +9,19 @@ elif [[ "$AMPLITUDE_AUTH" =~ (^:|:$) ]]; then
 fi
 
 # our base timestamp is up to the minute so that we can tweak the start and end
-timestamp=$(date +"%Y-%m-%d %H:%M")
+timestamp="$(date +'%Y-%m-%d %H:%M')"
 # releases without an end "stack" on top of one another in the Amplitude UI, so
 # we "end" our releases a second after they start
 release_start="$timestamp:00"
 release_end="$timestamp:01"
 # our version is just the timestamp rounded to the hour (YYYYMMDDHH), since it's
 # (currently) impossible to release more frequently
-version=$(date +"%Y%m%d%H")
-title=$(date)
+version="$(date +'%Y%m%d%H')"
+title="$timestamp (automated release)"
 # commit message
-description="Automated release from CI: $(git log -1)"
+description="$(git log -1)"
 # commit author
-created_by=$(git log -1 --format='%ae')
+created_by="$(git log -1 --format='%ae')"
 
 # API docs: https://developers.amplitude.com/docs/releases-api
 curl -u "$AMPLITUDE_AUTH" -X POST \


### PR DESCRIPTION
For SG-1549. Currently our automated Amplitude releases don't have end timestamps, which makes them "stack" in the UI:

<img src="https://user-images.githubusercontent.com/113896/143922819-2899222d-340b-4655-91a7-0ad949536c99.png" width="300">

This sets their end to one second after the release, which should mark them as a point in time and prevent them from stacking. I'm also reformatting the title, setting the version to the date (similar to how we version in GitHub releases) and adding description and author fields.

You can see a preview of the release generated by this PR [on Amplitude](https://analytics.amplitude.com/sfdigitalservices/releases/project/254244), and in [this chart](https://analytics.amplitude.com/sfdigitalservices/chart/buqv0q0/edit/rbm74k0):

<img src="https://user-images.githubusercontent.com/113896/144132876-0ed39dc8-42ae-4fd1-9ba8-54aee16702c0.png" width="300">
