### PR TITLE
Amplitude page view json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -249,6 +249,7 @@
             "drupal/amplitude": {
                 "Page scroll depth": "patches/amplitude-scroll-depth.patch",
                 "Allow setting user properties": "https://www.drupal.org/files/issues/2020-07-05/3157006-user-properties-2.patch",
+                "Missing config_export definition in its annotation": "https://www.drupal.org/files/issues/2020-11-24/amplitude-3184640-1.patch",
                 "JSON parse event property values": "patches/amplitude-parse-event-property-values.patch",
                 "Auto-capture href for anchors": "patches/auto-capture-anchor-href.patch"
             },

--- a/config/amplitude.amplitude_event.page_view.yml
+++ b/config/amplitude.amplitude_event.page_view.yml
@@ -4,15 +4,7 @@ status: true
 dependencies: {  }
 id: page_view
 label: 'Page view'
-properties: |
-  {
-    "page_title": "[current-page:title]",
-    "page_url": "[current-page:url]",
-    "content_lang": "[node:langcode]",
-    "content_type": "[node:content-type:name]",
-    "department": "[sfgov:field_departments]",
-    "topic":"[sfgov:field_topics]"
-  }
+properties: '{"page_title": "[current-page:title]","page_url": "[current-page:url]","content_lang": "[node:langcode]","content_type": "[node:content-type:name]","department": "[sfgov:field_departments]","topic":"[sfgov:field_topics]"}'
 event_trigger: pageLoad
 event_trigger_pages: "/*\r\n<front>"
 event_trigger_scroll_depths: ''


### PR DESCRIPTION
- patch amplitude to fix the missing annotation error which was preventing changes from being saved
- update the yaml config for page view event `properties` key to a string