### PR TITLE
SG-1690 - disable unused field_dept fields

### DIFF
--- a/config/core.entity_form_display.node.campaign.default.yml
+++ b/config/core.entity_form_display.node.campaign.default.yml
@@ -45,7 +45,6 @@ third_party_settings:
     group_about:
       children:
         - field_campaign_about
-        - field_dept
         - field_departments
         - field_links
       label: About
@@ -65,7 +64,7 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 13
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -105,16 +104,6 @@ content:
   field_departments:
     type: entity_reference_autocomplete
     weight: 14
-    region: content
-    settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_dept:
-    type: entity_reference_autocomplete
-    weight: 13
     region: content
     settings:
       match_operator: CONTAINS
@@ -226,36 +215,36 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 16
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
   path:
     type: path
-    weight: 15
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 20
+    weight: 19
     region: content
     settings: {  }
     third_party_settings: {  }
   publish_state:
     type: scheduler_moderation
-    weight: 22
+    weight: 21
     region: content
     settings: {  }
     third_party_settings: {  }
   scheduler_settings:
-    weight: 18
+    weight: 17
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 17
+    weight: 16
     region: content
     settings:
       display_label: true
@@ -278,7 +267,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 12
+    weight: 11
     region: content
     settings:
       match_operator: CONTAINS
@@ -288,21 +277,22 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 21
+    weight: 20
     region: content
     settings: {  }
     third_party_settings: {  }
   unpublish_state:
     type: scheduler_moderation
-    weight: 19
+    weight: 18
     region: content
     settings: {  }
     third_party_settings: {  }
   url_redirects:
-    weight: 14
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_dept: true
   promote: true
   sticky: true

--- a/config/core.entity_form_display.node.department_table.default.yml
+++ b/config/core.entity_form_display.node.department_table.default.yml
@@ -76,17 +76,7 @@ content:
     third_party_settings: {  }
   field_departments:
     type: entity_reference_autocomplete
-    weight: 102
-    region: content
-    settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_dept:
-    type: entity_reference_autocomplete
-    weight: 101
+    weight: 20
     region: content
     settings:
       match_operator: CONTAINS
@@ -199,5 +189,6 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_dept: true
   promote: true
   sticky: true

--- a/config/core.entity_form_display.node.event.default.yml
+++ b/config/core.entity_form_display.node.event.default.yml
@@ -135,16 +135,6 @@ content:
     third_party_settings: {  }
   field_departments:
     type: entity_reference_autocomplete
-    weight: 10
-    region: content
-    settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_dept:
-    type: entity_reference_autocomplete
     weight: 9
     region: content
     settings:
@@ -254,7 +244,7 @@ content:
     third_party_settings: {  }
   field_topics:
     type: entity_reference_autocomplete
-    weight: 11
+    weight: 10
     region: content
     settings:
       match_operator: CONTAINS
@@ -264,31 +254,31 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 13
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
   path:
     type: path
-    weight: 15
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 19
+    weight: 18
     region: content
     settings: {  }
     third_party_settings: {  }
   publish_state:
     type: scheduler_moderation
-    weight: 17
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 14
+    weight: 13
     region: content
     settings:
       display_label: true
@@ -302,24 +292,25 @@ content:
       placeholder: ''
     third_party_settings: {  }
   translation:
-    weight: 12
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 18
+    weight: 17
     region: content
     settings: {  }
     third_party_settings: {  }
   unpublish_state:
     type: scheduler_moderation
-    weight: 16
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
   created: true
+  field_dept: true
   field_end_date: true
   field_start_date: true
   langcode: true

--- a/config/core.entity_form_display.node.form_confirmation_page.default.yml
+++ b/config/core.entity_form_display.node.form_confirmation_page.default.yml
@@ -192,16 +192,6 @@ content:
     third_party_settings: {  }
   field_departments:
     type: entity_reference_autocomplete
-    weight: 101
-    region: content
-    settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_dept:
-    type: entity_reference_autocomplete
     weight: 15
     region: content
     settings:
