### PR TITLE
SG-1720 - Disable Reviewer process custom permissions workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
     ```
 4. Install Composer dependencies and execute post-install scripts (including copying saml related things above to the right vendor directory): `composer install`
 5. **Start the Lando VM**: `lando start`
-6. **Obtain a [machine token](https://pantheon.io/docs/machine-tokens/)** from your Pantheon dashboard, and run the provided command, making sure to prefix it with `lando`, e.g. `lando terminus auth:login --machine-token=TOKEN`.
+6. **Obtain a [machine token](https://pantheon.io/docs/machine-tokens/)** from your Pantheon dashboard, and run the provided command, making sure to prefix it with `lando`, e.g. `lando terminus auth:login --machine-token=TOKEN`
 7. **Get latest DB and files from Pantheon** dev environment: `lando pull`. Most of the time, code will not need to be pulled from Pantheon: `lando pull --code=none --database=dev --files=dev`.
 8. Create a **local services** file:
 

--- a/web/modules/custom/sfgov_moderation/src/StateTransitionValidation.php
+++ b/web/modules/custom/sfgov_moderation/src/StateTransitionValidation.php
@@ -130,6 +130,9 @@ class StateTransitionValidation extends CoreStateTransitionValidation {
 
     $validTransitions = parent::getValidTransitions($entity, $user);
 
+    /*
+     * Disable reviewer checks, always return $validTransitions
+     * 
     // For admins, new content or other entity types, inherit behavior.
     if ($entity->getEntityTypeId() != 'node' ||
       $entity->isNew() ||
@@ -153,6 +156,9 @@ class StateTransitionValidation extends CoreStateTransitionValidation {
         return in_array($transition->id(), static::AUTHOR_ALLOWED_TRANSITIONS);
       });
     }
+    * 
+    *
+    */
 
     // If user is not the author or reviewer, allow access.
     return $validTransitions;


### PR DESCRIPTION
The code that modifies permissions for the workflow has been disabled, but the Reviewer process functionality and "reviewer" field are still working. Writers can now set content to published at any time, not only when first creating a page.