### PR TITLE
[SG-1746] - Link to archive sfgov.org from department home pages

### DIFF
--- a/config/core.entity_form_display.node.department.default.yml
+++ b/config/core.entity_form_display.node.department.default.yml
@@ -9,6 +9,8 @@ dependencies:
     - field.field.node.department.field_address
     - field.field.node.department.field_alert_expiration_date
     - field.field.node.department.field_alert_text
+    - field.field.node.department.field_archive_date
+    - field.field.node.department.field_archive_url
     - field.field.node.department.field_call_to_action
     - field.field.node.department.field_department_code
     - field.field.node.department.field_department_services
@@ -114,16 +116,20 @@ third_party_settings:
         id: ''
         direction: vertical
     group_02:
-      children: {  }
-      label: '02'
-      region: hidden
+      children:
+        - field_archive_url
+        - field_archive_date
+      label: 'Archive information'
+      region: content
       parent_name: ''
-      weight: 28
+      weight: 11
       format_type: details
       format_settings:
         classes: ''
+        show_empty_fields: false
         id: ''
-        open: false
+        open: true
+        description: ''
         required_fields: true
     group_alert:
       children:
@@ -146,7 +152,7 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 18
+    weight: 19
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -202,6 +208,20 @@ content:
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_enforce: true
         maxlength_js_truncate_html: true
+  field_archive_date:
+    type: datetime_default
+    weight: 15
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_archive_url:
+    type: link_default
+    weight: 14
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
   field_call_to_action:
     type: paragraphs
     weight: 60
@@ -223,7 +243,7 @@ content:
     third_party_settings: {  }
   field_department_code:
     type: string_textfield
-    weight: 14
+    weight: 15
     region: content
     settings:
       size: 60
@@ -314,7 +334,7 @@ content:
     third_party_settings: {  }
   field_go_to_current_url:
     type: boolean_checkbox
-    weight: 13
+    weight: 14
     region: content
     settings:
       display_label: true
@@ -507,7 +527,7 @@ content:
     third_party_settings: {  }
   field_topics:
     type: entity_reference_autocomplete
-    weight: 15
+    weight: 16
     region: content
     settings:
       match_operator: CONTAINS
@@ -517,7 +537,7 @@ content:
     third_party_settings: {  }
   field_url:
     type: link_default
-    weight: 12
+    weight: 13
     region: content
     settings:
       placeholder_url: ''
@@ -525,20 +545,20 @@ content:
     third_party_settings: {  }
   langcode:
     type: language_select
-    weight: 11
+    weight: 12
     region: content
     settings:
       include_locked: true
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 24
+    weight: 25
     region: content
     settings: {  }
     third_party_settings: {  }
   path:
     type: path
-    weight: 16
+    weight: 17
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -551,19 +571,19 @@ content:
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp
-    weight: 22
+    weight: 23
     region: content
     settings: {  }
     third_party_settings: {  }
   publish_state:
     type: options_select
-    weight: 17
+    weight: 18
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 20
+    weight: 21
     region: content
     settings:
       display_label: true
@@ -585,7 +605,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 19
+    weight: 20
     region: content
     settings:
       match_operator: CONTAINS
@@ -595,18 +615,18 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp
-    weight: 23
+    weight: 24
     region: content
     settings: {  }
     third_party_settings: {  }
   unpublish_state:
     type: options_select
-    weight: 21
+    weight: 22
     region: content
     settings: {  }
     third_party_settings: {  }
   url_redirects:
-    weight: 25
+    weight: 26
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/core.entity_view_display.node.department.default.yml
+++ b/config/core.entity_view_display.node.department.default.yml
@@ -8,6 +8,8 @@ dependencies:
     - field.field.node.department.field_address
     - field.field.node.department.field_alert_expiration_date
     - field.field.node.department.field_alert_text
+    - field.field.node.department.field_archive_date
+    - field.field.node.department.field_archive_url
     - field.field.node.department.field_call_to_action
     - field.field.node.department.field_department_code
     - field.field.node.department.field_department_services
@@ -89,6 +91,27 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 23
+    region: content
+  field_archive_date:
+    type: datetime_custom
+    label: hidden
+    settings:
+      timezone_override: ''
+      date_format: 'F Y'
+    third_party_settings: {  }
+    weight: 26
+    region: content
+  field_archive_url:
+    type: link
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 25
     region: content
   field_call_to_action:
     type: entity_reference_revisions_entity_view

