### PR TITLE
[SG-1737] - Automatically re-sync body type fields with the formatter that should be applied to them

### DIFF
--- a/web/modules/custom/sfgov_admin/sfgov_admin.module
+++ b/web/modules/custom/sfgov_admin/sfgov_admin.module
@@ -5,7 +5,6 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Component\Utility\Html;
 use Drupal\Core\Url;
-use Druapl\views\Views;
 use Drupal\views\ViewExecutable;
 
 /**
@@ -72,6 +71,72 @@ function sfgov_admin_custom_validate($form, &$form_state) {
   if ((isset($form_state['values']['field_location_in_person'])) && (empty($form_state['values']['field_address']))) {
     form_set_error('field_address', 'Field cannot be left blank');
   }
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function sfgov_admin_form_node_form_alter(&$form, &$form_state, $form_id) {
+
+  // SEE ALSO: sfgov_admin_field_widget_entity_reference_paragraphs_form_alter:236
+  // - This setup applies to main level body type fields.
+  //
+  // Go thru every field, searching for "containers" with widgets, and search
+  // thru those widgets for any field of a type "text_format"...
+  foreach (Element::children($form) as $field_name) {
+    if ($form[$field_name]['#type'] == 'container' && isset($form[$field_name]['widget'])) {
+      foreach (Element::children($form[$field_name]['widget']) as $delta) {
+        if ($form[$field_name]['widget'][$delta]['#type'] == 'text_format') {
+
+          // Look thru those "text_format" body type fields for any that have
+          // limited allowed formats (ONLY 1 ALLOWED FORMAT)...
+          if (isset($form[$field_name]['widget'][$delta]['#allowed_formats']) ) {
+            if (count($form[$field_name]['widget'][$delta]['#allowed_formats']) == 1) {
+
+              // Compare the applied format to the only allowed format, and if
+              // they do not match, begin the process of syncing them up and
+              // fixing the content.
+              $applied_format = $form[$field_name]['widget'][$delta]['#format'];
+              $allowed_format = $form[$field_name]['widget'][$delta]['#allowed_formats'][0];
+              if ($applied_format != $allowed_format) {
+                $storage = $form_state->getStorage();
+                $langcode = $storage['langcode'];
+
+                // Set the allowed format to the applied format value.
+                $form[$field_name]['widget'][$delta]['#format'] = $allowed_format;
+
+                // Pull the text value, and if the allowed format is plain,
+                // remove any forbidden html tags...
+                $text = $form[$field_name]['widget'][$delta]['#default_value'] ?? '';
+                if ($allowed_format == 'plain_text') {
+                  $text = strip_tags($text);
+                }
+                // Apply the allowed format to the text value...
+                $filtered_text = check_markup($text, $allowed_format, $langcode);
+                $filtered_text = is_object($filtered_text) ? $filtered_text->__toString() : $filtered_text;
+                // If the allowed format is plain, we need to clean the text one
+                // more time to clear out any html tags generated from the
+                // filtering.
+                if ($allowed_format == 'plain_text') {
+                  $filtered_text = strip_tags($filtered_text);
+                }
+
+                // Reapply the formatted text to the default value. This will
+                // help avoid issues with formatters being broken on body type
+                // fields. This setup only applies to those fields out of sync.
+                // It will not run on body type fields that are already in sync
+                // or have more that 1 allowed format. It is still possible that
+                // a field could be out of sync, but this setup should address
+                // the majority of items.
+                $form[$field_name]['widget'][$delta]['#default_value'] = $filtered_text;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
 }
 
 /**
@@ -167,6 +232,68 @@ function sfgov_admin_field_widget_entity_reference_paragraphs_form_alter(&$eleme
       $element['subform']['field_text']['widget'][0]['#allowed_formats'][1] = 'sf_basic_html_with_restricted_headings';
     }
   }
+
+  // SEE ALSO: sfgov_admin_form_node_form_alter:83 - This setup applies to
+  // embedded paragraphs with body type fields.
+  //
+  // Go thru every field, searching for "containers" with widgets, and search
+  // thru those widgets for any field of a type "text_format"...
+  foreach (Element::children($element['subform']) as $field_name) {
+    if ($element['subform'][$field_name]['#type'] == 'container') {
+      foreach (Element::children($element['subform'][$field_name]['widget']) as $delta) {
+        if ($element['subform'][$field_name]['widget'][$delta]['#type'] == 'text_format') {
+
+          // Look thru those "text_format" body type fields for any that have
+          // limited allowed formats (ONLY 1 ALLOWED FORMAT)...
+          if (isset($element['subform'][$field_name]['widget'][$delta]['#allowed_formats']) ) {
+            if (count($element['subform'][$field_name]['widget'][$delta]['#allowed_formats']) == 1) {
+
+              // Compare the applied format to the only allowed format, and if
+              // they do not match, begin the process of syncing them up and
+              // fixing the content.
+              $applied_format = $element['subform'][$field_name]['widget'][$delta]['#format'];
+              $allowed_format = $element['subform'][$field_name]['widget'][$delta]['#allowed_formats'][0];
+              if ($applied_format != $allowed_format) {
+                $storage = $form_state->getStorage();
+                $langcode = $storage['langcode'];
+
+                // Set the allowed format to the applied format value.
+                $element['subform'][$field_name]['widget'][$delta]['#format'] = $allowed_format;
+
+                // Pull the text value, and if the allowed format is plain,
+                // remove any forbidden html tags...
+                $text = $element['subform'][$field_name]['widget'][$delta]['#default_value'] ?? '';
+                if ($allowed_format == 'plain_text') {
+                  $text = strip_tags($text);
+                }
+
+                // Apply the allowed format to the text value...
+                $filtered_text = check_markup($text, $allowed_format, $langcode);
+                $filtered_text = is_object($filtered_text) ? $filtered_text->__toString() : $filtered_text;
+
+                // If the allowed format is plain, we need to clean the text one
+                // more time to clear out any html tags generated from the
+                // filtering.
+                if ($allowed_format == 'plain_text') {
+                  $filtered_text = strip_tags($filtered_text);
+                }
+
+                // Reapply the formatted text to the default value. This will
+                // help avoid issues with formatters being broken on body type
+                // fields. This setup only applies to those fields out of sync.
+                // It will not run on body type fields that are already in sync
+                // or have more that 1 allowed format. It is still possible that
+                // a field could be out of sync, but this setup should address
+                // the majority of items.
+                $element['subform'][$field_name]['widget'][$delta]['#default_value'] = $filtered_text;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
 }
 
 /**
@@ -344,7 +471,7 @@ function sfgov_admin_form_content_moderation_entity_moderation_form_alter(&$form
 
 /**
  * Implements hook_views_pre_view().
-*/
+ */
 function sfgov_admin_views_pre_view(ViewExecutable $view) {
   if ($view->id() == 'content') {
     // Set english as default langcode for admin content list.

--- a/web/modules/custom/sfgov_admin/sfgov_admin.module
+++ b/web/modules/custom/sfgov_admin/sfgov_admin.module
@@ -233,13 +233,14 @@ function sfgov_admin_field_widget_entity_reference_paragraphs_form_alter(&$eleme
     }
   }
 
+  // [SG-1737] - Automatically reassign text formats
   // SEE ALSO: sfgov_admin_form_node_form_alter:83 - This setup applies to
   // embedded paragraphs with body type fields.
   //
   // Go thru every field, searching for "containers" with widgets, and search
   // thru those widgets for any field of a type "text_format"...
   foreach (Element::children($element['subform']) as $field_name) {
-    if ($element['subform'][$field_name]['#type'] == 'container') {
+    if (isset($element['subform'][$field_name]['#type']) && $element['subform'][$field_name]['#type'] == 'container') {
       foreach (Element::children($element['subform'][$field_name]['widget']) as $delta) {
         if ($element['subform'][$field_name]['widget'][$delta]['#type'] == 'text_format') {
 
@@ -302,6 +303,48 @@ function sfgov_admin_field_widget_entity_reference_paragraphs_form_alter(&$eleme
  * Alters the Paragraphs Experimental widget.
  */
 function sfgov_admin_field_widget_paragraphs_form_alter(&$element, FormStateInterface $form_state, $context) {
+  // [SG-1737] - Automatically reassign text formats.
+  // We apply the same changes to the entity reference widget to this widget.
+  return sfgov_admin_field_widget_entity_reference_paragraphs_form_alter($element, $form_state, $context);
+}
+/**
+ * Implements hook_field_widget_WIDGET_TYPE_form_alter().
+ *
+ * Alters the SFGov customizable paragraphs widget.
+ */
+function sfgov_admin_field_widget_sfgov_customizable_paragraphs_form_alter(&$element, FormStateInterface $form_state, $context) {
+  // [SG-1737] - Automatically reassign text formats.
+  // We apply the same changes to the entity reference widget to this widget.
+  return sfgov_admin_field_widget_entity_reference_paragraphs_form_alter($element, $form_state, $context);
+}
+/**
+ * Implements hook_field_widget_WIDGET_TYPE_form_alter().
+ *
+ * Alters the SFGov paragraphs widget.
+ */
+function sfgov_admin_field_widget_sfgov_paragraphs_form_alter(&$element, FormStateInterface $form_state, $context) {
+  // [SG-1737] - Automatically reassign text formats.
+  // We apply the same changes to the entity reference widget to this widget.
+  return sfgov_admin_field_widget_entity_reference_paragraphs_form_alter($element, $form_state, $context);
+}
+/**
+ * Implements hook_field_widget_WIDGET_TYPE_form_alter().
+ *
+ * Alters the Inline entity form (simple) widget.
+ */
+function sfgov_admin_field_widget_inline_entity_form_simple_form_alter(&$element, FormStateInterface $form_state, $context) {
+  // [SG-1737] - Automatically reassign text formats.
+  // We apply the same changes to the entity reference widget to this widget.
+  return sfgov_admin_field_widget_entity_reference_paragraphs_form_alter($element, $form_state, $context);
+}
+/**
+ * Implements hook_field_widget_WIDGET_TYPE_form_alter().
+ *
+ * Alters the Inline entity form (complex) widget.
+ */
+function sfgov_admin_field_widget_inline_entity_form_complex_form_alter(&$element, FormStateInterface $form_state, $context) {
+  // [SG-1737] - Automatically reassign text formats.
+  // We apply the same changes to the entity reference widget to this widget.
   return sfgov_admin_field_widget_entity_reference_paragraphs_form_alter($element, $form_state, $context);
 }
 


### PR DESCRIPTION
This setup should force body type fields, with only 1 allowed type of formatter, to reapply the correct
formatter on a nodes edit page, so that it doesn't break the editorial workflow.

It works on main level body type fields thru a node_form_alter hook, and on body fields in paragraph subforms thru a paragraph_widget_form_alter hook.

Testing instructions:
1. Clear cache
2. Review any known pages that have the broken body formatters, like transaction nodes.
3. Confirm that upon going to that nodes edit page, that no body type fields have a broken formatter and don't cause an error on save.