### PR TITLE
SG-1743 -- Update to pathauto patterns config files to have the new syntax from the updated module

### DIFF
--- a/config/pathauto.pattern.about.yml
+++ b/config/pathauto.pattern.about.yml
@@ -10,7 +10,7 @@ type: 'canonical_entities:node'
 pattern: '[node:field_parent_department:entity:url:path]/about'
 selection_criteria:
   a1635dad-3bcd-40c2-85fe-19bb723f6cfd:
-    id: node_type
+    id: 'entity_bundle:node'
     negate: false
     uuid: a1635dad-3bcd-40c2-85fe-19bb723f6cfd
     context_mapping:

--- a/config/pathauto.pattern.content.yml
+++ b/config/pathauto.pattern.content.yml
@@ -10,7 +10,7 @@ type: 'canonical_entities:node'
 pattern: '[node:source:title]'
 selection_criteria:
   34d318f6-bf62-4f4b-814e-f7df871f69be:
-    id: node_type
+    id: 'entity_bundle:node'
     negate: false
     uuid: 34d318f6-bf62-4f4b-814e-f7df871f69be
     context_mapping:

--- a/config/pathauto.pattern.data_story.yml
+++ b/config/pathauto.pattern.data_story.yml
@@ -10,7 +10,7 @@ type: 'canonical_entities:node'
 pattern: 'data/[node:title]'
 selection_criteria:
   51dc9c35-f202-493c-bdf9-3aca304e1915:
-    id: node_type
+    id: 'entity_bundle:node'
     negate: false
     uuid: 51dc9c35-f202-493c-bdf9-3aca304e1915
     context_mapping:

--- a/config/pathauto.pattern.departments.yml
+++ b/config/pathauto.pattern.departments.yml
@@ -10,7 +10,7 @@ type: 'canonical_entities:node'
 pattern: 'departments/[node:field_parent_department]/[node:source:title]'
 selection_criteria:
   e9b2cbb7-6ced-4f42-b2b5-3f6ff6de091b:
-    id: node_type
+    id: 'entity_bundle:node'
     negate: false
     uuid: e9b2cbb7-6ced-4f42-b2b5-3f6ff6de091b
     context_mapping:

--- a/config/pathauto.pattern.events.yml
+++ b/config/pathauto.pattern.events.yml
@@ -10,7 +10,7 @@ type: 'canonical_entities:node'
 pattern: 'events/[node:field_smart_date:value-custom:F-j-Y]/[node:source:title]'
 selection_criteria:
   f15214cd-d3fd-4859-a76b-02fdc3b08a3e:
-    id: node_type
+    id: 'entity_bundle:node'
     negate: false
     uuid: f15214cd-d3fd-4859-a76b-02fdc3b08a3e
     context_mapping:

--- a/config/pathauto.pattern.form_confirmation_page.yml
+++ b/config/pathauto.pattern.form_confirmation_page.yml
@@ -10,7 +10,7 @@ type: 'canonical_entities:node'
 pattern: '[node:field_form_confirm_page_slug]/confirm'
 selection_criteria:
   ac68847f-f5da-4c71-8749-d9a9f6aba6c0:
-    id: node_type
+    id: 'entity_bundle:node'
     negate: false
     uuid: ac68847f-f5da-4c71-8749-d9a9f6aba6c0
     context_mapping:

--- a/config/pathauto.pattern.form_start_page.yml
+++ b/config/pathauto.pattern.form_start_page.yml
@@ -10,7 +10,7 @@ type: 'canonical_entities:node'
 pattern: '[node:source:title]/form'
 selection_criteria:
   57e9fa44-80cb-4c08-ac32-d8981fa188d8:
-    id: node_type
+    id: 'entity_bundle:node'
     negate: false
     uuid: 57e9fa44-80cb-4c08-ac32-d8981fa188d8
     context_mapping:

--- a/config/pathauto.pattern.information.yml
+++ b/config/pathauto.pattern.information.yml
@@ -10,7 +10,7 @@ type: 'canonical_entities:node'
 pattern: 'information/[node:source:title]'
 selection_criteria:
   2616e3cc-643d-495e-b13c-80955b37666a:
-    id: node_type
+    id: 'entity_bundle:node'
     negate: false
     uuid: 2616e3cc-643d-495e-b13c-80955b37666a
     context_mapping:

--- a/config/pathauto.pattern.locations.yml
+++ b/config/pathauto.pattern.locations.yml
@@ -10,7 +10,7 @@ type: 'canonical_entities:node'
 pattern: '/location/[node:title]'
 selection_criteria:
   fd414694-d652-4bfb-b47e-4d342b3797ff:
