### PR TITLE
Sg 1528 patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -283,6 +283,9 @@
             "drupal/media_entity_file_replace": {
                 "Multi value field file replace": "https://www.drupal.org/files/issues/2022-04-01/media_entity_file_replace-3254763-multiple-files-8.patch",
                 "Labels and descriptions update": "patches/media_entity_file_replace--update-labels.patch"
+            },
+            "drupal/datalayer": {
+                "Update field output to always be an array to allow for multivalue fields": "https://www.drupal.org/files/issues/2019-03-24/2940811-update-field-output-to-array-12.patch"
             }
         },
         "enable-patching": "true"

--- a/config/field.field.node.campaign.field_departments.yml
+++ b/config/field.field.node.campaign.field_departments.yml
@@ -8,8 +8,12 @@ dependencies:
     - node.type.department
     - node.type.public_body
   module:
+    - datalayer
     - tmgmt_content
 third_party_settings:
+  datalayer:
+    expose: 1
+    label: field_departments
   tmgmt_content:
     excluded: false
 id: node.campaign.field_departments

--- a/config/field.field.node.data_story.field_departments.yml
+++ b/config/field.field.node.data_story.field_departments.yml
@@ -7,8 +7,12 @@ dependencies:
     - node.type.data_story
     - node.type.department
   module:
+    - datalayer
     - tmgmt_content
 third_party_settings:
+  datalayer:
+    expose: 1
+    label: field_departments
   tmgmt_content:
     excluded: false
 id: node.data_story.field_departments
@@ -28,6 +32,7 @@ settings:
       department: department
     sort:
       field: _none
+      direction: ASC
     auto_create: false
     auto_create_bundle: ''
 field_type: entity_reference

--- a/config/field.field.node.department_table.field_departments.yml
+++ b/config/field.field.node.department_table.field_departments.yml
@@ -8,8 +8,12 @@ dependencies:
     - node.type.department_table
     - node.type.public_body
   module:
+    - datalayer
     - tmgmt_content
 third_party_settings:
+  datalayer:
+    expose: 1
+    label: field_departments
   tmgmt_content:
     excluded: false
 id: node.department_table.field_departments

--- a/config/field.field.node.event.field_departments.yml
+++ b/config/field.field.node.event.field_departments.yml
@@ -8,8 +8,12 @@ dependencies:
     - node.type.event
     - node.type.public_body
   module:
+    - datalayer
     - tmgmt_content
 third_party_settings:
+  datalayer:
+    expose: 1
+    label: field_departments
   tmgmt_content:
     excluded: false
 id: node.event.field_departments

--- a/config/field.field.node.form_confirmation_page.field_departments.yml
+++ b/config/field.field.node.form_confirmation_page.field_departments.yml
@@ -8,8 +8,12 @@ dependencies:
     - node.type.form_confirmation_page
     - node.type.public_body
   module:
+    - datalayer
     - tmgmt_content
 third_party_settings:
+  datalayer:
+    expose: 1
+    label: field_departments
   tmgmt_content:
     excluded: false
 id: node.form_confirmation_page.field_departments

--- a/config/field.field.node.information_page.field_departments.yml
+++ b/config/field.field.node.information_page.field_departments.yml
@@ -8,8 +8,12 @@ dependencies:
     - node.type.information_page
     - node.type.public_body
   module:
+    - datalayer
     - tmgmt_content
 third_party_settings:
+  datalayer:
+    expose: 1
+    label: field_departments
   tmgmt_content:
     excluded: false
 id: node.information_page.field_departments

--- a/config/field.field.node.location.field_departments.yml
+++ b/config/field.field.node.location.field_departments.yml
@@ -7,8 +7,12 @@ dependencies:
     - node.type.department
     - node.type.location
   module:
+    - datalayer
     - tmgmt_content
 third_party_settings:
+  datalayer:
+    expose: 1
+    label: field_departments
   tmgmt_content:
     excluded: false
 id: node.location.field_departments
