### PR TITLE
[SG-1749] - Fix reading order accessibility issues on Profiles

### DIFF
--- a/web/themes/custom/sfgovpl/templates/node/node--person--full.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--person--full.html.twig
@@ -18,9 +18,9 @@
 <div class="profile--container-narrow">
 
 <div class="profile--info">
-  <div class="profile--name">
+  <h1 class="profile--name">
     {{ node.field_first_name.0.value|striptags }} {{ node.field_last_name.0.value|striptags }}
-  </div>
+  </h1>
 
   {% if content.field_profile_photo|render %}
     <div class="profile--photo">


### PR DESCRIPTION
Changed profile name for persons to use H1 instead of div

Instructions:
1. Clear cache
2. Review person node (full page) and confirm name is in H1