### PR TITLE
set lionbridge creds post config-import

### DIFF
--- a/pantheon.yml
+++ b/pantheon.yml
@@ -1,5 +1,5 @@
 # changes to pantheon.yml will not be processed when first creating the branch for multidevs
-# as a workaround, modify this file, then push to trigger configuration changes
+# as a workaround, modify this file, then push to trigger configuration changes 
 # more: https://pantheon.io/docs/pantheon-yml#deploying-configuration-changes-to-multidev
 api_version: 1
 web_docroot: true

--- a/pantheon.yml
+++ b/pantheon.yml
@@ -28,6 +28,9 @@ workflows:
         description: 'Import configuration from .yml files'
         script: private/scripts/drush_config_import/drush_config_import.php
       - type: webphp
+        description: 'Set lionbridge credentials'
+        script: private/scripts/lionbridge/lionbridge-credentials.php
+      - type: webphp
         description: 'Create test users (multidev)'
         script: private/scripts/drush-create-users/drush-create-users.php
         
@@ -40,6 +43,9 @@ workflows:
         description: 'Import configuration from .yml files'
         script: private/scripts/drush_config_import/drush_config_import.php
       - type: webphp
+        description: 'Set lionbridge credentials'
+        script: private/scripts/lionbridge/lionbridge-credentials.php
+      - type: webphp
         description: 'Log to New Relic'
         script: private/scripts/new_relic/new_relic_deploy.php
       - type: webphp
@@ -51,6 +57,9 @@ workflows:
       - type: webphp
         description: 'Import configuration from .yml files'
         script: private/scripts/drush_config_import/drush_config_import.php
+      - type: webphp
+        description: 'Set lionbridge credentials'
+        script: private/scripts/lionbridge/lionbridge-credentials.php
       - type: webphp
         description: 'Notify in slack when deployed'
         script: private/scripts/slack-notify/slack_notify_drush_site_audit.php

--- a/pantheon.yml
+++ b/pantheon.yml
@@ -1,4 +1,5 @@
-# note: changes to pantheon.yml will not be processed when first creating the branch for multidevs
+# changes to pantheon.yml will not be processed when first creating the branch for multidevs
+# as a workaround, modify this file, then push to trigger configuration changes
 # more: https://pantheon.io/docs/pantheon-yml#deploying-configuration-changes-to-multidev
 api_version: 1
 web_docroot: true

--- a/web/private/scripts/lionbridge/lionbridge-credentials.php
+++ b/web/private/scripts/lionbridge/lionbridge-credentials.php
@@ -1,0 +1,23 @@
+<?php
+  use Symfony\Component\Yaml\Yaml;
+
+  require dirname(__DIR__) . '/../shared.php';
+  
+  // echo PANTHEON_ENVIRONMENT;
+  $lbConfigItem = 'tmgmt.translator.contentapi';
+  $lbConfigItemKey = 'settings.capi-settings';
+
+  $lbEnv = PANTHEON_ENVIRONMENT === 'live' ? 'prod' : 'staging';
+  $lbPath = '/code/web/sites/default';
+  $lbCredsContents = file_get_contents($_SERVER['HOME'] . "/code/web/sites/default/files/private/credentials/lionbridge/lionbridge-$lbEnv.yml");
+
+  $lbCreds = Yaml::parse($lbCredsContents);
+  $lbCredsStr = json_encode($lbCreds, JSON_UNESCAPED_SLASHES|JSON_HEX_QUOT);
+
+  $status = '';
+  $output = [];
+  
+  exec("drush config-set $lbConfigItem $lbConfigItemKey --input-format=yaml --value='$lbCredsStr' -y 2>&1", $output, $status);
+  $output = array_map(function($item) { return "    - " . trim($item); }, array_filter($output));
+
+  _test_hook_slack_notification("lionbridge credentials: \n  - exit status: $status \n  - output: \n" . implode("\n", $output));

