### PR TITLE
[SG-1753] - Empty button appears when URL is not included for CTA on …

### DIFF
--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--call-to-action.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--call-to-action.html.twig
@@ -15,9 +15,12 @@
   {% if cta_title is not empty %}
     <p class="{{ textColor }} text-title-xs font-medium m-0 mb-24">{{ cta_title }}</p>
   {% endif %}
-  {% include "@sfgov-design-system/button/link.twig" with {
+  {% if ( url is not empty ) and ( btnText is not empty ) %}
+    {% include "@sfgov-design-system/button/link.twig" with {
       "href": url,
       "text": btnText,
       "classes": btnClasses
-  } %}
+    } %}
+  {% endif %}
+
 {% endblock %}


### PR DESCRIPTION
…events

On CTA's for events, the url and title text must now be present before it will render a button

Instructions:
1. clear cache
2. Visit an event (https://sf.gov/events/september-3-2022/teen-healthy-eating-active-living-heal-internship-program)
3. Confirm that the button no longer prints blank/broken if there is no title or url