### PR TITLE
SG-1794 - Resource collection sometimes has duplicate title on Document sections

### DIFF
--- a/web/themes/custom/sfgovpl/templates/node/resource_collection/node--resource-collection--full.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/resource_collection/node--resource-collection--full.html.twig
@@ -54,7 +54,7 @@
       This is a bit of a hack to keep the H2 on nodes created before
       Resource Collections were changed.
       #}
-      {% if rc_version == 1 %}
+      {% if rc_version == 1 and content.field_content|render|striptags|trim %}
         <h2 class="title-2">
           {{ 'Documents'|t }}
         </h2>


### PR DESCRIPTION
SG-1794

* Updates resource collection template to check that legacy document sections have content before rendering Documents title