### PR TITLE
[SG-1769] - Style for horizontal rules

### DIFF
--- a/web/themes/custom/sfgovpl/src/sass/node/_node-report.scss
+++ b/web/themes/custom/sfgovpl/src/sass/node/_node-report.scss
@@ -214,11 +214,22 @@
     }
 
     //SG-1676 Align images in report body left and always on its own line.
-    
+
     img {
       margin-left: 0;
       margin-right: auto;
       float: none;
+    }
+
+    hr {
+      border-width: 3px 0 0;
+      border-color: $c-grey-4;
+      border-style: solid;
+      margin: $rhythm * 4 0 $rhythm * 2;
+      display: none;
+      @media screen and (min-width: $medium-screen) {
+        display: block;
+      }
     }
   }
 


### PR DESCRIPTION
Set styling for hr tags in reports (3px solid #e9e9e9 or light gray color)

Instructions:
1. Clear cache
2. Visit report with hr tags in content and confirm that the style matches 3px solid #e9e9e9 (light gray color)