### PR TITLE
(hopefully) make it easier to log in with different roles

### DIFF
--- a/web/modules/custom/sfgov_utilities/js/sfgov_utilities_sandbox_user.js
+++ b/web/modules/custom/sfgov_utilities/js/sfgov_utilities_sandbox_user.js
@@ -1,70 +1,22 @@
 (() => {
-  const style = document.createElement('style')
-  style.innerHTML = `
-    .sfgov-user__login {
-      position: relative;
-    }
-
-    details.sfgov-sandbox-user {
-      position: absolute;
-      top: 85px;
-      background: #fff;
-      margin: 0 0 20px 0;
-      border: 3px solid red;
-      border-radius: 0;
-      padding: 10px;
-    }
-
-    details.sfgov-sandbox-user ul {
-      padding: 20px;
-      margin: 0;
-      list-style-type: none;
-    }
-
-    details.sfgov-sandbox-user ul li {
-      margin-bottom: 10px;
-    }
-
-    details.sfgov-sandbox-user summary {
-      display: revert;
-      font-size: initial;
-      font-weight:normal;
-      line-height:initial;
-      border:0;
-      border-radius: 0;
-      color:initial;
-      padding:0;
-    }
-
-    details.sfgov-sandbox-user summary:after {
-      display: none;
-    }
-
-    details.sfgov-sandbox-user[open] summary {
-      background: none;
-      border-radius: 0;
-    }
-  `
-  document.head.appendChild(style)
-
   const sandboxUsers = drupalSettings.sfgov_sandbox_user.users
   const sandboxPw = drupalSettings.sfgov_sandbox_user.pw
-  const selector = '.sfgov-user__login h1'
+  const selector = '.sfgov-user__content'
   const loginContainer = document.createElement('details')
 
-  loginContainer.className = 'sfgov-sandbox-user'
-  loginContainer.innerHTML = '<summary>Login as a test user</summary>'
-  let html = '<ul>'
+  loginContainer.style.width = '80%'
+  loginContainer.innerHTML = '<summary class="details__summary">Log in as a test user</summary>'
+  let html = '<ul class="details__content" style="margin: 0">'
   
   for (let user of sandboxUsers) {
-    html += '<li><a data-user="' + user + '" href="">' + user + '</a></li>'
+    html += '<li style="margin:0 0 10px 25px"><a data-user="' + user + '" href="">' + user + '</a></li>'
   }
 
   html += '</ul>'
 
   loginContainer.innerHTML += html
 
-  document.querySelector(selector).after(loginContainer)
+  document.querySelector(selector).prepend(loginContainer)
 
   loginContainer.querySelectorAll('a').forEach((item) => {
     item.addEventListener('click', (e) => {

--- a/web/modules/custom/sfgov_utilities/js/sfgov_utilities_sandbox_user.js
+++ b/web/modules/custom/sfgov_utilities/js/sfgov_utilities_sandbox_user.js
@@ -1,0 +1,77 @@
+(() => {
+  const style = document.createElement('style')
+  style.innerHTML = `
+    .sfgov-user__login {
+      position: relative;
+    }
+
+    details.sfgov-sandbox-user {
+      position: absolute;
+      top: 85px;
+      background: #fff;
+      margin: 0 0 20px 0;
+      border: 3px solid red;
+      border-radius: 0;
+      padding: 10px;
+    }
+
+    details.sfgov-sandbox-user ul {
+      padding: 20px;
+      margin: 0;
+      list-style-type: none;
+    }
+
+    details.sfgov-sandbox-user ul li {
+      margin-bottom: 10px;
+    }
+
+    details.sfgov-sandbox-user summary {
+      display: revert;
+      font-size: initial;
+      font-weight:normal;
+      line-height:initial;
+      border:0;
+      border-radius: 0;
+      color:initial;
+      padding:0;
+    }
+
+    details.sfgov-sandbox-user summary:after {
+      display: none;
+    }
+
+    details.sfgov-sandbox-user[open] summary {
+      background: none;
+      border-radius: 0;
+    }
+  `
+  document.head.appendChild(style)
+
+  const sandboxUsers = drupalSettings.sfgov_sandbox_user.users
+  const sandboxPw = drupalSettings.sfgov_sandbox_user.pw
+  const selector = '.sfgov-user__login h1'
+  const loginContainer = document.createElement('details')
+
+  loginContainer.className = 'sfgov-sandbox-user'
+  loginContainer.innerHTML = '<summary>Login as a test user</summary>'
+  let html = '<ul>'
+  
+  for (let user of sandboxUsers) {
+    html += '<li><a data-user="' + user + '" href="">' + user + '</a></li>'
+  }
+
+  html += '</ul>'
+
+  loginContainer.innerHTML += html
+
+  document.querySelector(selector).after(loginContainer)
+
+  loginContainer.querySelectorAll('a').forEach((item) => {
+    item.addEventListener('click', (e) => {
+      e.preventDefault()
+      document.querySelector('#edit-name').value = item.getAttribute('data-user')
+      document.querySelector('#edit-pass').value = sandboxPw;
+      document.querySelector('#user-login-form').submit();
+    })
+  })
+})()

--- a/web/modules/custom/sfgov_utilities/js/sfgov_utilities_sandbox_user.js
+++ b/web/modules/custom/sfgov_utilities/js/sfgov_utilities_sandbox_user.js
@@ -70,8 +70,8 @@
     item.addEventListener('click', (e) => {
       e.preventDefault()
       document.querySelector('#edit-name').value = item.getAttribute('data-user')
-      document.querySelector('#edit-pass').value = sandboxPw;
-      document.querySelector('#user-login-form').submit();
+      document.querySelector('#edit-pass').value = sandboxPw
+      setTimeout(() => { document.querySelector('#user-login-form').submit() }, 500)
     })
   })
 })()

--- a/web/modules/custom/sfgov_utilities/js/sfgov_utilities_sandbox_user.js
+++ b/web/modules/custom/sfgov_utilities/js/sfgov_utilities_sandbox_user.js
@@ -4,12 +4,12 @@
   const selector = '.sfgov-user__content'
   const loginContainer = document.createElement('details')
 
-  loginContainer.style.width = '80%'
+  loginContainer.className = 'w-3/4'
   loginContainer.innerHTML = '<summary class="details__summary">Log in as a test user</summary>'
-  let html = '<ul class="details__content" style="margin: 0">'
+  let html = '<ul class="details__content m-0">'
   
   for (let user of sandboxUsers) {
-    html += '<li style="margin:0 0 10px 25px"><a data-user="' + user + '" href="">' + user + '</a></li>'
+    html += '<li class="mb-8 ml-28"><a data-user="' + user + '" href="">' + user + '</a></li>'
   }
 
   html += '</ul>'

--- a/web/modules/custom/sfgov_utilities/sfgov_utilities.libraries.yml
+++ b/web/modules/custom/sfgov_utilities/sfgov_utilities.libraries.yml
@@ -6,3 +6,6 @@ services:
 sandbox:
   js:
     js/sfgov_utilities_sandbox.js: {}
+sandbox_user:
+  js:
+    js/sfgov_utilities_sandbox_user.js: {}

--- a/web/modules/custom/sfgov_utilities/sfgov_utilities.module
+++ b/web/modules/custom/sfgov_utilities/sfgov_utilities.module
@@ -161,28 +161,30 @@ function sfgov_utilities_page_attachments(array &$page) {
     $page['#attached']['library'][] = 'sfgov_utilities/sandbox';
     
     /* sandbox user login */
-    $sandboxUserCredsPath = DRUPAL_ROOT . '/sites/default/files/private/secrets.json';
-    $sandboxUserCreds = null;
-    $routeName = \Drupal::routeMatch()->getRouteName();
-    if(file_exists($sandboxUserCredsPath) && $routeName == 'user.login') {
-      try {
-        $roles = \Drupal::entityTypeManager()->getStorage('user_role')->loadMultiple();
-        $sandboxUsers = [];
-        $sandboxUserPw = json_decode(file_get_contents($sandboxUserCredsPath), true);
+    if ($_ENV['PANTHEON_ENVIRONMENT'] !== 'content') { // don't do this for the content environment
+      $sandboxUserCredsPath = DRUPAL_ROOT . '/sites/default/files/private/secrets.json';
+      $sandboxUserCreds = null;
+      $routeName = \Drupal::routeMatch()->getRouteName();
+      if(file_exists($sandboxUserCredsPath) && $routeName == 'user.login') {
+        try {
+          $roles = \Drupal::entityTypeManager()->getStorage('user_role')->loadMultiple();
+          $sandboxUsers = [];
+          $sandboxUserPw = json_decode(file_get_contents($sandboxUserCredsPath), true);
 
-        foreach($roles as $role) {
-          $roleId = $role->id();
-          if($roleId != 'authenticated' && $roleId != 'anonymous') {
-            $sandboxUser = 'test.' . str_replace('_', '', $roleId);
-            $sandboxUsers[] = $sandboxUser;
+          foreach($roles as $role) {
+            $roleId = $role->id();
+            if($roleId != 'authenticated' && $roleId != 'anonymous') {
+              $sandboxUser = 'test.' . str_replace('_', '', $roleId);
+              $sandboxUsers[] = $sandboxUser;
+            }
           }
-        }
 
-        $page['#attached']['drupalSettings']['sfgov_sandbox_user']['users'] = $sandboxUsers;
-        $page['#attached']['drupalSettings']['sfgov_sandbox_user']['pw'] = $sandboxUserPw['drush_pw'];
-        $page['#attached']['library'][] = 'sfgov_utilities/sandbox_user';
-      } catch(\Exception $e) {
-        error_log($e->getMessage);
+          $page['#attached']['drupalSettings']['sfgov_sandbox_user']['users'] = $sandboxUsers;
+          $page['#attached']['drupalSettings']['sfgov_sandbox_user']['pw'] = $sandboxUserPw['drush_pw'];
+          $page['#attached']['library'][] = 'sfgov_utilities/sandbox_user';
+        } catch(\Exception $e) {
+          error_log($e->getMessage);
+        }
       }
     }
   }

--- a/web/modules/custom/sfgov_utilities/sfgov_utilities.module
+++ b/web/modules/custom/sfgov_utilities/sfgov_utilities.module
@@ -159,7 +159,8 @@ function sfgov_utilities_page_attachments(array &$page) {
   // Sandbox alert
   if (isset($_ENV['PANTHEON_ENVIRONMENT']) && $_ENV['PANTHEON_ENVIRONMENT'] !== 'live') {
     $page['#attached']['library'][] = 'sfgov_utilities/sandbox';
-
+    
+    /* sandbox user login */
     $sandboxUserCredsPath = DRUPAL_ROOT . '/sites/default/files/private/secrets.json';
     $sandboxUserCreds = null;
     $routeName = \Drupal::routeMatch()->getRouteName();
@@ -176,7 +177,7 @@ function sfgov_utilities_page_attachments(array &$page) {
             $sandboxUsers[] = $sandboxUser;
           }
         }
-        
+
         $page['#attached']['drupalSettings']['sfgov_sandbox_user']['users'] = $sandboxUsers;
         $page['#attached']['drupalSettings']['sfgov_sandbox_user']['pw'] = $sandboxUserPw['drush_pw'];
         $page['#attached']['library'][] = 'sfgov_utilities/sandbox_user';

--- a/web/modules/custom/sfgov_utilities/sfgov_utilities.module
+++ b/web/modules/custom/sfgov_utilities/sfgov_utilities.module
@@ -8,6 +8,7 @@ use Drupal\Core\Render\Element;
 use Drupal\Core\Cache\Cache;
 use Drupal\node\NodeInterface;
 use Drupal\node\Entity\Node;
+use Drush\Drush;
 
 /**
  * Implements hook_template_preprocess_default_variables_alter().
@@ -158,6 +159,31 @@ function sfgov_utilities_page_attachments(array &$page) {
   // Sandbox alert
   if (isset($_ENV['PANTHEON_ENVIRONMENT']) && $_ENV['PANTHEON_ENVIRONMENT'] !== 'live') {
     $page['#attached']['library'][] = 'sfgov_utilities/sandbox';
+
+    $sandboxUserCredsPath = DRUPAL_ROOT . '/sites/default/files/private/secrets.json';
+    $sandboxUserCreds = null;
+    $routeName = \Drupal::routeMatch()->getRouteName();
+    if(file_exists($sandboxUserCredsPath) && $routeName == 'user.login') {
+      try {
+        $roles = \Drupal::entityTypeManager()->getStorage('user_role')->loadMultiple();
+        $sandboxUsers = [];
+        $sandboxUserPw = json_decode(file_get_contents($sandboxUserCredsPath), true);
+
+        foreach($roles as $role) {
+          $roleId = $role->id();
+          if($roleId != 'authenticated' && $roleId != 'anonymous') {
+            $sandboxUser = 'test.' . str_replace('_', '', $roleId);
+            $sandboxUsers[] = $sandboxUser;
+          }
+        }
+        
+        $page['#attached']['drupalSettings']['sfgov_sandbox_user']['users'] = $sandboxUsers;
+        $page['#attached']['drupalSettings']['sfgov_sandbox_user']['pw'] = $sandboxUserPw['drush_pw'];
+        $page['#attached']['library'][] = 'sfgov_utilities/sandbox_user';
+      } catch(\Exception $e) {
+        error_log($e->getMessage);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
* adds an accordion on the login page for logging in as the different roles that exist on sf.gov
* enabled only for multidev environments, not enabled for `live` or `content`

![image](https://user-images.githubusercontent.com/19291154/168400914-b983b453-165c-4b9c-b22f-8160c900742a.png)

