### PR TITLE
#SG-1831 -- Set spotlight fields on departments to be translatable

### DIFF
--- a/config/field.field.node.department.field_spotlight.yml
+++ b/config/field.field.node.department.field_spotlight.yml
@@ -7,7 +7,15 @@ dependencies:
     - node.type.department
     - paragraphs.paragraphs_type.spotlight
   module:
+    - datalayer
     - entity_reference_revisions
+    - tmgmt_content
+third_party_settings:
+  datalayer:
+    expose: 0
+    label: field_spotlight
+  tmgmt_content:
+    excluded: false
 id: node.department.field_spotlight
 field_name: field_spotlight
 entity_type: node
@@ -15,7 +23,7 @@ bundle: department
 label: Spotlight
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
@@ -186,6 +194,12 @@ settings:
         enabled: false
       public_body_profiles:
         weight: 125
+        enabled: false
+      resource_entity:
+        weight: 129
+        enabled: false
+      resource_node:
+        weight: 130
         enabled: false
       resource_section:
         weight: 127

--- a/config/field.field.node.department.field_spotlight2.yml
+++ b/config/field.field.node.department.field_spotlight2.yml
@@ -7,7 +7,15 @@ dependencies:
     - node.type.department
     - paragraphs.paragraphs_type.spotlight
   module:
+    - datalayer
     - entity_reference_revisions
+    - tmgmt_content
+third_party_settings:
+  datalayer:
+    expose: 0
+    label: field_spotlight2
+  tmgmt_content:
+    excluded: false
 id: node.department.field_spotlight2
 field_name: field_spotlight2
 entity_type: node
@@ -15,7 +23,7 @@ bundle: department
 label: Spotlight
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
@@ -79,6 +87,15 @@ settings:
       custom_section:
         weight: 77
         enabled: false
+      data_story_reference_section:
+        weight: 92
+        enabled: false
+      data_story_reference_subsection:
+        weight: 93
+        enabled: false
+      data_story_section:
+        weight: 94
+        enabled: false
       department_content:
         weight: 78
         enabled: false
@@ -88,6 +105,12 @@ settings:
       document:
         weight: 80
         enabled: false
+      document_section:
+        weight: 98
+        enabled: false
+      document_subsection:
+        weight: 99
+        enabled: false
       email:
         weight: 81
         enabled: false
@@ -96,6 +119,9 @@ settings:
         enabled: false
       events:
         weight: 83
+        enabled: false
+      existing_agency:
+        weight: 103
         enabled: false
       fact:
         weight: 84
@@ -114,6 +140,9 @@ settings:
         enabled: false
       help:
         weight: 89
+        enabled: false
+      image:
+        weight: 110
         enabled: false
       image_with_text:
         weight: 90
@@ -154,8 +183,29 @@ settings:
       phone_numbers:
         weight: 102
         enabled: false
+      powerbi_embed:
+        weight: 124
+        enabled: false
       process_step:
         weight: 103
+        enabled: false
+      profile_group:
+        weight: 126
+        enabled: false
+      public_body_profiles:
+        weight: 127
+        enabled: false
+      resource_entity:
+        weight: 129
+        enabled: false
+      resource_node:
+        weight: 130
+        enabled: false
+      resource_section:
+        weight: 131
+        enabled: false
+      resource_subsection:
+        weight: 132
         enabled: false
       resources:
         weight: 104

--- a/config/field.field.paragraph.spotlight.field_spotlight_button.yml
+++ b/config/field.field.paragraph.spotlight.field_spotlight_button.yml
@@ -7,7 +7,15 @@ dependencies:
     - paragraphs.paragraphs_type.button
     - paragraphs.paragraphs_type.spotlight
   module:
+    - datalayer
     - entity_reference_revisions
+    - tmgmt_content
+third_party_settings:
+  datalayer:
+    expose: 0
+    label: field_spotlight_button
+  tmgmt_content:
+    excluded: false
 id: paragraph.spotlight.field_spotlight_button
 field_name: field_spotlight_button
 entity_type: paragraph
@@ -15,7 +23,7 @@ bundle: spotlight
 label: 'Spotlight Button'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
@@ -25,8 +33,26 @@ settings:
       button: button
     negate: 0
     target_bundles_drag_drop:
+      accordion:
+        weight: 74
+        enabled: false
+      accordion_item:
+        weight: 75
+        enabled: false
+      accordion_item_simple:
+        weight: 76
+        enabled: false
+      acuity_embed:
+        weight: 77
+        enabled: false
       additional_info:
         weight: 26
+        enabled: false
+      agenda_item:
+        weight: 79
+        enabled: false
+      basic_html_section:
+        weight: 80
         enabled: false
       block:
         weight: 27