@@ -28,6 +32,7 @@ settings:
       department: department
     sort:
       field: _none
+      direction: ASC
     auto_create: false
     auto_create_bundle: ''
 field_type: entity_reference

--- a/config/field.field.node.meeting.field_departments.yml
+++ b/config/field.field.node.meeting.field_departments.yml
@@ -8,8 +8,12 @@ dependencies:
     - node.type.meeting
     - node.type.public_body
   module:
+    - datalayer
     - tmgmt_content
 third_party_settings:
+  datalayer:
+    expose: 1
+    label: field_departments
   tmgmt_content:
     excluded: false
 id: node.meeting.field_departments

--- a/config/field.field.node.news.field_departments.yml
+++ b/config/field.field.node.news.field_departments.yml
@@ -8,8 +8,12 @@ dependencies:
     - node.type.news
     - node.type.public_body
   module:
+    - datalayer
     - tmgmt_content
 third_party_settings:
+  datalayer:
+    expose: 1
+    label: field_departments
   tmgmt_content:
     excluded: false
 id: node.news.field_departments

--- a/config/field.field.node.public_body.field_departments.yml
+++ b/config/field.field.node.public_body.field_departments.yml
@@ -7,8 +7,12 @@ dependencies:
     - node.type.department
     - node.type.public_body
   module:
+    - datalayer
     - tmgmt_content
 third_party_settings:
+  datalayer:
+    expose: 1
+    label: field_departments
   tmgmt_content:
     excluded: false
 id: node.public_body.field_departments
@@ -28,6 +32,7 @@ settings:
       department: department
     sort:
       field: _none
+      direction: ASC
     auto_create: 0
     auto_create_bundle: ''
 field_type: entity_reference

--- a/config/field.field.node.resource_collection.field_departments.yml
+++ b/config/field.field.node.resource_collection.field_departments.yml
@@ -8,8 +8,12 @@ dependencies:
     - node.type.public_body
     - node.type.resource_collection
   module:
+    - datalayer
     - tmgmt_content
 third_party_settings:
+  datalayer:
+    expose: 1
+    label: field_departments
   tmgmt_content:
     excluded: false
 id: node.resource_collection.field_departments

--- a/config/field.field.node.step_by_step.field_departments.yml
+++ b/config/field.field.node.step_by_step.field_departments.yml
@@ -8,8 +8,12 @@ dependencies:
     - node.type.public_body
     - node.type.step_by_step
   module:
+    - datalayer
     - tmgmt_content
 third_party_settings:
+  datalayer:
+    expose: 1
+    label: field_departments
   tmgmt_content:
     excluded: false
 id: node.step_by_step.field_departments

--- a/config/field.field.node.topic.field_departments.yml
+++ b/config/field.field.node.topic.field_departments.yml
@@ -7,8 +7,12 @@ dependencies:
     - node.type.department
     - node.type.topic
   module:
+    - datalayer
     - tmgmt_content
 third_party_settings:
+  datalayer:
+    expose: 1
+    label: field_departments
   tmgmt_content:
     excluded: false
 id: node.topic.field_departments
@@ -28,6 +32,7 @@ settings:
       department: department
     sort:
       field: _none
+      direction: ASC
     auto_create: 0
     auto_create_bundle: ''
 field_type: entity_reference

--- a/config/field.field.node.transaction.field_departments.yml
+++ b/config/field.field.node.transaction.field_departments.yml
@@ -7,8 +7,12 @@ dependencies:
     - node.type.department
     - node.type.transaction
   module:
+    - datalayer
     - tmgmt_content
 third_party_settings:
+  datalayer:
+    expose: 1
+    label: field_departments
   tmgmt_content:
     excluded: false
 id: node.transaction.field_departments


### PR DESCRIPTION
* patches drupal/datalayer to handle multi-value references (which we do use for `field_departments`
* configure `field_departments` on all content types to expose to datalayer module to capture in gtm