@@ -316,5 +306,6 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_dept: true
   promote: true
   sticky: true

--- a/config/core.entity_form_display.node.information_page.default.yml
+++ b/config/core.entity_form_display.node.information_page.default.yml
@@ -28,7 +28,7 @@ mode: default
 content:
   field_departments:
     type: entity_reference_autocomplete
-    weight: 5
+    weight: 4
     region: content
     settings:
       match_operator: CONTAINS
@@ -71,19 +71,9 @@ content:
         collapse_edit_all: collapse_edit_all
         duplicate: duplicate
     third_party_settings: {  }
-  field_public_body:
-    type: entity_reference_autocomplete
-    weight: 4
-    region: content
-    settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
   field_related_content:
     type: entity_reference_autocomplete
-    weight: 7
+    weight: 6
     region: content
     settings:
       match_operator: CONTAINS
@@ -93,7 +83,7 @@ content:
     third_party_settings: {  }
   field_topics:
     type: entity_reference_autocomplete
-    weight: 6
+    weight: 5
     region: content
     settings:
       match_operator: CONTAINS
@@ -113,19 +103,19 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 8
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 11
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }
   publish_state:
     type: scheduler_moderation
-    weight: 13
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -138,30 +128,31 @@ content:
       placeholder: ''
     third_party_settings: {  }
   translation:
-    weight: 9
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 12
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
   unpublish_state:
     type: scheduler_moderation
-    weight: 14
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }
   url_redirects:
-    weight: 10
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
   body: true
   created: true
+  field_public_body: true
   langcode: true
   path: true
   promote: true

--- a/config/core.entity_form_display.node.meeting.default.yml
+++ b/config/core.entity_form_display.node.meeting.default.yml
@@ -159,16 +159,6 @@ content:
     third_party_settings: {  }
   field_departments:
     type: entity_reference_autocomplete
-    weight: 10
-    region: content
-    settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_dept:
-    type: entity_reference_autocomplete
     weight: 9
     region: content
     settings:
@@ -319,31 +309,31 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 14
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }
   path:
     type: path
-    weight: 12
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 19
+    weight: 18
     region: content
     settings: {  }
     third_party_settings: {  }
   publish_state:
     type: scheduler_moderation
-    weight: 17
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 13
+    weight: 12
     region: content
     settings:
       display_label: true
@@ -357,29 +347,30 @@ content:
       placeholder: ''
     third_party_settings: {  }
   translation:
-    weight: 15
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 16
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
   unpublish_state:
     type: scheduler_moderation
-    weight: 18
+    weight: 17
     region: content
     settings: {  }
     third_party_settings: {  }
   url_redirects:
-    weight: 11
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
   created: true
+  field_dept: true
   field_end_date: true
   field_start_date: true
   field_title: true

--- a/config/core.entity_form_display.node.news.default.yml
+++ b/config/core.entity_form_display.node.news.default.yml
@@ -60,16 +60,6 @@ content:
     third_party_settings: {  }
   field_departments:
     type: entity_reference_autocomplete
-    weight: 13
-    region: content
-    settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_dept:
-    type: entity_reference_autocomplete
     weight: 12
     region: content
     settings:
@@ -109,7 +99,7 @@ content:
     third_party_settings: {  }
   field_topics:
     type: entity_reference_autocomplete
-    weight: 14
+    weight: 13
     region: content
     settings:
       match_operator: CONTAINS
@@ -131,13 +121,13 @@ content:
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 18
+    weight: 17
     region: content
     settings: {  }
     third_party_settings: {  }
   publish_state:
     type: scheduler_moderation
-    weight: 16
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -163,13 +153,13 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 17
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }
   unpublish_state:
     type: scheduler_moderation
-    weight: 15
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -180,6 +170,7 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_dept: true
   langcode: true
   promote: true
   sticky: true

--- a/config/core.entity_form_display.node.resource_collection.default.yml
+++ b/config/core.entity_form_display.node.resource_collection.default.yml
@@ -202,16 +202,6 @@ content:
     third_party_settings: {  }
   field_departments:
     type: entity_reference_autocomplete
