### PR TITLE
[SG-1723] - Adjust size calculations for powerBI embeds

### DIFF
--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--powerbi-embed.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--powerbi-embed.html.twig
@@ -10,7 +10,7 @@
 
     {% for device, chart in charts %}
       <div tabindex="0" class="sfgov-powerbi-embed__wrapper" data-powerbi data-device="{{ device }}" data-src="{{ chart.embed_url }}"
-           style="display: none; position: relative; padding-top: calc({{ chart.padding_top }}% + 37px)">
+           style="display: none; position: relative; padding-top: calc({{ chart.padding_top }}% + 60px)">
         <div class="iframe-container"><span class="powerbi-title" title="{{ paragraph.field_title.value }}" style="display: none;"></span></div>
       </div>
     {% endfor %}


### PR DESCRIPTION
Adjustment to the power bi embed template, to give a better iframe size ratio. This ratio should help get the width of the embed to fit better.

Instructions:
1. clear cache
2. visit pages with power bi embeds and confirm that the width of the embed matches the embed footer