--- a/config/core.entity_view_display.node.department.location_page.yml
+++ b/config/core.entity_view_display.node.department.location_page.yml
@@ -8,6 +8,8 @@ dependencies:
     - field.field.node.department.field_address
     - field.field.node.department.field_alert_expiration_date
     - field.field.node.department.field_alert_text
+    - field.field.node.department.field_archive_date
+    - field.field.node.department.field_archive_url
     - field.field.node.department.field_call_to_action
     - field.field.node.department.field_department_code
     - field.field.node.department.field_department_services
@@ -54,6 +56,8 @@ hidden:
   field_about_or_description: true
   field_alert_expiration_date: true
   field_alert_text: true
+  field_archive_date: true
+  field_archive_url: true
   field_call_to_action: true
   field_department_code: true
   field_department_services: true

--- a/config/core.entity_view_display.node.department.search_index.yml
+++ b/config/core.entity_view_display.node.department.search_index.yml
@@ -9,6 +9,8 @@ dependencies:
     - field.field.node.department.field_address
     - field.field.node.department.field_alert_expiration_date
     - field.field.node.department.field_alert_text
+    - field.field.node.department.field_archive_date
+    - field.field.node.department.field_archive_url
     - field.field.node.department.field_call_to_action
     - field.field.node.department.field_department_code
     - field.field.node.department.field_department_services
@@ -73,6 +75,8 @@ hidden:
   field_about_or_description: true
   field_alert_expiration_date: true
   field_alert_text: true
+  field_archive_date: true
+  field_archive_url: true
   field_call_to_action: true
   field_department_code: true
   field_department_services: true

--- a/config/core.entity_view_display.node.department.teaser.yml
+++ b/config/core.entity_view_display.node.department.teaser.yml
@@ -4,10 +4,13 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
+    - field.field.node.department.field_about_description
     - field.field.node.department.field_about_or_description
     - field.field.node.department.field_address
     - field.field.node.department.field_alert_expiration_date
     - field.field.node.department.field_alert_text
+    - field.field.node.department.field_archive_date
+    - field.field.node.department.field_archive_url
     - field.field.node.department.field_call_to_action
     - field.field.node.department.field_department_code
     - field.field.node.department.field_department_services
@@ -66,6 +69,8 @@ hidden:
   field_address: true
   field_alert_expiration_date: true
   field_alert_text: true
+  field_archive_date: true
+  field_archive_url: true
   field_call_to_action: true
   field_department_code: true
   field_department_services: true

--- a/config/core.entity_view_display.node.department.title.yml
+++ b/config/core.entity_view_display.node.department.title.yml
@@ -9,6 +9,8 @@ dependencies:
     - field.field.node.department.field_address
     - field.field.node.department.field_alert_expiration_date
     - field.field.node.department.field_alert_text
+    - field.field.node.department.field_archive_date
+    - field.field.node.department.field_archive_url
     - field.field.node.department.field_call_to_action
     - field.field.node.department.field_department_code
     - field.field.node.department.field_department_services
@@ -47,6 +49,8 @@ hidden:
   field_address: true
   field_alert_expiration_date: true
   field_alert_text: true
+  field_archive_date: true
+  field_archive_url: true
   field_call_to_action: true
   field_department_code: true
   field_department_services: true

--- a/config/field.field.node.department.field_archive_date.yml
+++ b/config/field.field.node.department.field_archive_date.yml
@@ -1,0 +1,29 @@
+uuid: 3fa5d5f2-d581-440d-87e3-e6c7ba176a26
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_archive_date
+    - node.type.department
+  module:
+    - datalayer
+    - datetime
+    - tmgmt_content
+third_party_settings:
+  datalayer:
+    expose: 0
+    label: field_archive_date
+  tmgmt_content:
+    excluded: false
+id: node.department.field_archive_date
+field_name: field_archive_date
+entity_type: node
+bundle: department
+label: 'Archive date'
+description: 'Date the archive site was last archived. (Month and Year) '
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/config/field.field.node.department.field_archive_date.yml
+++ b/config/field.field.node.department.field_archive_date.yml
@@ -20,7 +20,7 @@ field_name: field_archive_date
 entity_type: node
 bundle: department
 label: 'Archive date'
