### PR TITLE
Add VS Code settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,10 +115,6 @@ Thumbs.db
 # Things in the core directory that Drupal 8 commits in the repository.
 !web/core/**/*.gz
 
-# visual code config
-.vscode/*
-!.vscode/launch.json.example
-
 # ignore language collections, currently cannot be excluded by config_ignore or config_split modules
 /.drush-lock-update
 /.gitattributes

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "xdebug.php-debug"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Listen for XDebug",
+      "type": "php",
+      "request": "launch",
+      "port": 9003,
+      "xdebugSettings": {
+        "max_depth": 5,
+      },
+      "log": false,
+      "pathMappings": {
+        "/app/": "${workspaceFolder}/",
+      }
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "npm.exclude": "{**/vendor/**,**/web/core,**/web/libraries/**}",
+  "[javascript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+    "editor.formatOnSave": true,
+    "editor.formatOnSaveMode": "file"
+  }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,92 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Setup",
+      "dependsOn": [
+        "Composer install",
+        "Update database",
+        "Update config",
+        "Build theme",
+        "Clear cache"
+      ],
+      "dependsOrder": "sequence",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Composer install",
+      "dependsOn": [
+      ],
+      "type": "shell",
+      "command": "composer install",
+      "group": "build",
+      "problemMatcher": []
+    },
+    {
+      "label": "Composer clean",
+      "type": "shell",
+      "command": "rm -rf vendor web/core web/libraries",
+      "group": "build",
+      "problemMatcher": []
+    },
+    {
+      "label": "Lando start",
+      "type": "shell",
+      "command": "lando start",
+      "group": "build",
+      "problemMatcher": []
+    },
+    {
+      "label": "Update database",
+      "type": "shell",
+      "command": "lando drush updatedb -y",
+      "problemMatcher": []
+    },
+    {
+      "label": "Update config",
+      "type": "shell",
+      "command": "lando drush cim -y",
+      "problemMatcher": []
+    },
+    {
+      "label": "Clear cache",
+      "type": "shell",
+      "command": "lando drush cr",
+      "problemMatcher": []
+    },
+    {
+      "label": "Export config",
+      "type": "shell",
+      "command": "lando drush cex -y"
+    },
+    {
+      "label": "Lint PHP",
+      "type": "shell",
+      "command": "lando php-sniff ${relativeFile}",
+      "problemMatcher": []
+    },
+    {
+      "label": "Pull database (live)",
+      "type": "shell",
+      "command": "lando pull --files=none --code=none --database=live",
+      "problemMatcher": []
+    },
+    {
+      "label": "Pull files (live)",
+      "type": "shell",
+      "command": "lando pull --files=live --code=none --database=none",
+      "problemMatcher": []
+    },
+    {
+      "label": "Build assets",
+      "type": "shell",
+      "command": "npm install && npm run -ws build",
+      "group": "build",
+      "problemMatcher": []
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "sfgov",
       "workspaces": [
         "web/themes/custom/sfgovpl",
         "web/modules/custom/sfgov_*"


### PR DESCRIPTION
For SG-1797, this PR promotes the `.vscode` directory to first-class status and introduces:

1. `extensions.json` to recommend ESLint and PHP XDebug extensions if they're not installed
1. `settings.json` to provide default workspace settings, initially for JavaScript only:
    - `npm.exclude` excludes vendored `package.json` scripts from the npm scripts sidebar
    - `[javascript]` editor settings set ESLint as the formatter and enable auto-formatting on save
1. `launch.json` to provide a [launch configuration](https://code.visualstudio.com/docs/editor/debugging) for PHP's XDebug
1. `tasks.json` to provide access to common [tasks](https://code.visualstudio.com/docs/editor/tasks):
    - Setup (composer install, update db, update config, build theme, and clear cache)
    - Composer install
    - Composer clean
    - Lando start
    - Update db
    - Update (Drupal) config
    - Export config
    - Lint all PHP files (`lando php-sniff`)
    - Pull the db from `live`
    - Pull files from `live`
    - Build assets