### PR TITLE
[SG-1724] - Document paragraphs only show the first file on a multi item file field

### DIFF
--- a/web/themes/custom/sfgovpl/includes/paragraph.inc
+++ b/web/themes/custom/sfgovpl/includes/paragraph.inc
@@ -166,6 +166,35 @@ function sfgovpl_preprocess_paragraph__video(&$variables) {
 function sfgovpl_preprocess_paragraph__document(&$variables) {
   // Don't translate document paragraphs by gtranslate.
   $variables['attributes']['class'][] = 'notranslate';
+
+  // Our variables to start our document information list variable.
+  $paragraph = $variables['paragraph'];
+  $entity_type_manager = \Drupal::entityTypeManager();
+  $media_manager = $entity_type_manager->getStorage('media');
+  $file_manager = $entity_type_manager->getStorage('file');
+  $generator_service = \Drupal::service('file_url_generator');
+
+  // Create a listing of all the URLS and labels of all the attached documents.
+  $variables['document_list'] = [];
+  if ($paragraph->hasField('field_file')) {
+    foreach ($paragraph->get('field_file')->getValue() as $delta => $item) {
+      // If the field returns any media entities (aka not empty)...
+      if ($media_item = $media_manager->load($item['target_id'])) {
+
+        // Get the file uri of the file attached to the media entity.
+        $file = $media_item->get('field_media_file')->getValue();
+        $file_uri = $file_manager->load($file[0]['target_id'])->getFileUri();
+
+        // The variable "document_list" is used in paragraph--document.html.twig.
+        // We generate a relative url to the file.
+        $variables['document_list'][$delta] = [
+          'label' => $media_item->label(),
+          'url' => $generator_service->generateString($file_uri),
+        ];
+      };
+    }
+  }
+
 }
 
 /**

--- a/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-document.scss
+++ b/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-document.scss
@@ -1,7 +1,20 @@
 /* purgecss start ignore */
 .paragraph--type--document {
   .document {
-    margin-bottom: 63px;
+    margin-bottom: 1rem;
+  }
+
+  .document__item {
+    margin-bottom: 1rem;
+    display: block;
+    padding-left: 2.5rem;
+    margin-left: -2.5rem;
+  }
+
+  [data-contact="document__item"] {
+    @include background-image('document.svg');
+    min-height: 26px;
+    background-position: left center;
   }
 
   .link-date {

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--document.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--document.html.twig
@@ -39,43 +39,40 @@
  */
 #}
 
-{% set parent = paragraph.getParentEntity() %}
-{% set field_file = paragraph.field_file  %}
-{% set entityUriValue = paragraph.field_file.entity.field_media_file.entity.uri.value ?? "" %}
-{% set fileurl = file_url(entityUriValue) %}
-
 {%
-set classes = [
-'paragraph',
-'paragraph--type--' ~ paragraph.bundle|clean_class,
-view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
-not paragraph.isPublished() ? 'paragraph--unpublished',
-"parent--bundle--" ~ parent.bundle
+  set classes = [
+  'paragraph',
+  'paragraph--type--' ~ paragraph.bundle|clean_class,
+  view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+  not paragraph.isPublished() ? 'paragraph--unpublished',
+  "parent--bundle--" ~ parent.bundle
 ]
 %}
 
+
 {% block paragraph %}
-  <div {{ attributes.addClass(classes).setAttribute('data-contact', paragraph.bundle|clean_class) }}>
-    {% block content %}
-      {% if not field_file.isEmpty %}
-        {% if fileurl|length > 3 %}
-          <div class="document">
-            <span class="document">
-              <a href="{{ fileurl }}">{{ field_file.entity.label }}</a>
-            </span>
-          </div>
-        {% elseif field_file.entity.field_document_url %}
-          <div class="document">
-            <span class="document">
-              <a href="{{ field_file.entity.field_document_url.value.0.uri }}">{{ field_file.entity.label }}</a>
-            </span>
-          </div>
-        {% else %}
-          <div class="document">
-            <span class="document">{{ field_file.entity.label }}</span>
-          </div>
-        {% endif %}
-      {% endif %}
-    {% endblock %}
+  <div {{ attributes.addClass(classes) }}>
+
+    <ul class="document__list">
+      {% for document in document_list %}
+
+        {% set item_attributes = create_attribute({
+          'data-contact': paragraph.bundle|clean_class ~ '__item',
+        }) %}
+
+        <li {{ item_attributes.addClass(['document__item', 'list-none']) }}>
+
+          {% block content %}
+            {% if document.url|length > 3 %}
+                <a href="{{ document.url }}" class="document__label">{{ document.label }}</a>
+            {% else %}
+                <span class="document__label">{{ document.label }}</span>
+            {% endif %}
+          {% endblock %}
+
+        </li>
+      {% endfor %}
+    </ul>
+
   </div>
 {% endblock paragraph %}


### PR DESCRIPTION
This is a rebuild to the output of the document paragraph. The preprocess function now builds an array of file information
to print out in a loop on the twig template. Before the twig template was setup to print the first, and only first item of the
files field.

Instructions:
1. Clear cache
2. Review a transaction node with multiple files in a document paragraph.
3. Confirm visually that all documents print out, and thru the inspector, that the documents all list out in an unordered list.