-    weight: 101
-    region: content
-    settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_dept:
-    type: entity_reference_autocomplete
     weight: 19
     region: content
     settings:
@@ -356,6 +346,7 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_dept: true
   field_sidebar: true
   langcode: true
   promote: true

--- a/config/core.entity_form_display.node.step_by_step.default.yml
+++ b/config/core.entity_form_display.node.step_by_step.default.yml
@@ -33,17 +33,7 @@ content:
     third_party_settings: {  }
   field_departments:
     type: entity_reference_autocomplete
-    weight: 102
-    region: content
-    settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_dept:
-    type: entity_reference_autocomplete
-    weight: 101
+    weight: 16
     region: content
     settings:
       match_operator: CONTAINS
@@ -187,6 +177,7 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_dept: true
   langcode: true
   promote: true
   sticky: true

--- a/config/core.entity_view_display.node.campaign.default.yml
+++ b/config/core.entity_view_display.node.campaign.default.yml
@@ -30,7 +30,7 @@ third_party_settings:
       label: 'Locations and Access'
       parent_name: ''
       region: hidden
-      weight: 16
+      weight: 15
       format_type: html_element
       format_settings:
         classes: __campaign-locations-access-wrapper
@@ -75,14 +75,6 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 9
-    region: content
-  field_dept:
-    type: entity_reference_label
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
     weight: 8
     region: content
   field_header_spotlight:
@@ -104,7 +96,7 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    weight: 10
+    weight: 9
     region: content
   field_logo:
     type: image
@@ -144,6 +136,7 @@ content:
     region: content
 hidden:
   field_campaign_theme: true
+  field_dept: true
   formio_url: true
   langcode: true
   links: true

--- a/config/core.entity_view_display.node.event.default.yml
+++ b/config/core.entity_view_display.node.event.default.yml
@@ -73,14 +73,6 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 11
-    region: content
-  field_dept:
-    type: entity_reference_label
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
     weight: 10
     region: content
   field_description:
@@ -116,7 +108,7 @@ content:
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
-    weight: 12
+    weight: 11
     region: content
   field_location_online:
     type: boolean
@@ -126,7 +118,7 @@ content:
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
-    weight: 13
+    weight: 12
     region: content
   field_phone_numbers:
     type: entity_reference_revisions_entity_view
@@ -145,6 +137,7 @@ content:
     weight: 3
     region: content
 hidden:
+  field_dept: true
   field_end_date: true
   field_topics: true
   formio_url: true

--- a/config/core.entity_view_display.node.form_confirmation_page.default.yml
+++ b/config/core.entity_view_display.node.form_confirmation_page.default.yml
@@ -68,6 +68,15 @@ content:
     third_party_settings: {  }
     weight: 3
     region: content
+  field_dept:
+    type: entity_reference_entity_view
+    label: above
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    weight: 10
+    region: content
   field_step:
     type: entity_reference_revisions_entity_view
     label: above
@@ -79,7 +88,6 @@ content:
     region: content
 hidden:
   field_departments: true
-  field_dept: true
   field_form_confirm_page_slug: true
   formio_url: true
   langcode: true

--- a/config/core.entity_view_display.node.information_page.default.yml
+++ b/config/core.entity_view_display.node.information_page.default.yml
@@ -32,7 +32,7 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 5
+    weight: 4
     region: content
   field_description:
     type: text_default
@@ -50,21 +50,13 @@ content:
     third_party_settings: {  }
     weight: 3
     region: content
-  field_public_body:
-    type: entity_reference_label
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    weight: 4
-    region: content
   field_related_content:
     type: entity_reference_label
     label: above
     settings:
       link: true
     third_party_settings: {  }
-    weight: 6
+    weight: 5
     region: content
   field_transactions:
     type: entity_reference_entity_view
@@ -77,6 +69,7 @@ content:
     region: content
 hidden:
   body: true
+  field_public_body: true
   field_topics: true
   formio_url: true
   langcode: true

