### PR TITLE
SG-1828 -- Setup character limited fields to not force truncation if translations are over character limit.

### DIFF
--- a/config/core.entity_form_display.block_content.alert.default.yml
+++ b/config/core.entity_form_display.block_content.alert.default.yml
@@ -43,8 +43,8 @@ content:
       maxlength:
         maxlength_js: 100
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
-        maxlength_js_enforce: true
-        maxlength_js_truncate_html: true
+        maxlength_js_enforce: false
+        maxlength_js_truncate_html: false
   info:
     type: string_textfield
     weight: 0

--- a/config/core.entity_form_display.node.department.default.yml
+++ b/config/core.entity_form_display.node.department.default.yml
@@ -170,8 +170,8 @@ content:
       maxlength:
         maxlength_js: 450
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
-        maxlength_js_enforce: true
-        maxlength_js_truncate_html: true
+        maxlength_js_enforce: false
+        maxlength_js_truncate_html: false
   field_address:
     type: entity_browser_entity_reference
     weight: 35
@@ -206,8 +206,8 @@ content:
       maxlength:
         maxlength_js: 100
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
-        maxlength_js_enforce: true
-        maxlength_js_truncate_html: true
+        maxlength_js_enforce: false
+        maxlength_js_truncate_html: false
   field_archive_date:
     type: datetime_default
     weight: 15

--- a/config/core.entity_form_display.node.event.default.yml
+++ b/config/core.entity_form_display.node.event.default.yml
@@ -157,7 +157,7 @@ content:
       maxlength:
         maxlength_js: 280
         maxlength_js_label: '<strong>@remaining</strong>'
-        maxlength_js_enforce: true
+        maxlength_js_enforce: false
         maxlength_js_truncate_html: false
   field_email:
     type: paragraphs

--- a/config/core.entity_form_display.node.form_confirmation_page.default.yml
+++ b/config/core.entity_form_display.node.form_confirmation_page.default.yml
@@ -149,8 +149,8 @@ content:
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_summary: null
         maxlength_js_label_summary: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
-        maxlength_js_enforce: true
-        maxlength_js_truncate_html: true
+        maxlength_js_enforce: false
+        maxlength_js_truncate_html: false
   created:
     type: datetime_timestamp
     weight: 5
@@ -199,8 +199,8 @@ content:
       maxlength:
         maxlength_js: null
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
-        maxlength_js_enforce: true
-        maxlength_js_truncate_html: true
+        maxlength_js_enforce: false
+        maxlength_js_truncate_html: false
   field_form_confirm_page_slug:
     type: string_textfield
     weight: 105

--- a/config/core.entity_form_display.node.information_page.default.yml
+++ b/config/core.entity_form_display.node.information_page.default.yml
@@ -50,7 +50,7 @@ content:
       maxlength:
         maxlength_js: 300
         maxlength_js_label: '<strong>@remaining</strong>'
-        maxlength_js_enforce: true
+        maxlength_js_enforce: false
         maxlength_js_truncate_html: false
   field_information_section:
     type: paragraphs

--- a/config/core.entity_form_display.node.location.default.yml
+++ b/config/core.entity_form_display.node.location.default.yml
@@ -190,8 +190,8 @@ content:
       maxlength:
         maxlength_js: 100
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
-        maxlength_js_enforce: true
-        maxlength_js_truncate_html: true
+        maxlength_js_enforce: false
+        maxlength_js_truncate_html: false
   field_at_this_location:
     type: entity_reference_autocomplete
     weight: 10

--- a/config/core.entity_form_display.node.person.default.yml
+++ b/config/core.entity_form_display.node.person.default.yml
@@ -108,8 +108,8 @@ content:
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_summary: null
         maxlength_js_label_summary: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
-        maxlength_js_enforce: true
-        maxlength_js_truncate_html: true
+        maxlength_js_enforce: false
+        maxlength_js_truncate_html: false
   created:
     type: datetime_timestamp
     weight: 16

