### PR TITLE
SG-1598 - do not translate cost type radio button values

### DIFF
--- a/config/field.field.paragraph.cost.field_cost_type.yml
+++ b/config/field.field.paragraph.cost.field_cost_type.yml
@@ -14,7 +14,7 @@ bundle: cost
 label: 'Cost Type'
 description: ''
 required: true
-translatable: true
+translatable: false
 default_value:
   -
     value: none


### PR DESCRIPTION
The chosen value of the cost type (`free`, `flat`, `range`, etc) are being translated by our translation vendor, but the input field value isn’t translated on the drupal backend.  For example, in the english translation, `range` is selected as cost type, that value is sent to lionbridge to translate to Spanish and comes back as `rango`.  But, the radio input of the value isn’t translated, so there’s a mismatch and the system won’t select the appropriate radio button automatically.

This pr prevents the cost type from being translated.  This should be ok since the cost type value isn't being used in the templates.

