### PR TITLE
[SG-746] -- Fix to callout description text box formatting.

### DIFF
--- a/web/themes/custom/sfgovpl/templates/components/callout.twig
+++ b/web/themes/custom/sfgovpl/templates/components/callout.twig
@@ -3,6 +3,6 @@
     {%- if title -%}
       <h3 class="sfgov-callout-heading">{{ title }}</h3>
     {%- endif -%}
-    <p class="sfgov-callout-content">{{ content|striptags('<a>')|raw }}</p>
+    <p class="sfgov-callout-content">{{ content|striptags('<a><strong><u>')|raw }}</p>
   </div>
 </div>


### PR DESCRIPTION
Twig file had the "striptags" filter applied to the content. It was only allowing <a> tags. I changed to allow <strong> and <ul> as they are allowed by the "SF restricted HTML" formatter.

Test/Instructions:
1. 	Clear cache
2.	Edit a known callout box or create one on a transaction
3.	Edit the text to add bold or underline text.
4.	Save and observe fix.