### PR TITLE
SG-1663 - Translated forms should not have translated URLs

### DIFF
--- a/config/pathauto.pattern.form_start_page.yml
+++ b/config/pathauto.pattern.form_start_page.yml
@@ -7,12 +7,12 @@ dependencies:
 id: form_start_page
 label: 'Form start page'
 type: 'canonical_entities:node'
-pattern: '[node:title]/form'
+pattern: '[node:source:title]/form'
 selection_criteria:
-  64b6b17d-179d-43e6-8065-d13baafcf194:
+  57e9fa44-80cb-4c08-ac32-d8981fa188d8:
     id: node_type
     negate: false
-    uuid: 64b6b17d-179d-43e6-8065-d13baafcf194
+    uuid: 57e9fa44-80cb-4c08-ac32-d8981fa188d8
     context_mapping:
       node: node
     bundles:


### PR DESCRIPTION
Update pathauto pattern to use the token `[node:source:title]` for form pages