### PR TITLE
SG-1824 - Allow writers, publishers, and DS permission levels to duplicate "reports"

### DIFF
--- a/config/user.role.digital_services.yml
+++ b/config/user.role.digital_services.yml
@@ -180,6 +180,7 @@ permissions:
   - 'clone page content'
   - 'clone person content'
   - 'clone public_body content'
+  - 'clone report content'
   - 'clone resource_collection content'
   - 'clone step_by_step content'
   - 'clone topic content'

--- a/config/user.role.publisher.yml
+++ b/config/user.role.publisher.yml
@@ -99,6 +99,7 @@ permissions:
   - 'clone news content'
   - 'clone person content'
   - 'clone public_body content'
+  - 'clone report content'
   - 'clone resource_collection content'
   - 'clone step_by_step content'
   - 'create about content'

--- a/config/user.role.writer.yml
+++ b/config/user.role.writer.yml
@@ -89,6 +89,7 @@ permissions:
   - 'clone news content'
   - 'clone person content'
   - 'clone public_body content'
+  - 'clone report content'
   - 'clone resource_collection content'
   - 'clone step_by_step content'
   - 'create about content'


### PR DESCRIPTION
SG-1824

* enable quick node clone for reports for writer, publisher, and ds roles