### PR TITLE
SG-1073: fix bulleted list spacing

### DIFF
--- a/web/themes/custom/sfgovpl/src/sass/node/_node-transaction-help.scss
+++ b/web/themes/custom/sfgovpl/src/sass/node/_node-transaction-help.scss
@@ -14,7 +14,6 @@
 
   p {
     @include fs-body-short;
-    margin: 0;
   }
 
   .paragraph--type--help {


### PR DESCRIPTION
@aekong, not 100% sure this is the right way to solve the problem here. But I removed the `margin: 0` because that was inconsistent with how all of the other wyswigs are being rendered and it was causing the weird spacing. Im not quite sure why it was there in the first place. 