### PR TITLE
[SG-1771] - Add keyboard focus indicator to city logo seal and department icons

### DIFF
--- a/web/themes/custom/sfgovpl/src/sass/_base.scss
+++ b/web/themes/custom/sfgovpl/src/sass/_base.scss
@@ -123,7 +123,14 @@ b {
 }
 
 *:focus {
-  outline: 2px dotted #aeb0b5;
+  outline: 3px solid $c-grey-dark; // old color: #aeb0b5
   outline-offset: 3px;
 }
+
+.text-white {
+  *:focus {
+    outline-color: $c-white;
+  }
+}
+
 /* purgecss end ignore */

--- a/web/themes/custom/sfgovpl/src/sass/block/_block-branding.scss
+++ b/web/themes/custom/sfgovpl/src/sass/block/_block-branding.scss
@@ -51,4 +51,9 @@
 .sfgov-logo--campaign {
   max-width: 260px;
 }
+
+a.branding-link:focus .sfgov-logo__image {
+  outline: 3px solid $c-grey-dark; // old color: #aeb0b5
+  outline-offset: 7px;
+}
 /* purgecss end ignore */


### PR DESCRIPTION
Setup the logo/icon to have a focus border.
Changed the overall style of focus to a solid dark gray border.
Setup links in dark backgrounds with white text to have a white focus.

Instructions:
1. Clear cache
2. starting at top of page, hit tab until it gets to the logo.
3. Confirm that the logo has a focus border.
4. Continue tabbing till it gets to a dark background element and shows a white colored focus.