### PR TITLE
[SG-570] - Setup to make department teaser links open in a new tab, if they are linked to an external site.

### DIFF
--- a/web/themes/custom/sfgovpl/includes/node.inc
+++ b/web/themes/custom/sfgovpl/includes/node.inc
@@ -50,6 +50,28 @@ function sfgovpl_preprocess_node(&$variables) {
           break;
       }
     }
+
+    // Teaser.
+    if ($view_mode == 'teaser') {
+      switch ($content_type) {
+        case 'department':
+
+          // Set the target for department links on teasers.
+          // If the "Go to current URL" field is checked, it sets the target to
+          // "_blank". This will print the target on the department teaser
+          // template file (node--department--teaser.html.twig).
+          $variables['target'] = NULL;
+          if ($node->hasField('field_go_to_current_url')) {
+            $field_go_to_current_url = $node->get('field_go_to_current_url')
+              ->getValue();
+            if (!empty($field_go_to_current_url[0]) && $field_go_to_current_url[0]['value'] == '1') {
+              $variables['target'] = '_blank';
+            }
+          }
+          break;
+      }
+    }
+
     $variables['language'] = \Drupal::languageManager()->getCurrentLanguage()->getId();
   }
 }
@@ -680,7 +702,7 @@ function profile_page_fields($node) {
         } else {
           $Addresstitle = $addressValues['organization'] ?: $addressValues['addressee'] ?: $addressValues['location_name'];
         }
-        // Choose a title value in descending order. 
+        // Choose a title value in descending order.
         $theFields['address']['title'] = $Addresstitle;
         // If one of the address fields was used as the title, remove it from
         // the render array so that it doesn't show up twice.

--- a/web/themes/custom/sfgovpl/templates/node/node--department--teaser.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--department--teaser.html.twig
@@ -3,8 +3,7 @@
   <div class="transaction-card-container">
     <h2 class="transaction-card__title">
       {% if url %}
-        <a href="{{ url }}" class="transaction-card--link">{{ node.label }}</a>
-      {% else %}
+        <a href="{{ url }}" class="transaction-card--link" {% if target %}target="{{ target }}"{% endif %}>{{ node.label }}</a>      {% else %}
         {{ node.label }}
       {% endif %}
     </h2>


### PR DESCRIPTION
The setup looks for the "Go to current URL" checkbox, which forces the site to redirect to an external site.
If it finds the checkbox is checked, it adds the target attribute to the link in the department teaser template.

Testing/Implementing instructions:
1. 	Clear caches
2. 	Test any link on the Departments page, and confirm that those links that go off to external websites,
	open in a new tab