-description: 'Date the archive site was last archived. (Month and Year) '
+description: 'Date the archive site was last archived. (Month and Year). This field is REQUIRED if a URL is provided above.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/field.field.node.department.field_archive_url.yml
+++ b/config/field.field.node.department.field_archive_url.yml
@@ -1,0 +1,31 @@
+uuid: a78c2388-8073-4c17-9304-20a9b9be3286
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_archive_url
+    - node.type.department
+  module:
+    - datalayer
+    - link
+    - tmgmt_content
+third_party_settings:
+  datalayer:
+    expose: 0
+    label: field_archive_url
+  tmgmt_content:
+    excluded: false
+id: node.department.field_archive_url
+field_name: field_archive_url
+entity_type: node
+bundle: department
+label: 'Archive URL'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 0
+  link_type: 17
+field_type: link

--- a/config/field.field.node.department.field_req_public_records.yml
+++ b/config/field.field.node.department.field_req_public_records.yml
@@ -21,7 +21,7 @@ entity_type: node
 bundle: department
 label: 'Request public records'
 description: 'Select the method that residents will use to contact the department for public records'
-required: false
+required: true
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/config/field.storage.node.field_archive_date.yml
+++ b/config/field.storage.node.field_archive_date.yml
@@ -1,0 +1,20 @@
+uuid: 9e33b57e-e92d-414d-811c-ca62c5365a81
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - node
+id: node.field_archive_date
+field_name: field_archive_date
+entity_type: node
+type: datetime
+settings:
+  datetime_type: date
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_archive_url.yml
+++ b/config/field.storage.node.field_archive_url.yml
@@ -1,0 +1,19 @@
+uuid: 69ac7d5e-4050-4fd2-a789-d1f2f8993f9f
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - node
+id: node.field_archive_url
+field_name: field_archive_url
+entity_type: node
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/sfgov_departments/sfgov_departments.module
+++ b/web/modules/custom/sfgov_departments/sfgov_departments.module
@@ -126,6 +126,32 @@ function sfgov_departments_form_node_department_edit_form_alter(&$form, FormStat
       $form['field_req_public_records']['widget']['#attributes']['disabled'] = 'disabled';
     }
   }
+
+  // [SG-1746]
+  // This setup sets the archive date field to be required, if the archive url
+  // is set. This ensures that if a department has an archive that the last
+  // archived date must be set.
+  $form['field_archive_date']['widget'][0]['value']['#states'] = [
+    'required' => [
+      ':input[name="field_archive_url[0][uri]"]' => ['filled' => TRUE]
+    ],
+  ];
+  $form['#validate'][] = '_sfgov_departments_dept_node_archive_url_and_date_form_validate';
+}
+
+/**
+ * Validates submission values in the FORM_ID() form.
+ */
+function _sfgov_departments_dept_node_archive_url_and_date_form_validate($form, FormStateInterface $form_state) {
+  // [SG-1746]
+  // This validation handler ensures that if an archive url is set, then the
+  // archive date must also be set.
+  $values = $form_state->getValues();
+  if (!empty($values['field_archive_url'][0]['uri'])) {
+    if (empty($values['field_archive_date'][0]['value'])) {
+      $form_state->setErrorByName("field_archive_date[0][value][date]", t('Archive date is required if an Archive URL is set.'));
+    }
+  }
 }
 
 /**
@@ -197,9 +223,9 @@ function _fetch_departments_submit(array &$form, FormStateInterface $form_state)
   return $form['field_departments'];
 }
 
-/**  
- * Implements hook_field_widget_WIDGET_TYPE_form_alter().  
- */  
+/**
+ * Implements hook_field_widget_WIDGET_TYPE_form_alter().
+ */
 function sfgov_departments_field_widget_paragraphs_form_alter(&$element, $form_state, $context) {
   $parentEntity = $form_state->getFormObject()->getEntity();
 

--- a/web/modules/custom/sfgov_departments/sfgov_departments.module
+++ b/web/modules/custom/sfgov_departments/sfgov_departments.module
@@ -137,6 +137,35 @@ function sfgov_departments_form_node_department_edit_form_alter(&$form, FormStat
     ],
   ];
   $form['#validate'][] = '_sfgov_departments_dept_node_archive_url_and_date_form_validate';
