### PR TITLE
[SG-1730] - Fix to broken img box on Services and Public body (departments) page.

### DIFF
--- a/web/themes/custom/sfgovpl/templates/components/hero-banner-default.twig
+++ b/web/themes/custom/sfgovpl/templates/components/hero-banner-default.twig
@@ -4,7 +4,9 @@
     {{ banner.label }}
     <div class="hero-banner--logo-wrapper">
       {% block logo %}
-        <img class="hero-banner--logo" src="{{ banner.logo }}"/>
+        {% if banner.logo %}
+          <img class="hero-banner--logo" src="{{ banner.logo }}"/>
+        {% endif %}
       {% endblock logo %}
       <h1 class="hero-banner--title">{{ banner.title }}</h1>
     </div>


### PR DESCRIPTION
[SG-1730] - Fix to broken img box on Services and Public body (departments) page.

Update to the hero banner template, to only print out the img tag if the banner logo url is present. Otherwise, don't print out.

**Instructions:** 
A cache clear and review /services and /departments is all that's needed.

[SG-1730]: https://sfgovdt.jira.com/browse/SG-1730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