### PR TITLE
CI: fix composer cache key expression

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - composer-{{ checksum 'composer.lock' }}
+            - composer-{{ checksum "composer.lock" }}
             - terminus-install
 
       - run:
@@ -56,7 +56,7 @@ jobs:
           command: composer install
 
       - save_cache:
-          key: composer-{{ checksum 'composer.lock' }}
+          key: composer-{{ checksum "composer.lock" }}
           paths:
               - $HOME/.composer/cache
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,9 +33,6 @@ defaults: &defaults
     ADMIN_USERNAME: admin
     # BUILD_TOOLS_VERSION: ^2.0.0-alpha4
     TERM: dumb
-    
-    # where to find the custom theme
-    THEME_PATH: web/themes/custom/sfgovpl
 
 version: 2
 jobs:
@@ -75,13 +72,6 @@ jobs:
       - run:
           name: run code-sniff
           command: composer -n code-sniff
-
-      - run:
-          name: lint theme source files
-          command: |
-            cd $THEME_PATH
-            npm ci
-            npm run lint
             
       - run:
           name: run unit tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,9 @@ defaults: &defaults
     ADMIN_USERNAME: admin
     # BUILD_TOOLS_VERSION: ^2.0.0-alpha4
     TERM: dumb
+    
+    # where to find the custom theme
+    THEME_PATH: web/themes/custom/sfgovpl
 
 version: 2
 jobs:
@@ -70,9 +73,16 @@ jobs:
           command: composer -n lint
 
       - run:
-          name: check coding standards
+          name: run code-sniff
           command: composer -n code-sniff
 
+      - run:
+          name: lint theme source files
+          command: |
+            cd $THEME_PATH
+            npm ci
+            npm run lint
+            
       - run:
           name: run unit tests
           command: composer -n unit-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
       - run:
           name: run code-sniff
           command: composer -n code-sniff
-            
+
       - run:
           name: run unit tests
           command: composer -n unit-test
@@ -103,7 +103,7 @@ jobs:
       - run:
           name: sync saml dependencies
           command: ./.circleci/scripts/saml/saml-dependencies
-      
+
       - run:
           name: build assets (theme)
           command: ./scripts/custom/build-theme-assets.sh
@@ -144,7 +144,7 @@ jobs:
           name: create gh release
           command: |
             echo "create gh release for $CIRCLE_TAG"
-            curl -H "Authorization: token $GITHUB_TOKEN" -X POST -d "{\"tag_name\":\"$CIRCLE_TAG\",\"target_commitish\":\"$CIRCLE_BRANCH\",\"name\":\"$CIRCLE_TAG\",\"body\":\"created via api, add release notes\",\"draft\":false,\"prerelease\":false}" https://api.github.com/repos/sfdigitalservices/sfgov/releases 
+            curl -H "Authorization: token $GITHUB_TOKEN" -X POST -d "{\"tag_name\":\"$CIRCLE_TAG\",\"target_commitish\":\"$CIRCLE_BRANCH\",\"name\":\"$CIRCLE_TAG\",\"body\":\"created via api, add release notes\",\"draft\":false,\"prerelease\":false}" https://api.github.com/repos/sfdigitalservices/sfgov/releases
 
   create_amplitude_release:
     docker:
@@ -160,7 +160,7 @@ jobs:
               export AMPLITUDE_AUTH="$AMPLITUDE_TEST_API_KEY:$AMPLITUDE_TEST_SECRET_KEY"
             fi
             ./scripts/custom/create-amplitude-release.sh
-  
+
 workflows:
   version: 2
   build_and_test:


### PR DESCRIPTION
I noticed errors like [this one](https://app.circleci.com/pipelines/github/SFDigitalServices/sfgov/3826/workflows/e4e9e1be-ddb3-4d6f-8174-01ed62fd1f4b/jobs/13191?invite=true#step-102-2) since merging #1134. This fixes them! 🎉 

The problem was that CircleCI wants double quotes (I had single) in interpolations.