### PR TITLE
use tailwind safelist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4925,9 +4925,9 @@
       "link": true
     },
     "node_modules/sfgov-design-system": {
-      "version": "2.5.1-rc.206cb7e",
-      "resolved": "https://registry.npmjs.org/sfgov-design-system/-/sfgov-design-system-2.5.1-rc.206cb7e.tgz",
-      "integrity": "sha512-bGpsZKuL17WMvcD8My8hEDMnjJtQJC8Z5wjaH0dj5AfI1LGBe/nbwKIH5RJnYMa3iQKmndCAywvR1x/F9bapQQ=="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/sfgov-design-system/-/sfgov-design-system-2.5.1.tgz",
+      "integrity": "sha512-V+4aiepCtKVrBkhrXlDwhlVoWR+7J3UvEO8CH95Zi/aV/mWgr4DZIH/Y//o3bCDLFL6Q09Kgvb1xYGidg7023Q=="
     },
     "node_modules/sfgovpl": {
       "resolved": "web/themes/custom/sfgovpl",
@@ -5438,7 +5438,7 @@
     "web/modules/custom/sfgov_vaccine": {},
     "web/themes/custom/sfgovpl": {
       "dependencies": {
-        "sfgov-design-system": "^2.5.1-rc.206cb7e",
+        "sfgov-design-system": "^2.5.1",
         "tailwindcss": "^3.2.0",
         "tailwindcss-interaction-variants": "^5.0.0"
       },
@@ -10516,9 +10516,9 @@
       "version": "file:web/modules/custom/sfgov_vaccine"
     },
     "sfgov-design-system": {
-      "version": "2.5.1-rc.206cb7e",
-      "resolved": "https://registry.npmjs.org/sfgov-design-system/-/sfgov-design-system-2.5.1-rc.206cb7e.tgz",
-      "integrity": "sha512-bGpsZKuL17WMvcD8My8hEDMnjJtQJC8Z5wjaH0dj5AfI1LGBe/nbwKIH5RJnYMa3iQKmndCAywvR1x/F9bapQQ=="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/sfgov-design-system/-/sfgov-design-system-2.5.1.tgz",
+      "integrity": "sha512-V+4aiepCtKVrBkhrXlDwhlVoWR+7J3UvEO8CH95Zi/aV/mWgr4DZIH/Y//o3bCDLFL6Q09Kgvb1xYGidg7023Q=="
     },
     "sfgovpl": {
       "version": "file:web/themes/custom/sfgovpl",
@@ -10539,9 +10539,9 @@
         "prettier-plugin-twig-melody": "^0.4.6",
         "purgecss": "^4.1.3",
         "sass-migrator": "^1.5.5",
-        "sfgov-design-system": "^2.5.1-rc.206cb7e",
+        "sfgov-design-system": "^2.5.1",
         "tailwindcss": "^3.2.0",
-        "tailwindcss-interaction-variants": "^5.0.0"
+        "tailwindcss-interaction-variants": "*"
       },
       "dependencies": {
         "@fullhuman/postcss-purgecss": {

--- a/web/themes/custom/sfgovpl/package.json
+++ b/web/themes/custom/sfgovpl/package.json
@@ -18,7 +18,7 @@
     "watch-js": "npm run build-js -- --watch"
   },
   "dependencies": {
-    "sfgov-design-system": "^2.5.1-rc.206cb7e",
+    "sfgov-design-system": "^2.5.1",
     "tailwindcss": "^3.2.0",
     "tailwindcss-interaction-variants": "^5.0.0"
   },

--- a/web/themes/custom/sfgovpl/tailwind.config.js
+++ b/web/themes/custom/sfgovpl/tailwind.config.js
@@ -1,4 +1,4 @@
-const { content, ...purgeOptions } = require('./purgecss.config')
+const { content, safelist } = require('./purgecss.config')
 
 /** @type {import('tailwindcss/types').Config} */
 module.exports = {
@@ -14,7 +14,7 @@ module.exports = {
     }
   },
   content,
-  purge: {
-    options: purgeOptions
-  }
+  safelist: safelist.greedy.map(pattern => {
+    return { pattern }
+  })
 }


### PR DESCRIPTION
we're trying to update our current theme build to include its own tailwind config to take the design system's preset and extend it in #1429 

tailwind's internal purge is removing all the safelisted patterns before our own purgeCSS does its thing.  tailwind used to have a `purge: false` option, [but it sounds like the `purge` option for tailwind 3 has been changed to `content` and only takes an array of glob patterns for tailwind's internal purge](https://tailwindcss.com/docs/upgrade-guide#configure-content-sources) (not 100% on this 😅 ).

[there is a `safelist` option](https://purgecss.com/safelisting.html), though, so this pr takes the purgeCss safelist and drops it in the tailwind config to honor that safelist