--- a/config/core.entity_view_display.node.meeting.default.yml
+++ b/config/core.entity_view_display.node.meeting.default.yml
@@ -51,7 +51,7 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 16
+    weight: 15
     region: content
   field_address:
     type: entity_reference_entity_view
@@ -69,19 +69,11 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 9
+    weight: 8
     region: content
   field_departments:
     type: entity_reference_label
     label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    weight: 4
-    region: content
-  field_dept:
-    type: entity_reference_label
-    label: hidden
     settings:
       link: true
     third_party_settings: {  }
@@ -97,7 +89,7 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    weight: 6
+    weight: 5
     region: content
   field_link:
     type: link
@@ -109,7 +101,7 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    weight: 17
+    weight: 16
     region: content
   field_location_in_person:
     type: boolean
@@ -119,7 +111,7 @@ content:
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
-    weight: 15
+    weight: 14
     region: content
   field_location_online:
     type: boolean
@@ -129,7 +121,7 @@ content:
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
-    weight: 14
+    weight: 13
     region: content
   field_meeting_artifacts:
     type: entity_reference_revisions_entity_view
@@ -138,7 +130,7 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 8
+    weight: 7
     region: content
   field_meeting_cancel:
     type: boolean
@@ -148,7 +140,7 @@ content:
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
-    weight: 7
+    weight: 6
     region: content
   field_phone_numbers:
     type: entity_reference_revisions_entity_view
@@ -157,7 +149,7 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 18
+    weight: 17
     region: content
   field_public_body:
     type: entity_reference_entity_view
@@ -166,7 +158,7 @@ content:
       view_mode: default
       link: false
     third_party_settings: {  }
-    weight: 10
+    weight: 9
     region: content
   field_regulations_accordions:
     type: entity_reference_revisions_entity_view
@@ -175,7 +167,7 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 13
+    weight: 12
     region: content
   field_regulations_title:
     type: string
@@ -183,14 +175,14 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 12
+    weight: 11
     region: content
   field_smart_date:
     type: sfgov_dates_node_date
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 5
+    weight: 4
     region: content
   field_videos:
     type: entity_reference_revisions_entity_view
@@ -199,9 +191,10 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 11
+    weight: 10
     region: content
 hidden:
+  field_dept: true
   field_title: true
   formio_url: true
   langcode: true

--- a/config/core.entity_view_display.node.news.default.yml
+++ b/config/core.entity_view_display.node.news.default.yml
@@ -57,14 +57,6 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 6
-    region: content
-  field_dept:
-    type: entity_reference_label
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
     weight: 5
     region: content
   field_image:
@@ -81,9 +73,10 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 7
+    weight: 6
     region: content
 hidden:
+  field_dept: true
   field_direct_external_url: true
   field_topics: true
   formio_url: true

--- a/config/core.entity_view_display.node.resource_collection.default.yml
+++ b/config/core.entity_view_display.node.resource_collection.default.yml
@@ -61,14 +61,6 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 9
-    region: content
-  field_dept:
-    type: entity_reference_label
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
     weight: 8
     region: content
   field_description:
@@ -94,7 +86,7 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 10
+    weight: 9
     region: content
   field_sidebar:
     type: entity_reference_revisions_entity_view
@@ -114,6 +106,7 @@ content:
     weight: 4
     region: content
 hidden:
+  field_dept: true
   formio_url: true
   langcode: true
   links: true

--- a/config/field.field.node.meeting.field_departments.yml
+++ b/config/field.field.node.meeting.field_departments.yml
@@ -16,7 +16,7 @@ id: node.meeting.field_departments
 field_name: field_departments
 entity_type: node
 bundle: meeting
-label: Department
+label: Departments
 description: ''
 required: false
 translatable: true


### PR DESCRIPTION
Done in production.  This pr preserves the changes made in production for the next release.  `field_dept` disabled on these content types because those references have been moved to `field_departments`:

- Campaign
- Department table
- Event
- Form confirmation page
- Information page
- Meeting
- News
- Resource collection
- Step by step
