### PR TITLE
Form previews: use safeJSONParse() for page view event properties

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -249,6 +249,7 @@
             "drupal/amplitude": {
                 "Page scroll depth": "patches/amplitude-scroll-depth.patch",
                 "Allow setting user properties": "https://www.drupal.org/files/issues/2020-07-05/3157006-user-properties-2.patch",
+                "Missing config_export definition in its annotation": "https://www.drupal.org/files/issues/2020-11-24/amplitude-3184640-1.patch",
                 "JSON parse event property values": "patches/amplitude-parse-event-property-values.patch",
                 "Auto-capture href for anchors": "patches/auto-capture-anchor-href.patch"
             },

--- a/config/amplitude.amplitude_event.page_view.yml
+++ b/config/amplitude.amplitude_event.page_view.yml
@@ -4,15 +4,7 @@ status: true
 dependencies: {  }
 id: page_view
 label: 'Page view'
-properties: |
-  {
-    "page_title": "[current-page:title]",
-    "page_url": "[current-page:url]",
-    "content_lang": "[node:langcode]",
-    "content_type": "[node:content-type:name]",
-    "department": "[sfgov:field_departments]",
-    "topic":"[sfgov:field_topics]"
-  }
+properties: '{"page_title": "[current-page:title]","page_url": "[current-page:url]","content_lang": "[node:langcode]","content_type": "[node:content-type:name]","department": "[sfgov:field_departments]","topic":"[sfgov:field_topics]"}'
 event_trigger: pageLoad
 event_trigger_pages: "/*\r\n<front>"
 event_trigger_scroll_depths: ''

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io--feedback.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io--feedback.html.twig
@@ -18,7 +18,7 @@
       if (typeof amplitude != 'undefined' && drupalSettings.amplitude.events.length > 0) {
         drupalSettings.amplitude.events.find(function(obj) {
           if (obj.name === 'Feedback form') {
-            amplitudeData = JSON.parse(obj.properties);
+            amplitudeData = safeJSONParse(obj.properties);
           }
         });
       }

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -79,7 +79,7 @@
     if (drupalSettings.amplitude.events.length) {
       drupalSettings.amplitude.events.find(function(obj) {
         if (obj.name === 'Page view') {
-          amplitudeData = JSON.parse(obj.properties)
+          amplitudeData = safeJSONParse(obj.properties)
         }
       })
     }


### PR DESCRIPTION
It looks like something is causing previews of form page translations to get event properties in `drupalSettings.amplitude.events` that don't parse as valid JSON. The one I'm seeing is:

```js
'{"page_title":"Preview for the &quot;Filipino&quot; version of &quot;Aplikasyon para sa Gawad na Tulong sa Upa\r\n&quot;","page_url":"https://sf.gov/rent-relief-grant-application/preview-link/xdmT9PCTstIDFMDXhXb9lcERWlmmjGUiMpaxGtlY1DZPjAwzpeFJLIg8cYgUgh1ZXa7pb","content_type":"Form page","department":"", "topic":""}'
```

Specifically, in this string the `\r\n` at the end of that Drupal-generated `page_title` field is invalid JSON: the carriage return and newline characters need to be escaped (doubly, as `\\r\\n`). I'm not sure what's creating this JSON string; @aekong, any idea?

We should be using the `safeJSONParse()` function for this either way so that it doesn't short-circuit the most important part of the page. It won't return any data and the Amplitude events will be bogus, but at least the form preview will work.