--- a/config/core.entity_form_display.node.public_body.default.yml
+++ b/config/core.entity_form_display.node.public_body.default.yml
@@ -137,8 +137,8 @@ content:
       maxlength:
         maxlength_js: 100
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
-        maxlength_js_enforce: true
-        maxlength_js_truncate_html: true
+        maxlength_js_enforce: false
+        maxlength_js_truncate_html: false
   field_board_members:
     type: paragraphs
     weight: 6

--- a/config/core.entity_form_display.node.step_by_step.default.yml
+++ b/config/core.entity_form_display.node.step_by_step.default.yml
@@ -55,8 +55,8 @@ content:
       maxlength:
         maxlength_js: 110
         maxlength_js_label: '<strong>@remaining</strong>/@limit'
-        maxlength_js_enforce: true
-        maxlength_js_truncate_html: true
+        maxlength_js_enforce: false
+        maxlength_js_truncate_html: false
   field_intro_text:
     type: text_textarea
     weight: 2
@@ -71,8 +71,8 @@ content:
       maxlength:
         maxlength_js: null
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
-        maxlength_js_enforce: true
-        maxlength_js_truncate_html: true
+        maxlength_js_enforce: false
+        maxlength_js_truncate_html: false
   field_process_steps:
     type: paragraphs
     weight: 3

--- a/config/core.entity_form_display.paragraph.campaign_spotlight.default.yml
+++ b/config/core.entity_form_display.paragraph.campaign_spotlight.default.yml
@@ -52,8 +52,8 @@ content:
       maxlength:
         maxlength_js: 300
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
-        maxlength_js_enforce: true
-        maxlength_js_truncate_html: true
+        maxlength_js_enforce: false
+        maxlength_js_truncate_html: false
   field_is_reversed:
     type: boolean_checkbox
     weight: 6

--- a/config/core.entity_form_display.paragraph.featured_item.default.yml
+++ b/config/core.entity_form_display.paragraph.featured_item.default.yml
@@ -31,8 +31,8 @@ content:
       maxlength:
         maxlength_js: 140
         maxlength_js_label: '<strong>@remaining</strong> left'
-        maxlength_js_enforce: true
-        maxlength_js_truncate_html: true
+        maxlength_js_enforce: false
+        maxlength_js_truncate_html: false
   field_feature_link:
     type: link_default
     weight: 2

--- a/config/core.entity_form_display.paragraph.resources.default.yml
+++ b/config/core.entity_form_display.paragraph.resources.default.yml
@@ -31,8 +31,8 @@ content:
       maxlength:
         maxlength_js: 110
         maxlength_js_label: '<strong>@remaining</strong> left'
-        maxlength_js_enforce: true
-        maxlength_js_truncate_html: true
+        maxlength_js_enforce: false
+        maxlength_js_truncate_html: false
   field_link:
     type: link_default
     weight: 2

--- a/config/core.entity_form_display.paragraph.spotlight.default.yml
+++ b/config/core.entity_form_display.paragraph.spotlight.default.yml
@@ -35,8 +35,8 @@ content:
       maxlength:
         maxlength_js: 300
         maxlength_js_label: '<strong>@remaining</strong> left'
-        maxlength_js_enforce: true
-        maxlength_js_truncate_html: true
+        maxlength_js_enforce: false
+        maxlength_js_truncate_html: false
   field_spotlight_button:
     type: entity_reference_paragraphs
     weight: 3

--- a/config/core.entity_form_display.resource.resource.default.yml
+++ b/config/core.entity_form_display.resource.resource.default.yml
@@ -42,8 +42,8 @@ content:
       maxlength:
         maxlength_js: 110
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
-        maxlength_js_enforce: true
-        maxlength_js_truncate_html: true
+        maxlength_js_enforce: false
+        maxlength_js_truncate_html: false
   field_topic:
     type: entity_reference_autocomplete
     weight: 4


### PR DESCRIPTION
Setup character limited fields to not force truncation if translations are over character limit.

#SG-1828

This should help keep html tags from being added/processed in text fields with character limits, especially plain text items. Don't know if this will fix existing issues, but should help prevent them from occurring with future translations.

Import config and clear caches 