### PR TITLE
Add "enforce_https: full" to pantheon.yml for HSTS header

### DIFF
--- a/pantheon.yml
+++ b/pantheon.yml
@@ -3,6 +3,8 @@
 # more: https://pantheon.io/docs/pantheon-yml#deploying-configuration-changes-to-multidev 
 api_version: 1
 web_docroot: true
+# see: https://pantheon.io/docs/pantheon-yml#enforce-https--hsts
+enforce_https: full
 php_version: 7.4
 database:
   version: 10.4


### PR DESCRIPTION
For SG-1642. Per the [Pantheon docs](https://pantheon.io/docs/pantheon-yml#enforce-https--hsts):

> Use of `full` or `full+subdomains` should be treated as a commitment. HSTS headers are cached by browsers for the duration of the max-age period. If your site is unable to serve HTTPS (e.g. by moving to a host that doesn't support HTTPS), visitors will be unable to access your site.