-    id: node_type
+    id: 'entity_bundle:node'
     negate: false
     uuid: fd414694-d652-4bfb-b47e-4d342b3797ff
     context_mapping:

--- a/config/pathauto.pattern.meeting.yml
+++ b/config/pathauto.pattern.meeting.yml
@@ -10,7 +10,7 @@ type: 'canonical_entities:node'
 pattern: 'meeting/[node:field_smart_date:value-custom:F-j-Y]/[node:source:title]'
 selection_criteria:
   63dd80db-0328-448c-b779-e456e57fa7d0:
-    id: node_type
+    id: 'entity_bundle:node'
     negate: false
     uuid: 63dd80db-0328-448c-b779-e456e57fa7d0
     context_mapping:

--- a/config/pathauto.pattern.person.yml
+++ b/config/pathauto.pattern.person.yml
@@ -10,7 +10,7 @@ type: 'canonical_entities:node'
 pattern: 'profile/[node:source:title]'
 selection_criteria:
   0edcb641-3039-4516-bdac-c757e8871be4:
-    id: node_type
+    id: 'entity_bundle:node'
     negate: false
     uuid: 0edcb641-3039-4516-bdac-c757e8871be4
     context_mapping:

--- a/config/pathauto.pattern.public_body.yml
+++ b/config/pathauto.pattern.public_body.yml
@@ -10,7 +10,7 @@ type: 'canonical_entities:node'
 pattern: 'public-body/[node:source:title]'
 selection_criteria:
   2dadbf62-1659-4919-9af6-3591e012c9cd:
-    id: node_type
+    id: 'entity_bundle:node'
     negate: false
     uuid: 2dadbf62-1659-4919-9af6-3591e012c9cd
     context_mapping:

--- a/config/pathauto.pattern.report.yml
+++ b/config/pathauto.pattern.report.yml
@@ -10,7 +10,7 @@ type: 'canonical_entities:node'
 pattern: 'reports/[node:field_date_only:date:custom:F-Y]/[node:source:title]'
 selection_criteria:
   06c1a2fa-b1c6-4980-ab43-ec0f9a864624:
-    id: node_type
+    id: 'entity_bundle:node'
     negate: false
     uuid: 06c1a2fa-b1c6-4980-ab43-ec0f9a864624
     context_mapping:

--- a/config/pathauto.pattern.resource_collection.yml
+++ b/config/pathauto.pattern.resource_collection.yml
@@ -10,7 +10,7 @@ type: 'canonical_entities:node'
 pattern: 'resource/[node:created:custom:Y]/[node:source:title]'
 selection_criteria:
   022a199f-426b-471e-9210-cdd2869f680f:
-    id: node_type
+    id: 'entity_bundle:node'
     negate: false
     uuid: 022a199f-426b-471e-9210-cdd2869f680f
     context_mapping:

--- a/config/pathauto.pattern.standard.yml
+++ b/config/pathauto.pattern.standard.yml
@@ -10,7 +10,7 @@ type: 'canonical_entities:node'
 pattern: '[node:content-type]/[node:source:title]'
 selection_criteria:
   4b246367-e457-4cf4-ac9e-96d3793e4121:
-    id: node_type
+    id: 'entity_bundle:node'
     negate: false
     uuid: 4b246367-e457-4cf4-ac9e-96d3793e4121
     context_mapping:

--- a/config/pathauto.pattern.step_by_step.yml
+++ b/config/pathauto.pattern.step_by_step.yml
@@ -11,7 +11,7 @@ type: 'canonical_entities:node'
 pattern: 'step-by-step/[node:source:title]'
 selection_criteria:
   26733516-74fe-40c0-a287-77ac5a223d63:
-    id: node_type
+    id: 'entity_bundle:node'
     negate: false
     uuid: 26733516-74fe-40c0-a287-77ac5a223d63
     context_mapping:

--- a/config/pathauto.pattern.topics.yml
+++ b/config/pathauto.pattern.topics.yml
@@ -10,7 +10,7 @@ type: 'canonical_entities:node'
 pattern: 'topics/[node:source:title]'
 selection_criteria:
   cb7a77a6-c70c-400c-8caa-31c08bae3ae6:
-    id: node_type
+    id: 'entity_bundle:node'
     negate: false
     uuid: cb7a77a6-c70c-400c-8caa-31c08bae3ae6
     context_mapping:


### PR DESCRIPTION
Update to pathauto patterns config files to have the new syntax from the updated module

The newer version changes the ID of the pathauto selector type from
`id: node_type`
to
`id: 'entity_bundle:node'`