+
+  // [SG-1746]
+  // This setup sets the request public records type fields to be required, if 
+  // the "Required public records" radio type field is set. This ensures that if 
+  // a department has a required type, that the type field associated with that is
+  // filled in.
+
+  // Set the Link field to required if checkbox is set to Link.
+  $form['field_req_public_records_link']['widget'][0]['uri']['#states'] = [
+    'required' => [
+      ':input[name="field_req_public_records"]' => ['value' => 'Link']
+    ],
+  ];
+
+  // Set the Email field to required if checkbox is set to Email.
+  $form['field_req_public_records_email']['widget'][0]['value']['#states'] = [
+    'required' => [
+      ':input[name="field_req_public_records"]' => ['value' => 'Email']
+    ],
+  ];
+
+  // Set the Phone field to required if checkbox is set to Phone.
+  $form['field_req_public_records_phone']['widget'][0]['value']['#states'] = [
+    'required' => [
+      ':input[name="field_req_public_records"]' => ['value' => 'Phone']
+    ],
+  ];
+
+  $form['#validate'][] = '_sfgov_departments_dept_req_public_records_form_validate';
 }
 
 /**
@@ -150,6 +179,32 @@ function _sfgov_departments_dept_node_archive_url_and_date_form_validate($form, 
   if (!empty($values['field_archive_url'][0]['uri'])) {
     if (empty($values['field_archive_date'][0]['value'])) {
       $form_state->setErrorByName("field_archive_date[0][value][date]", t('Archive date is required if an Archive URL is set.'));
+    }
+  }
+}
+
+/**
+ * Validates submission values in the FORM_ID() form.
+ */
+function _sfgov_departments_dept_req_public_records_form_validate($form, FormStateInterface $form_state) {
+  // [SG-1746]
+  // This validation handler ensures that if a request type is set, then the
+  // associated request type data field must also be set.
+  $values = $form_state->getValues();
+  if (!empty($values['field_req_public_records'][0]['value'])) {
+
+    $required_type = $values['field_req_public_records'][0]['value'];
+
+    if ($required_type == 'Link' && empty($values['field_req_public_records_link'][0]['uri'])) {
+      $form_state->setErrorByName("field_req_public_records_link", t('Public records link is required if request type is set to Link.'));
+    }
+
+    if ($required_type == 'Email' && empty($values['field_req_public_records_email'][0]['value'])) {
+      $form_state->setErrorByName("field_req_public_records_email", t('Public records email is required if request type is set to Email.'));
+    }
+
+    if ($required_type == 'Phone' && empty($values['field_req_public_records_phone'][0]['value'])) {
+      $form_state->setErrorByName("field_req_public_records_phone", t('Public records phone is required if request type is set to Phone.'));
     }
   }
 }

--- a/web/themes/custom/sfgovpl/templates/node/node--department--full.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--department--full.html.twig
@@ -352,9 +352,9 @@
 
                 {% if hasArchiveDate %}
                   {% set date = content.field_archive_date|render|striptags|trim %}
-                  <a href="{{ url }}">{{ text }}</a> {{ 'archived @date.'|trans({'@date': date}) }}
+                  <a target="_blank" href="{{ url }}">{{ text }}</a> {{ 'archived @date.'|trans({'@date': date}) }}
                 {% else %}
-                  <a href="{{ url }}">{{ text }}</a>.
+                  <a target="_blank" href="{{ url }}">{{ text }}</a>.
                 {% endif %}
 
               </p>

--- a/web/themes/custom/sfgovpl/templates/node/node--department--full.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--department--full.html.twig
@@ -77,7 +77,7 @@
         'text': node.field_description.value
       }
     } %}
-  
+
       {% block logo %}
         {% if content.field_image|render|striptags %}
           <div class="hero-banner--logo">
@@ -164,14 +164,14 @@
 {% set numPublicBodies = content.field_public_bodies['#items']|length %}
 {% set numDivisions = content.field_divisions['#items']|length %}
 
