### PR TITLE
[SG-803] - Moved "Files" tab from under content, to under reports to help remove confusion.

### DIFF
--- a/web/modules/custom/sfgov_admin/sfgov_admin.links.menu.yml
+++ b/web/modules/custom/sfgov_admin/sfgov_admin.links.menu.yml
@@ -1,0 +1,6 @@
+sfgov_admin.files_report_listing:
+  title: 'Files'
+  description: 'All files known to the File System'
+  route_name: view.files.page_1
+  parent: system.admin_reports
+  menu_name: admin

--- a/web/modules/custom/sfgov_admin/sfgov_admin.module
+++ b/web/modules/custom/sfgov_admin/sfgov_admin.module
@@ -1,5 +1,6 @@
 <?php
 
+use Drupal\Core\Cache\RefinableCacheableDependencyInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Component\Utility\Html;
@@ -425,4 +426,22 @@ function sfgov_admin_cron() {
         ->execute();
     }
   }
+}
+
+/**
+ * Implements hook_menu_local_tasks_alter().
+ */
+function sfgov_admin_menu_local_tasks_alter(&$data, $route_name, RefinableCacheableDependencyInterface $cacheability) {
+
+  // Remove the Files tab from the Content administration page.
+  unset($data['tabs'][0]['views_view:view.files.page_1']);
+}
+
+/**
+ * Implements hook_menu_links_discovered_alter().
+ */
+function sfgov_admin_menu_links_discovered_alter(&$links) {
+
+  // Remove the Files tab from the Content administration page.
+  unset($links['admin_toolbar_tools.extra_links:view.files']);
 }


### PR DESCRIPTION
The Files page is more of an information page anyways, So I created a link in the Reports section to go to the Files listing page, and I've removed the Files link from displaying under "Content" in the admin menu, and as a Tab under the "Content" section.

I moved the link to the Reports because it still provides useful information about the files that Drupal knows about, even if there is no direct editing or other functionality.

Test:
1. Clear cache.
2. Hover over the Content tab in the admin menu, and you won't see "Files" link in the dropdown.
3. Click into the Content section. You shouldn't see a "Files" Tab in the tab links.
4. Hover over Reports, and you should see a "Files" link
5. Click into the Reports section and you should see a "Files" link in the listings