### PR TITLE
#SG-1842 -- Fix to alignment issues by adding the proper container class to header-banner template

### DIFF
--- a/web/themes/custom/sfgovpl/templates/components/hero-banner-color.twig
+++ b/web/themes/custom/sfgovpl/templates/components/hero-banner-color.twig
@@ -1,5 +1,5 @@
 <header class="hero-banner color {{ banner.notranslate ?? '' }} {{ banner.color ?? '' }}">
-  <div class="responsive-container">
+  <div class="responsive-container hero-banner--container">
     {% if banner.label %}
       <div class="hero-banner-label">
         {{ banner.label|raw }}


### PR DESCRIPTION
#SG-1842

Fix to alignment issues by adding the proper container class to header-banner template

