### PR TITLE
disable old spotlight image field for translation

### DIFF
--- a/config/core.base_field_override.paragraph.spotlight.created.yml
+++ b/config/core.base_field_override.paragraph.spotlight.created.yml
@@ -1,0 +1,18 @@
+uuid: 9c23931f-b812-4d3e-ad31-ee6f37c6320d
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.spotlight
+id: paragraph.spotlight.created
+field_name: created
+entity_type: paragraph
+bundle: spotlight
+label: 'Authored on'
+description: 'The time that the Paragraph was created.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/config/core.base_field_override.paragraph.spotlight.status.yml
+++ b/config/core.base_field_override.paragraph.spotlight.status.yml
@@ -1,0 +1,22 @@
+uuid: 08ff17ae-fa9d-4df8-89fe-e70b9e22ddd8
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.spotlight
+id: paragraph.spotlight.status
+field_name: status
+entity_type: paragraph
+bundle: spotlight
+label: Published
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/field.field.paragraph.spotlight.field_spotlight_image.yml
+++ b/config/field.field.paragraph.spotlight.field_spotlight_image.yml
@@ -6,15 +6,9 @@ dependencies:
     - field.storage.paragraph.field_spotlight_image
     - paragraphs.paragraphs_type.spotlight
   module:
-    - content_translation
     - image
     - tmgmt_content
 third_party_settings:
-  content_translation:
-    translation_sync:
-      alt: alt
-      title: title
-      file: '0'
   tmgmt_content:
     excluded: false
 id: paragraph.spotlight.field_spotlight_image
@@ -24,7 +18,7 @@ bundle: spotlight
 label: 'Spotlight Image'
 description: 'Minimum 550 px wide. Keep subject in the center. Image will resize based on text and screen size (mobile or desktop). Horizontal images need short text, vertical images work with longer text.'
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:


### PR DESCRIPTION
A disabled spotlight image field was causing translations to break.  This pr omits the old field from translation.