### PR TITLE
SG-1810 - enable alt text for campaign logo

### DIFF
--- a/config/field.field.node.campaign.field_logo.yml
+++ b/config/field.field.node.campaign.field_logo.yml
@@ -7,13 +7,20 @@ dependencies:
     - node.type.campaign
   module:
     - content_translation
+    - datalayer
     - image
+    - tmgmt_content
 third_party_settings:
+  datalayer:
+    expose: 0
+    label: field_logo
   content_translation:
     translation_sync:
       alt: alt
-      title: title
       file: '0'
+      title: '0'
+  tmgmt_content:
+    excluded: false
 id: node.campaign.field_logo
 field_name: field_logo
 entity_type: node
@@ -32,7 +39,7 @@ settings:
   max_filesize: ''
   max_resolution: ''
   min_resolution: ''
-  alt_field: false
+  alt_field: true
   alt_field_required: true
   title_field: false
   title_field_required: false

--- a/web/themes/custom/sfgovpl/templates/layout/page--node--campaign.html.twig
+++ b/web/themes/custom/sfgovpl/templates/layout/page--node--campaign.html.twig
@@ -75,7 +75,9 @@
         <div class="sfgov-logo__container">
           <h1 class="{{ titleVisibility }}">{{ node.title.value }}</h1>
           {% if logo is not empty %}
-            <img src="{{ node.field_logo.entity.uri.value | image_style('campaign_logo') }}" />
+            <img src="{{ node.field_logo.entity.uri.value | image_style('campaign_logo') }}" 
+              alt="{{ node.field_logo.alt }}"
+            />
           {% endif %}
         </div>
         <div class="head-right--container">


### PR DESCRIPTION
SG-1810

* enables and requires the alt text field for campaign content type logo
* updates corresponding twig template to add the `alt` attribute to the image markup