### PR TITLE
SG-1765 - update focus outline color for dark and light backgrounds

### DIFF
--- a/web/themes/custom/sfgovpl/src/sass/_base.scss
+++ b/web/themes/custom/sfgovpl/src/sass/_base.scss
@@ -130,7 +130,9 @@ b {
 // Set the focus color to white.
 .text-white,
 .dark-blue,
-.sfgov-title--elected-officials {
+.sfgov-title--elected-officials,
+.paragraph--formio--feedback,
+.sfgov-footer {
   *:focus {
     outline-color: $c-white;
   }

--- a/web/themes/custom/sfgovpl/src/sass/_mixins.scss
+++ b/web/themes/custom/sfgovpl/src/sass/_mixins.scss
@@ -386,7 +386,7 @@
 }
 
 @mixin focus-outline {
-  outline: 2px dotted #aeb0b5;
+  outline: 2px dotted $c-black;
   outline-offset: 3px;
 }
 

--- a/web/themes/custom/sfgovpl/src/sass/_mixins.scss
+++ b/web/themes/custom/sfgovpl/src/sass/_mixins.scss
@@ -387,6 +387,7 @@
 
 @mixin focus-outline {
   outline: 2px dotted #000;
+  border-radius: 2px;
   outline-offset: 3px;
 }
 

--- a/web/themes/custom/sfgovpl/src/sass/_mixins.scss
+++ b/web/themes/custom/sfgovpl/src/sass/_mixins.scss
@@ -386,7 +386,7 @@
 }
 
 @mixin focus-outline {
-  outline: 2px dotted $c-black;
+  outline: 2px dotted #000;
   outline-offset: 3px;
 }
 


### PR DESCRIPTION
SG-1756

* update focus outline color to black for light backgrounds
* add more dark background elements for white focus outline