@@ -34,8 +60,26 @@ settings:
       button:
         weight: 28
         enabled: true
+      call_to_action:
+        weight: 84
+        enabled: false
       callout:
         weight: 29
+        enabled: false
+      campaign:
+        weight: 85
+        enabled: false
+      campaign_resource_section:
+        weight: 87
+        enabled: false
+      campaign_resources:
+        weight: 86
+        enabled: false
+      campaign_spotlight:
+        weight: 88
+        enabled: false
+      content_link:
+        weight: 89
         enabled: false
       cost:
         weight: 30
@@ -43,23 +87,74 @@ settings:
       custom_section:
         weight: 31
         enabled: false
+      data_story_reference_section:
+        weight: 92
+        enabled: false
+      data_story_reference_subsection:
+        weight: 93
+        enabled: false
+      data_story_section:
+        weight: 94
+        enabled: false
+      department_content:
+        weight: 95
+        enabled: false
       department_service_section:
         weight: 32
         enabled: false
       document:
         weight: 33
         enabled: false
+      document_section:
+        weight: 98
+        enabled: false
+      document_subsection:
+        weight: 99
+        enabled: false
       email:
         weight: 34
+        enabled: false
+      email_addresses:
+        weight: 101
+        enabled: false
+      events:
+        weight: 102
+        enabled: false
+      existing_agency:
+        weight: 103
+        enabled: false
+      fact:
+        weight: 104
+        enabled: false
+      facts:
+        weight: 105
         enabled: false
       featured_item:
         weight: 35
         enabled: false
+      form:
+        weight: 107
+        enabled: false
+      form_io:
+        weight: 108
+        enabled: false
       help:
         weight: 36
         enabled: false
+      image:
+        weight: 110
+        enabled: false
+      image_with_text:
+        weight: 111
+        enabled: false
       in_person_location:
         weight: 37
+        enabled: false
+      instagram_embed:
+        weight: 112
+        enabled: false
+      link:
+        weight: 114
         enabled: false
       list:
         weight: 38
@@ -70,14 +165,56 @@ settings:
       mailing_address:
         weight: 40
         enabled: false
+      news:
+        weight: 118
+        enabled: false
+      other_info_card:
+        weight: 119
+        enabled: false
+      other_info_document:
+        weight: 120
+        enabled: false
       people:
         weight: 41
         enabled: false
       phone:
         weight: 42
         enabled: false
+      phone_numbers:
+        weight: 123
+        enabled: false
+      powerbi_embed:
+        weight: 124
+        enabled: false
+      process_step:
+        weight: 125
+        enabled: false
+      profile_group:
+        weight: 126
+        enabled: false
+      public_body_profiles:
+        weight: 127
+        enabled: false
+      resource_entity:
+        weight: 129
+        enabled: false
+      resource_node:
+        weight: 130
+        enabled: false
+      resource_section:
+        weight: 131
+        enabled: false
+      resource_subsection:
+        weight: 132
+        enabled: false
+      resources:
+        weight: 128
+        enabled: false
       section:
         weight: 43
+        enabled: false
+      social_media:
+        weight: 134
         enabled: false
       special_case:
         weight: 44
@@ -94,7 +231,25 @@ settings:
       thing_to_know:
         weight: 47
         enabled: false
+      timeline:
+        weight: 140
+        enabled: false
+      timeline_item:
+        weight: 141
+        enabled: false
       top_search_suggestion:
         weight: 48
+        enabled: false
+      twitter_embed:
+        weight: 143
+        enabled: false
+      video:
+        weight: 144
+        enabled: false
+      video_external:
+        weight: 146
+        enabled: false
+      videos:
+        weight: 145
         enabled: false
 field_type: entity_reference_revisions

--- a/config/field.field.paragraph.spotlight.field_spotlight_image.yml
+++ b/config/field.field.paragraph.spotlight.field_spotlight_image.yml
@@ -6,7 +6,15 @@ dependencies:
     - field.storage.paragraph.field_spotlight_image
     - paragraphs.paragraphs_type.spotlight
   module:
+    - datalayer
     - image
+    - tmgmt_content
+third_party_settings:
+  datalayer:
+    expose: 0
+    label: field_spotlight_image
+  tmgmt_content:
+    excluded: false
 id: paragraph.spotlight.field_spotlight_image
 field_name: field_spotlight_image
 entity_type: paragraph
@@ -14,7 +22,7 @@ bundle: spotlight
 label: 'Spotlight Image'
 description: 'Minimum 550 px wide. Keep subject in the center. Image will resize based on text and screen size (mobile or desktop). Horizontal images need short text, vertical images work with longer text.'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:


### PR DESCRIPTION
Set spotlight fields on departments to be translatable so that they load initial content when translated.

#SG-1831