--- a/web/private/scripts/lionbridge/lionbridge-credentials.php
+++ b/web/private/scripts/lionbridge/lionbridge-credentials.php
@@ -1,23 +1,37 @@
 <?php
-  use Symfony\Component\Yaml\Yaml;
 
-  require dirname(__DIR__) . '/../shared.php';
-  
-  $lbConfigItem = 'tmgmt.translator.contentapi';
-  $lbConfigItemKey = 'settings.capi-settings';
+/**
+ * This script reads the lionbridge credentials from a non-vcs location
+ * and updates the appropriate lionbridge configuration item with the read credentials
+ */
 
-  $lbEnv = PANTHEON_ENVIRONMENT === 'live' ? 'prod' : 'staging';
-  $lbPath = '/code/web/sites/default';
-  $lbCredsContents = file_get_contents($_SERVER['HOME'] . "/code/web/sites/default/files/private/credentials/lionbridge/lionbridge-$lbEnv.yml");
+use Symfony\Component\Yaml\Yaml;
 
-  $lbCreds = Yaml::parse($lbCredsContents);
-  $lbCredsStr = json_encode($lbCreds, JSON_UNESCAPED_SLASHES|JSON_HEX_QUOT);
+require dirname(__DIR__) . '/../shared.php';
 
-  $status = '';
-  $output = [];
-  
-  exec("drush config-set $lbConfigItem $lbConfigItemKey --input-format=yaml --value='$lbCredsStr' -y 2>&1", $output, $status);
-  
-  // some debug output
-  $output = array_map(function($item) { return "    - " . trim($item); }, array_filter($output));
-  _test_hook_slack_notification("lionbridge credentials: \n  - exit status: $status \n  - output: \n" . implode("\n", $output));
+$lbConfigItem = 'tmgmt.translator.contentapi';
+$lbConfigItemKey = 'settings.capi-settings';
+
+$lbEnv = PANTHEON_ENVIRONMENT === 'live' ? 'prod' : 'staging';
+$filesPath = '/code/web/sites/default/files/private';
+$lbCredsContents = file_get_contents(
+    $_SERVER['HOME'] . "$filesPath/credentials/lionbridge/lionbridge-$lbEnv.yml"
+);
+
+$lbCreds = Yaml::parse($lbCredsContents);
+$lbCredsStr = json_encode($lbCreds, JSON_UNESCAPED_SLASHES|JSON_HEX_QUOT);
+
+$status = '';
+$output = [];
+
+exec("drush config-set $lbConfigItem $lbConfigItemKey --input-format=yaml --value='$lbCredsStr' -y 2>&1", $output, $status);
+
+// some debug output
+$output = array_map(
+    function ($item) {
+        return "    - " . trim($item); 
+    }, array_filter($output)
+);
+_test_hook_slack_notification(
+    "lionbridge credentials: \n  - exit status: $status \n  - output: \n" . implode("\n", $output)
+);

--- a/web/private/scripts/lionbridge/lionbridge-credentials.php
+++ b/web/private/scripts/lionbridge/lionbridge-credentials.php
@@ -3,7 +3,6 @@
 
   require dirname(__DIR__) . '/../shared.php';
   
-  // echo PANTHEON_ENVIRONMENT;
   $lbConfigItem = 'tmgmt.translator.contentapi';
   $lbConfigItemKey = 'settings.capi-settings';
 
@@ -18,6 +17,7 @@
   $output = [];
   
   exec("drush config-set $lbConfigItem $lbConfigItemKey --input-format=yaml --value='$lbCredsStr' -y 2>&1", $output, $status);
+  
+  // some debug output
   $output = array_map(function($item) { return "    - " . trim($item); }, array_filter($output));
-
   _test_hook_slack_notification("lionbridge credentials: \n  - exit status: $status \n  - output: \n" . implode("\n", $output));


### PR DESCRIPTION
This pr adds a script to 

- read lionbridge credentials from a non-vcs directory
- execute `drush config-set` to update the lionbridge config with the appropriate keys and values `after` the pantheon `sync_code` workflow completes