### PR TITLE
Prod config update

### DIFF
--- a/config/core.entity_form_display.node.topic.default.yml
+++ b/config/core.entity_form_display.node.topic.default.yml
@@ -37,7 +37,7 @@ content:
     third_party_settings: {  }
   field_content:
     type: paragraphs
-    weight: 8
+    weight: 7
     region: content
     settings:
       title: Paragraph
@@ -56,7 +56,7 @@ content:
     third_party_settings: {  }
   field_content_top:
     type: paragraphs
-    weight: 5
+    weight: 4
     region: content
     settings:
       title: Paragraph
@@ -75,7 +75,7 @@ content:
     third_party_settings: {  }
   field_department_services:
     type: paragraphs
-    weight: 6
+    weight: 5
     region: content
     settings:
       title: Paragraph
@@ -126,7 +126,7 @@ content:
     third_party_settings: {  }
   field_resources:
     type: paragraphs
-    weight: 9
+    weight: 8
     region: content
     settings:
       title: Paragraph
@@ -145,7 +145,7 @@ content:
     third_party_settings: {  }
   field_spotlight:
     type: paragraphs
-    weight: 7
+    weight: 6
     region: content
     settings:
       title: Paragraph

--- a/config/editor.editor.sf_full_html_with_toc.yml
+++ b/config/editor.editor.sf_full_html_with_toc.yml
@@ -49,13 +49,13 @@ settings:
             - ShowBlocks
             - Source
   plugins:
-    stylescombo:
-      styles: ''
     drupallink:
       linkit_enabled: true
       linkit_profile: default
     language:
       language_list: un
+    stylescombo:
+      styles: ''
 image_upload:
   status: true
   scheme: public

--- a/config/filter.format.sf_full_html_with_toc.yml
+++ b/config/filter.format.sf_full_html_with_toc.yml
@@ -5,7 +5,6 @@ dependencies:
   module:
     - editor
     - linkit
-    - media
     - sfgov_doc_html
     - toc_filter
 name: 'SF Full HTML with TOC'
@@ -61,15 +60,6 @@ filters:
       type: default
       auto: ''
       block: '0'
-  media_embed:
-    id: media_embed
-    provider: media
-    status: false
-    weight: 100
-    settings:
-      default_view_mode: default
-      allowed_view_modes: {  }
-      allowed_media_types: {  }
   responsive_table:
     id: responsive_table
     provider: sfgov_doc_html

--- a/config/user.role.digital_services.yml
+++ b/config/user.role.digital_services.yml
@@ -11,6 +11,7 @@ dependencies:
     - filter.format.restricted_html
     - filter.format.sf_basic_html
     - filter.format.sf_basic_html_news
+    - filter.format.sf_full_html_with_toc
     - filter.format.sf_restricted_html
     - media.type.audio
     - media.type.file
@@ -459,6 +460,7 @@ permissions:
   - 'use text format restricted_html'
   - 'use text format sf_basic_html'
   - 'use text format sf_basic_html_news'
+  - 'use text format sf_full_html_with_toc'
   - 'use text format sf_restricted_html'
   - 'view about revisions'
   - 'view all media revisions'

--- a/config/user.role.publisher.yml
+++ b/config/user.role.publisher.yml
@@ -8,6 +8,7 @@ dependencies:
     - filter.format.restricted_html
     - filter.format.sf_basic_html
     - filter.format.sf_basic_html_news
+    - filter.format.sf_full_html_with_toc
     - filter.format.sf_restricted_html
     - media.type.audio
     - media.type.file
@@ -228,6 +229,7 @@ permissions:
   - 'use text format restricted_html'
   - 'use text format sf_basic_html'
   - 'use text format sf_basic_html_news'
+  - 'use text format sf_full_html_with_toc'
   - 'use text format sf_restricted_html'
   - 'view about revisions'
   - 'view all revisions'

--- a/config/user.role.writer.yml
+++ b/config/user.role.writer.yml
@@ -8,6 +8,7 @@ dependencies:
     - filter.format.restricted_html
     - filter.format.sf_basic_html
     - filter.format.sf_basic_html_news
+    - filter.format.sf_full_html_with_toc
     - filter.format.sf_restricted_html
     - media.type.audio
     - media.type.file
@@ -211,6 +212,7 @@ permissions:
   - 'use text format restricted_html'
   - 'use text format sf_basic_html'
   - 'use text format sf_basic_html_news'
+  - 'use text format sf_full_html_with_toc'
   - 'use text format sf_restricted_html'
   - 'view about revisions'
   - 'view all revisions'


### PR DESCRIPTION
* rearranges the form display for topics, resources are now above dept tagging
* updates the permission for text format `SF Full HTML with TOC` for the `Writer`, `Publisher`, and `Digital Services` user roles

this configuration is already live.  this pr serves to persist the configuration on the next production deploy