### PR TITLE
[SG-1718] -- Campaign page translation issues: disable "Theme" field translation

### DIFF
--- a/config/field.field.node.campaign.field_campaign_theme.yml
+++ b/config/field.field.node.campaign.field_campaign_theme.yml
@@ -18,7 +18,7 @@ bundle: campaign
 label: Theme
 description: ''
 required: true
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:


### PR DESCRIPTION
Disables the  "Theme" field translation and locks it to same values across translations.

Instructions:
1. Edit or create a new campaign.
2. Translate page, and notice that the Theme field is not available on translations edit.
3. View all translations of the campaign page and confirm that they are all the same "theme" colors in the header