### PR TITLE
[SG-1745] - Fix reading order accessibility issues on "Need to know" and "Get help" section in transactions.

### DIFF
--- a/web/themes/custom/sfgovpl/src/sass/components/_address.scss
+++ b/web/themes/custom/sfgovpl/src/sass/components/_address.scss
@@ -7,6 +7,7 @@
 .sfgov-address__title {
   @include antialiasing;
   @include fs-title-5;
+  font-size: 20px !important;
   margin: 0 0 10px 0;
 }
 

--- a/web/themes/custom/sfgovpl/templates/address/address-plain--location--field-address--physical.html.twig
+++ b/web/themes/custom/sfgovpl/templates/address/address-plain--location--field-address--physical.html.twig
@@ -1,0 +1,50 @@
+{#
+/**
+ * @file
+ * Template for the plain address formatter, for "Address" (phyiscal) location
+ * entity.
+ *
+ * Additional variables:
+ *  - parent_entity: The parent entity the address is attached to, such as an
+ *    ECK location entity, or a Node.
+ *
+ * The following fields are not printed:
+ *
+ *   Not used:
+ *   - given_name (first name)
+ *   - additional_name (middle name)
+ *   - family_name (last name)
+ *   - dependent_locality.code  (neighborhood)
+ *
+ *   Contain data, but intentionally omitted for this view mode:
+ *   - country (everything is in the US)
+ *
+ * @see sfgov_locations_preprocess_address_plain().
+ */
+#}
+{% set parent = parent_entity %}
+
+{# Use Department for title if available, otherwise, Organization, Location Name, or Addressee. #}
+{% set department = parent.field_department.entity.label %}
+{% set first_title = department ? department : organization %}
+{% set second_title = first_title ? first_title : location_name %}
+{% set title = second_title ? second_title : addressee %}
+{# Use Organization as subtitle, if it's not the same as Department name. #}
+{% set subtitle = (department and department != organization) ? organization : '' %}
+{# If Location Name is acting as title, do not display. #}
+{% set location_name = (title == location_name) ? '' : location_name %}
+{# If Addressee is acting as title, do not display. #}
+{% set addressee = (title == addressee) ? '' : addressee %}
+
+{% include '@theme/address.twig' with {
+  title_tag: 'h3',
+  title: title,
+  subtitle: subtitle,
+  addressee: addressee,
+  location_name: location_name,
+  line1: address_line1,
+  line2: address_line2,
+  city: locality,
+  state: administrative_area.code,
+  zip: postal_code
+} only %}

--- a/web/themes/custom/sfgovpl/templates/components/phone-alt.twig
+++ b/web/themes/custom/sfgovpl/templates/components/phone-alt.twig
@@ -1,0 +1,13 @@
+{% if phone_owner or phone_number or phone_details %}
+<div class="sfgov-phone">
+  {% if phone_owner %}
+    <h4 class="sfgov-phone-owner">{{ phone_owner }}</h4>
+  {% endif %}
+  {% if phone_number %}
+    <div class="sfgov-phone-number">{{ phone_number }}</div>
+  {% endif %}
+  {% if phone_details %}
+    <div class="sfgov-phone-details">{{ phone_details }}</div>
+  {% endif %}
+</div>
+{% endif %}

--- a/web/themes/custom/sfgovpl/templates/field/field--paragraph--email-addresses.html.twig
+++ b/web/themes/custom/sfgovpl/templates/field/field--paragraph--email-addresses.html.twig
@@ -1,0 +1,66 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ */
+#}
+{%
+  set classes = [
+  'field',
+  'field--type-' ~ field_type|clean_class,
+  label_display == 'inline' ? 'field--inline',
+  bundle|clean_class ~ '__' ~ field_name|replace({'field_' : ''})|clean_class,
+]
+%}
+{%
+  set title_classes = [
+  'field__label',
+  label_display == 'visually_hidden' ? 'visually-hidden',
+]
+%}
+
+<div{{ attributes.addClass(classes) }}>
+  <h3{{ title_attributes.addClass(title_classes) }}>{{ label }}</h3>
+  {% if multiple %}
+  <div class="field__items">
+    {% endif %}
+    {% for item in items %}
+      <div{{ item.attributes.addClass('field__item') }}>{{ item.content }}</div>
+    {% endfor %}
+    {% if multiple %}
+  </div>
+  {% endif %}
+</div>
+

--- a/web/themes/custom/sfgovpl/templates/field/field--paragraph--field-title--help.html.twig
+++ b/web/themes/custom/sfgovpl/templates/field/field--paragraph--field-title--help.html.twig
@@ -1,0 +1,49 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ */
+#}
+{%
+  set classes = [
+  'field',
+  'field--type-' ~ field_type|clean_class,
+  label_display == 'inline' ? 'field--inline',
+  bundle|clean_class ~ '__' ~ field_name|replace({'field_' : ''})|clean_class,
+]
+%}
+{% for item in items %}
+  <h3{{ attributes.addClass(classes, 'field__item') }}>{{ item.content }}</h3>
+{% endfor %}

--- a/web/themes/custom/sfgovpl/templates/field/field--paragraph--phone-numbers.html.twig
+++ b/web/themes/custom/sfgovpl/templates/field/field--paragraph--phone-numbers.html.twig
@@ -1,0 +1,66 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ */
+#}
+{%
+  set classes = [
+  'field',
+  'field--type-' ~ field_type|clean_class,
+  label_display == 'inline' ? 'field--inline',
+  bundle|clean_class ~ '__' ~ field_name|replace({'field_' : ''})|clean_class,
+]
+%}
+{%
+  set title_classes = [
+  'field__label',
+  label_display == 'visually_hidden' ? 'visually-hidden',
+]
+%}
+
+<div{{ attributes.addClass(classes) }}>
+  <h3{{ title_attributes.addClass(title_classes) }}>{{ label }}</h3>
+  {% if multiple %}
+  <div class="field__items">
+    {% endif %}
+    {% for item in items %}
+      <div{{ item.attributes.addClass('field__item') }}>{{ item.content }}</div>
+    {% endfor %}
+    {% if multiple %}
+  </div>
+  {% endif %}
+</div>
+

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--phone--default.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--phone--default.html.twig
@@ -38,45 +38,27 @@
  * @ingroup themeable
  */
 #}
-{% set classes = [
-  'paragraph',
-  'paragraph--type--' ~ paragraph.bundle|clean_class,
-  view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
-  not paragraph.isPublished() ? 'paragraph--unpublished'
-] %}
-{% set cost_type = paragraph.field_cost_type.value %}
+
+{% set parent = paragraph.getParentEntity() %}
+{%
+set classes = [
+'paragraph',
+'paragraph--type--' ~ paragraph.bundle|clean_class,
+view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+not paragraph.isPublished() ? 'paragraph--unpublished',
+"parent--bundle--" ~ parent.bundle
+]
+%}
+
 {% block paragraph %}
-  <div{{ attributes.addClass(classes) }}>
+  <div {{ attributes.addClass(classes).setAttribute('data-contact', paragraph.bundle|clean_class) }}>
     {% block content %}
-      {% block title %}
-        <h2 class="title">{{ 'Cost'|t }}</h2>
-      {% endblock title %}
-      {% if cost_type == 'free' %}
-        {% block costfree %}
-          <div>{{ content.field_cost_type }}</div>
-        {% endblock costfree %}
-      {% endif %}
-      {% if cost_type == 'flat' %}
-        {% block costflat %}
-          {{ content.field_cost_flat_fee }}
-        {% endblock costflat %}
-      {% endif %}
-      {% if cost_type == 'minimum' and content.field_cost_minimum|render %}
-        {% block costmin %}
-          {{ content.field_cost_minimum }} {{ ' and up'|t }}
-        {% endblock costmin %}
-      {% endif %}
-      {% if cost_type == 'range' and content.field_cost_minimum|render and content.field_cost_maximum|render %}
-        <div class="inline-flex">
-          {{ content.field_cost_minimum }} - {{ content.field_cost_maximum }}
-        </div>
-      {% endif %}
-    {{ content|without(
-      'field_cost_type',
-      'field_cost_flat_fee',
-      'field_cost_minimum',
-      'field_cost_maximum'
-    ) }}
+      {% include "@theme/phone-alt.twig" with {
+        "phone_owner": content.field_owner,
+        "phone_number": content.field_tel,
+        "phone_details": content.field_text
+      } %}
     {% endblock %}
   </div>
 {% endblock paragraph %}
+


### PR DESCRIPTION
Things to know "Cost" set to h2 instead of h3.
Get help section:
- Get help = H2
- Phone or Email or Address location title = H3
- Phone or Email owner = H4

Instructions:
1. Clear cache
2. Inspect a transaction page(s) with a phone, email, and address example and confirm they have the correct heading tags.