### PR TITLE
create users for non-live environments (including test)  on deploy

### DIFF
--- a/pantheon.yml
+++ b/pantheon.yml
@@ -58,6 +58,9 @@ workflows:
         description: 'Notify in slack when deployed'
         script: private/scripts/slack-notify/slack_notify_drush_site_audit.php
       - type: webphp
+        description: 'Create test users'
+        script: private/scripts/drush-create-users/drush-create-users.php
+      - type: webphp
         description: 'Log to New Relic'
         script: private/scripts/new_relic/new_relic_deploy.php
       - type: webphp

--- a/web/private/scripts/drush-create-users/drush-create-users.php
+++ b/web/private/scripts/drush-create-users/drush-create-users.php
@@ -1,63 +1,60 @@
 <?php
-  require dirname(__DIR__) . '/../shared.php';
 
-  // get the roles
-  echo "get roles\n";
-
-  // attempt to get the official roles
-  ob_start();
-  passthru('drush role:list --fields=label --format=json');
-  $roles = ob_get_contents();
-  ob_end_clean();
-  $json = json_decode($roles);
-
-  echo "roles\n";
-
-  // if unable to get the roles via drush, hard code known roles
-  if (empty($json)) {
-    $json = (object) [
-      'anonymous' => [
-        'label' => 'Anonymous user'
-      ],
-      'authenticated' => [
-        'label' => 'Authenticated user'
-      ],
-      'writer' => [
-        'label' => 'Writer'
-      ],
-      'publisher' => [
-        'label' => 'Publisher'
-      ],
-      'digital_services' => [
-        'label' => 'Digital Services'
-      ],
-      'administrator' => [
-        'label' => 'Administrator'
-      ],
-    ];
-  }
-
-  print_r($json);
-
-  $pw = _get_secrets(['drush_pw'])['drush_pw'];
-  $debug = '';
-
-  foreach ($json as $role => $val) {
-    if ($role !== 'authenticated' && $role !== 'anonymous') {
-      $machineNameRole = $role; 
-      $normalizedRole = strtolower(str_replace('_', '', $role));
-      $user = 'test.' . $normalizedRole;
-      $email = $user . '@test.com';
-      $exitStatus = null;
-      $output = null;
-      exec("drush user:create ${user} --mail=\"${email}\" --password=\"${pw}\"", $output, $exitStatus);
-      if ($exitStatus == 0) {
-        exec("drush user-add-role \"${machineNameRole}\" ${user}");
-        $msg = "user ${user} created with role ${machineNameRole}\n";
-        echo $msg;
-        $debug .= "  - " . $msg;
-      }
+  if($_ENV['PANTHEON_ENVIRONMENT'] != 'live') {
+    require dirname(__DIR__) . '/../shared.php';
+  
+    // attempt to get the official roles
+    ob_start();
+    passthru('drush role:list --fields=label --format=json');
+    $roles = ob_get_contents();
+    ob_end_clean();
+    $json = json_decode($roles);
+  
+    // if unable to get the roles via drush, hard code known roles
+    if (empty($json)) {
+      $json = (object) [
+        'anonymous' => [
+          'label' => 'Anonymous user'
+        ],
+        'authenticated' => [
+          'label' => 'Authenticated user'
+        ],
+        'writer' => [
+          'label' => 'Writer'
+        ],
+        'publisher' => [
+          'label' => 'Publisher'
+        ],
+        'digital_services' => [
+          'label' => 'Digital Services'
+        ],
+        'administrator' => [
+          'label' => 'Administrator'
+        ],
+      ];
     }
-  }  
-
-  _test_hook_slack_notification("create users: \n" . (strlen($debug) > 0 ? $debug : '  no users created'));
+  
+    $pw = _get_secrets(['drush_pw'])['drush_pw'];
+    $debug = '';
+  
+    foreach ($json as $role => $val) {
+      if ($role !== 'authenticated' && $role !== 'anonymous') {
+        $machineNameRole = $role; 
+        $normalizedRole = strtolower(str_replace('_', '', $role));
+        $user = 'test.' . $normalizedRole;
+        $email = $user . '@test.com';
+        $exitStatus = null;
+        $output = null;
+        exec("drush user:create ${user} --mail=\"${email}\" --password=\"${pw}\"", $output, $exitStatus);
+        if ($exitStatus == 0) {
+          exec("drush user-add-role \"${machineNameRole}\" ${user}");
+          $msg = "user ${user} created with role ${machineNameRole}\n";
+          echo $msg;
+          $debug .= "  - " . $msg;
+        }
+      }
+    }  
+  
+    _test_hook_slack_notification("create users: \n" . (strlen($debug) > 0 ? $debug : '  no users created'));
+  
+  }


### PR DESCRIPTION
trying to create test users in the pantheon `test` environment, but the `test` environment pantheon deploy hooks are specific to `test` _and_ `live`, there isn't one specific for `test` only.  

this pr modifies the existing script to create test users to only execute in non-live pantheon environments, so that we can auto-execute the script with the pantheon `deploy` workflow hook