-{% if content.field_about_or_description|render|striptags 
-    or about_page_link
-    or content.field_parent_department|render|striptags
-    or content.field_image|render|striptags
-    or content.field_call_to_action|render|striptags
-    or content.field_social_media|render|striptags
-    or numPublicBodies > 0
-    or numDivisions > 0
+{% if content.field_about_or_description|render|striptags
+  or about_page_link
+  or content.field_parent_department|render|striptags
+  or content.field_image|render|striptags
+  or content.field_call_to_action|render|striptags
+  or content.field_social_media|render|striptags
+  or numPublicBodies > 0
+  or numDivisions > 0
 %}
   {% set hasAboutSection = true %}
 {% endif %}
@@ -182,7 +182,7 @@
     <div class="sfgov-dept-about">
       <h2 class="text-white text-title-xl m-0 mb-40 lg:mb-28 lg:text-title-xl-desktop">{{ node.field_about_or_description.fieldDefinition.label | t }}</h2>
       {# parent department / part of #}
-      {% if node.field_parent_department.0 is not empty %}        
+      {% if node.field_parent_department.0 is not empty %}
         <h3 class="text-white text-body font-medium m-0 mb-28">
           {{ node.field_parent_department.fieldDefinition.label | t }}:
           <a class="text-white font-regular" href="{{ path('entity.node.canonical', {'node': node.field_parent_department.entity.nid.value}) }}">
@@ -205,13 +205,13 @@
           {% if about_page_link %}
             <div class="mb-60">
               {% include "@sfgov-design-system/button/link.twig" with {
-                  "href": about_page_link['#url'],
-                  "text": about_page_link['#title'],
-                  "classes": ['btn-inverse']
+                "href": about_page_link['#url'],
+                "text": about_page_link['#title'],
+                "classes": ['btn-inverse']
               } %}
             </div>
           {% endif %}
-          
+
           {# divisions and public bodies #}
           {% if content.field_divisions|render|striptags|trim or content.field_public_bodies|render|striptags|trim %}
             <div class="mb-60">
@@ -232,7 +232,7 @@
             </div>
           {% endif %}
 
-          {# call to action #}        
+          {# call to action #}
           {% if content.field_call_to_action|render|striptags|trim %}
             <div class="mb-60 lg:mb-0">
               {{ content.field_call_to_action }}
@@ -256,7 +256,7 @@
 
 {% if hasAddress or hasPhone or hasEmail %}
   <div id="sfgov-dept-contact" class="sfgov-dept-contact sfds-layout-container my-80">
-  <a name="contact"></a>
+    <a name="contact"></a>
     <div class="sfgov-dept-contact-content sfds-responsive-container">
       <div class="sfgov-contact-container">
         <h2 class="dept-heading--section">{{ 'Contact'|t }}</h2>
@@ -268,7 +268,7 @@
           {% endif %}
           {% if hasPhone %}
             <div class="sfgov-contact-section phone-numbers">
-            <p class="sfgov-contact-section-title">{{ 'Phone'|t }}</p>
+              <p class="sfgov-contact-section-title">{{ 'Phone'|t }}</p>
               {{ content.field_phone_numbers }}
             </div>
           {% endif %}
@@ -284,30 +284,87 @@
   </div>
 {% endif %}
 
+{% set hasPublicRecordsLink = content.field_req_public_records_link['#items'] is not empty %}
+{% set hasPublicRecordsEmail = content.field_req_public_records_email['#items'] is not empty %}
+{% set hasPublicRecordsPhone = content.field_req_public_records_phone['#items'] is not empty %}
+{% set hasArchiveUrl = content.field_archive_url['#items'] is not empty %}
+{% set hasArchiveDate = content.field_archive_date['#items'] is not empty %}
+
 {% set publicRecordsMethod = content.field_req_public_records|render|striptags|trim|lower %}
 {% set publicRecordsLink = content.field_req_public_records_link|render|striptags|trim %}
 {% set publicRecordsEmail = content.field_req_public_records_email|render|striptags|trim %}
 {% set publicRecordsPhone = content.field_req_public_records_phone|render|striptags|trim %}
 
-{% if publicRecordsLink is not empty or publicRecordsEmail is not empty or publicRecordsPhone is not empty %}
+{% if (hasPublicRecordsLink and publicRecordsMethod == "link")
+  or (hasPublicRecordsEmail and publicRecordsMethod == "email")
+  or (hasPublicRecordsPhone and publicRecordsMethod == "phone")
+  or hasArchiveUrl %}
   <div class="sfgov-dept-section sfgov-dept-public-records sfds-layout-container">
     <div class="sfgov-dept-public-records-content-container sfds-responsive-container">
       <div class="sfgov-dept-public-records-content">
-        <p class="title">{{ 'Request public records'|t }}</p>
-        <p>
-        {% if publicRecordsMethod == "phone" %}
-          <a href="tel:{{ publicRecordsPhone }}">{% trans %}Call {{ publicRecordsPhone }}</a> to submit a request.{% endtrans %}
-        {% elseif publicRecordsMethod == "email" %}
-          <a href="mailto:{{ publicRecordsEmail }}">{% trans %}Email {{ publicRecordsEmail }}</a> to submit a request.{% endtrans %}
-        {% elseif publicRecordsMethod == "link" %}
-          {% trans %}<a href="{{ publicRecordsLink }}">Submit requests</a> for the {{ node.getTitle() }}.{% endtrans %}
-        {% endif %}
-        </p>
+        <div class="lg:flex">
+
+          {% if (hasPublicRecordsLink and publicRecordsMethod == "link")
+            or (hasPublicRecordsEmail and publicRecordsMethod == "email")
+            or (hasPublicRecordsPhone and publicRecordsMethod == "phone") %}
+
+            {% set class = hasArchiveUrl ? 'lg:w-1/2 pb-28 lg:pb-0 lg:pr-28' : '' %}
+            {% set title = 'Request public records'|t %}
+
+            <div class="{{ class }}">
+              {% if publicRecordsMethod == "phone" %}
+
+                {# Print the phone info only if method is phone and phone is not empty #}
+                {% if hasPublicRecordsPhone %}
+                  <p class="title">{{ title }}</p>
+                  <p><a href="tel:{{ publicRecordsPhone }}">{% trans %}Call {{ publicRecordsPhone }}</a> to submit a request.{% endtrans %}</p>
+                {% endif %}
+
+              {% elseif publicRecordsMethod == "email" %}
+
+                {# Print the email info only if method is email and email is not empty #}
+                {% if hasPublicRecordsEmail %}
+                  <p class="title">{{ title }}</p>
+                  <p><a href="mailto:{{ publicRecordsEmail }}">{% trans %}Email {{ publicRecordsEmail }}</a> to submit a request.{% endtrans %}</p>
+                {% endif %}
+
+              {% elseif publicRecordsMethod == "link" %}
+
+                {# Print the link info only if method is link and link is not empty #}
+                {% if hasPublicRecordsLink %}
+                  <p class="title">{{ title }}</p>
+                  <p>{% trans %}<a href="{{ publicRecordsLink }}">Submit requests</a> for the {{ node.getTitle() }}.{% endtrans %}</p>
+                {% endif %}
+
+              {% else %}
+                {# do nothing #}
+              {% endif %}
+            </div>
+          {% endif %}
+
+          {% if hasArchiveUrl %}
+            {% set class = hasPublicRecordsLink or hasPublicRecordsPhone or hasPublicRecordsEmail ? 'lg:w-1/2 lg:pl-28' : '' %}
+            <div class="{{ class }}">
+              <p class="title">{{ 'Archived website'|t }}</p>
+              <p>
+                {% set url = content.field_archive_url.0['#url']|render %}
+                {% set text = 'See previous website'|t %}
+
+                {% if hasArchiveDate %}
+                  {% set date = content.field_archive_date|render|striptags|trim %}
+                  <a href="{{ url }}">{{ text }}</a> {{ 'archived @date.'|trans({'@date': date}) }}
+                {% else %}
+                  <a href="{{ url }}">{{ text }}</a>.
+                {% endif %}
+
+              </p>
+            </div>
+          {% endif %}
+
+        </div>
       </div>
     </div>
   </div>
 {% endif %}
-
-</div>
 
 {{ attach_library('sfgovpl/sfgov-dept-homepage') }}


### PR DESCRIPTION
Added 2 new fields to departments:
- Archive URL (field_archive_url)
- Archive date (field_archive_date)

Setup output next to the Request public records output (at the bottom of the content).

Instructions:
1. Clear cache
2. Import configuration
3. Confirm that the 2 new fields are added to departments by going to the Department content type
4. Edit an existing department or create a new one
5. Set the archived url and date values
6. Confirm they display as desired.