### PR TITLE
fix incorrect color on resource cards

### DIFF
--- a/web/themes/custom/sfgovpl/templates/components/atoms/service-card.twig
+++ b/web/themes/custom/sfgovpl/templates/components/atoms/service-card.twig
@@ -3,7 +3,7 @@
   invisible ? 'invisible'
 ]%}
 
-<a href="{{ invisible ? '' : url }}" {{ attributes.addClass(classes) }}>
+<a href="{{ invisible ? '' : url }}" class="{{ classes|join(' ') }}">
   {% if invisible == 'invisible' %}
   {% else %}
     <{{ heading ? heading : 'h3' }} class="service-card--title title">{{ title }}</{{ heading ? heading : 'h3' }}>


### PR DESCRIPTION
alert properties were being applied to the service/resource section when an alert was added.  this pr prevents unncessary attributes from being added to service/resource cards

**before**: [https://sf.gov/public-body/2020-census-redistricting-task-force](https://sf.gov/public-body/2020-census-redistricting-task-force)
**after**: [https://pr-1176-sfgov.pantheonsite.io/public-body/2020-census-redistricting-task-force](https://pr-1176-sfgov.pantheonsite.io/public-body/2020-census-redistricting-task-force)

|before|after|
|---|---|
![screencapture-sf-gov-public-body-2020-census-redistricting-task-force-2022-01-31-12_35_17](https://user-images.githubusercontent.com/19291154/151869259-03c3ad07-05a8-4860-b916-d86a9c16c560.png)|![screencapture-pr-1176-sfgov-pantheonsite-io-public-body-2020-census-redistricting-task-force-2022-01-31-12_25_26](https://user-images.githubusercontent.com/19291154/151869375-a06fc6e9-3d7e-4859-b9be-02bd611bfcb7.png)|