### PR TITLE
SG-1709 - Meeting and event URLs does not include date (for recurring instances)

### DIFF
--- a/config/pathauto.pattern.events.yml
+++ b/config/pathauto.pattern.events.yml
@@ -7,12 +7,12 @@ dependencies:
 id: events
 label: Events
 type: 'canonical_entities:node'
-pattern: 'events/[node:field_start_date:date:custom:F-j-Y]/[node:source:title]'
+pattern: 'events/[node:field_smart_date:value-custom:F-j-Y]/[node:source:title]'
 selection_criteria:
-  b3aca33b-8be4-4b88-bb90-e03c6c2c8ac5:
+  f15214cd-d3fd-4859-a76b-02fdc3b08a3e:
     id: node_type
     negate: false
-    uuid: b3aca33b-8be4-4b88-bb90-e03c6c2c8ac5
+    uuid: f15214cd-d3fd-4859-a76b-02fdc3b08a3e
     context_mapping:
       node: node
     bundles:

--- a/config/pathauto.pattern.meeting.yml
+++ b/config/pathauto.pattern.meeting.yml
@@ -7,12 +7,12 @@ dependencies:
 id: meeting
 label: Meeting
 type: 'canonical_entities:node'
-pattern: 'meeting/[node:source:title]'
+pattern: 'meeting/[node:field_smart_date:value-custom:F-j-Y]/[node:source:title]'
 selection_criteria:
-  6fe2d615-cdee-4d8a-87cd-60c3c7b92c6a:
+  63dd80db-0328-448c-b779-e456e57fa7d0:
     id: node_type
     negate: false
-    uuid: 6fe2d615-cdee-4d8a-87cd-60c3c7b92c6a
+    uuid: 63dd80db-0328-448c-b779-e456e57fa7d0
     context_mapping:
       node: node
     bundles:


### PR DESCRIPTION
Updates the pathauto url alias patterns for the `Event` and `Meeting` content type to use the new date field