### PR TITLE
SG-1666: Created sfgov_untranslated_aliases custom module.

### DIFF
--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -137,6 +137,7 @@ module:
   sfgov_public_bodies: 0
   sfgov_qless: 0
   sfgov_search: 0
+  sfgov_untranslated_aliases: 0
   sfgov_update_fields: 0
   sfgov_user: 0
   sfgov_utilities: 0

--- a/web/modules/custom/sfgov_untranslated_aliases/README.md
+++ b/web/modules/custom/sfgov_untranslated_aliases/README.md
@@ -1,0 +1,27 @@
+# SF.gov Untranslated Path Aliases
+
+- [Introduction](#introduction)
+- [Configuration](#configuration)
+- [Testing](#testing)
+- [Content](#content)
+
+## Functionality
+Drupal makes untranslated content available under a default "/[lang]/node/[id]" path. This modules alters the
+alias manager to enable the untranslated content to have the same node alias as the original content.
+
+Example:
+
+- An original "en" node, say, "/node/5" with a node alias "/wingardium-leviosa".
+- If the node has no translations:
+  - Without this module, translations would only be available under "/[lang]/node/5".
+  - With this module, the translations will be available under "/[lang]/wingardium-leviosa".
+
+Furthermore, it provides the same "alias" functionality for all content, not just nodes (views, taxonomy terms, etc.),
+essentially enabling a translation alias for all content that does not have an existing one.
+
+
+## Notes
+- This module was customized from the [Fake Path Alias](https://www.drupal.org/project/fake_path_alias) contrib module.
+- When enabled, all untranslated content will get aliases, as they are looked-for on-the-fly.
+- If disabling this module, consider that the untranslated aliases will no longer function, and work may be needed to
+redirect traffic from non-existing aliases to the original URLs.

--- a/web/modules/custom/sfgov_untranslated_aliases/sfgov_untranslated_aliases.info.yml
+++ b/web/modules/custom/sfgov_untranslated_aliases/sfgov_untranslated_aliases.info.yml
@@ -1,0 +1,8 @@
+name: 'SF.gov Untranslated Path Aliases'
+type: module
+description: 'Provide untranslated pages with the same path alias as the original content.'
+package: 'sf.gov'
+core_version_requirement: ^8 || ^9
+dependencies:
+  - drupal:language
+  - drupal:path

--- a/web/modules/custom/sfgov_untranslated_aliases/sfgov_untranslated_aliases.services.yml
+++ b/web/modules/custom/sfgov_untranslated_aliases/sfgov_untranslated_aliases.services.yml
@@ -1,0 +1,11 @@
+services:
+  sfgov_untranslated_aliases.path_processor_alias:
+    class: Drupal\sfgov_untranslated_aliases\PathProcessorUntranslatedAlias
+    tags:
+      - { name: path_processor_inbound, priority: 100 }
+      - { name: path_processor_outbound, priority: 100 }
+    arguments: [
+      '@path_alias.manager',
+      '@path_alias.repository',
+      '@language_manager'
+    ]

--- a/web/modules/custom/sfgov_untranslated_aliases/src/PathProcessorUntranslatedAlias.php
+++ b/web/modules/custom/sfgov_untranslated_aliases/src/PathProcessorUntranslatedAlias.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Drupal\sfgov_untranslated_aliases;
+
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\PathProcessor\InboundPathProcessorInterface;
+use Drupal\Core\PathProcessor\OutboundPathProcessorInterface;
+use Drupal\Core\Render\BubbleableMetadata;
+use Drupal\path_alias\AliasManagerInterface;
+use Drupal\path_alias\AliasRepositoryInterface;
+use Drupal\path_alias\PathProcessor\AliasPathProcessor;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Processes the inbound and outbound paths using path alias lookups.
+ */
+class PathProcessorUntranslatedAlias extends AliasPathProcessor implements InboundPathProcessorInterface, OutboundPathProcessorInterface {
+
+  /**
+   * The path alias storage service.
+   *
+   * @var \Drupal\path_alias\AliasRepositoryInterface
+   */
+  protected AliasRepositoryInterface $aliasStorage;
+
+  /**
+   * The language manager service.
+   *
+   * @var \Drupal\Core\Language\LanguageManagerInterface
+   */
+  protected LanguageManagerInterface $languageManager;
+
+  /**
+   * Current language id.
+   *
+   * @var string
+   */
+  protected string $currentLangId;
+
+  /**
+   * Default language id.
+   *
+   * @var string
+   */
+  protected string $defaultLangId;
+
+  /**
+   * Constructs a PathProcessorFakeAlias object.
+   *
+   * @param \Drupal\path_alias\AliasManagerInterface $alias_manager
+   *   An alias manager for looking up the system path.
+   * @param \Drupal\path_alias\AliasRepositoryInterface $alias_storage
+   *   The path alias storage.
+   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
+   *   The language manager service.
+   */
+  public function __construct(AliasManagerInterface $alias_manager, AliasRepositoryInterface $alias_storage, LanguageManagerInterface $language_manager) {
+    parent::__construct($alias_manager);
+
+    $this->aliasStorage = $alias_storage;
+    $this->languageManager = $language_manager;
+    $this->currentLangId = $this->languageManager->getCurrentLanguage()->getId();
+    $this->defaultLangId = $this->languageManager->getDefaultLanguage()->getId();
+  }
+
+  /**
+   * Convert path alias to system path.
+   *
+   * {@inheritdoc}
+   */
+  public function processInbound($path, Request $request) {
+    $path = parent::processInbound($path, $request);
+
+    // Current language has no alias, but original has one.
+    if (!$this->aliasStorage->lookupByAlias($path, $this->currentLangId)
+        && $this->aliasStorage->lookupByAlias($path, $this->defaultLangId)
+    ) {
+      // Get node source path from passed alias in original language.
+      $path = $this->aliasManager->getPathByAlias($path, $this->defaultLangId);
+    }
+
+    return $path;
+  }
+
+  /**
+   * Convert system path to path alias.
+   *
+   * {@inheritdoc}
+   */
+  public function processOutbound($path, &$options = array(), Request $request = NULL, BubbleableMetadata $bubbleable_metadata = NULL) {
+    $path = parent::processOutbound($path, $options, $request, $bubbleable_metadata);
+    $requestedLangId = isset($options['language']) ? $options['language']->getId() : NULL;
+
+    if (empty($options['alias'])) {
+
+      // Process paths for the non-default languages.
+      if (!empty($requestedLangId) && $requestedLangId != $this->defaultLangId) {
+        // Alias doesn't exist for requested language.
+        if (!$this->aliasStorage->lookupBySystemPath($path, $requestedLangId)
+          && !$this->aliasStorage->lookupByAlias($path, $requestedLangId)
+        ) {
+          // Instead of original node source path, get node alias.
+          $path = $this->aliasManager->getAliasByPath($path, $this->defaultLangId);
+        }
+      }
+
+      // Edge scenario - prevents redirects from /[lang]/alias to /[lang]/node/[id].
+      else {
+        if (!$this->aliasStorage->lookupBySystemPath($path, $this->currentLangId)
+          && !$this->aliasStorage->lookupByAlias($path, $this->currentLangId)
+        ) {
+          // Instead of original node source path, get node alias.
+          $path = $this->aliasManager->getAliasByPath($path, $this->defaultLangId);
+        }
+      }
+    }
+
+    return $path;
+  }
+
+  /*
+  public function processOutbound($path, &$options = array(), Request $request = NULL, BubbleableMetadata $bubbleable_metadata = NULL) {
+    $path = parent::processOutbound($path, $options, $request, $bubbleable_metadata);
+
+    if (empty($options['alias'])) {
+      // Alias doesn't exist for current language and source too.
+      if (!$this->aliasStorage->lookupBySystemPath($path, $this->currentLangId)
+        && !$this->aliasStorage->lookupByAlias($path, $this->currentLangId)
+      ) {
+        // Instead of original node source path, get node alias.
+        $path = $this->aliasManager->getAliasByPath($path, $this->defaultLangId);
+      }
+    }
+
+    return $path;
+  }
+  */
+
+}


### PR DESCRIPTION
SG-1666: Make machine-translated pages have the same alias as the original language.

### Description
Drupal makes untranslated content available under a default "/[lang]/node/[id]" path. This modules alters the
alias manager to enable the untranslated content to have the same node alias as the original content.

Example:

- An original "en" node, say, "/node/5" with a node alias "/wingardium-leviosa".
- If the node has no translations:
  - Without this module, translations would only be available under "/[lang]/node/5".
  - With this module, the translations will be available under "/[lang]/wingardium-leviosa".

Furthermore, it provides the same "alias" functionality for all content, not just nodes (views, taxonomy terms, etc.),
essentially enabling a translation alias for all content that does not have an existing one.