### PR TITLE
SG-1825 - Profile - overly long "Primary job title" squeezes thumbnail on public body page

### DIFF
--- a/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-people.scss
+++ b/web/themes/custom/sfgovpl/src/sass/paragraphs/_paragraph-people.scss
@@ -44,6 +44,7 @@
     margin-bottom: 20px;
     @include media($medium-screen) {
       display: flex;
+      flex-wrap: wrap;
       align-items: stretch;
       width: 33%;
       margin-bottom: 40px;


### PR DESCRIPTION
SG-1825

* apply flex-wrap to maintain width of display flex parent