### PR TITLE
SG# 1872 --  Allow notes to be output with addresses in sidebars

### DIFF
--- a/config/core.entity_view_display.location.physical.address_plus_notes.yml
+++ b/config/core.entity_view_display.location.physical.address_plus_notes.yml
@@ -1,0 +1,42 @@
+uuid: ac8b4310-a1ea-45ad-a7b4-28738bd3ef9c
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.location.address_plus_notes
+    - eck.eck_type.location.physical
+    - field.field.location.physical.field_address
+    - field.field.location.physical.field_department
+    - field.field.location.physical.field_operating_hours
+    - field.field.location.physical.field_text
+  module:
+    - address
+    - text
+id: location.physical.address_plus_notes
+targetEntityType: location
+bundle: physical
+mode: address_plus_notes
+content:
+  field_address:
+    type: address_plain
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_text:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  changed: true
+  created: true
+  field_department: true
+  field_operating_hours: true
+  langcode: true
+  search_api_excerpt: true
+  title: true
+  uid: true

--- a/config/core.entity_view_mode.location.address_plus_notes.yml
+++ b/config/core.entity_view_mode.location.address_plus_notes.yml
@@ -1,0 +1,10 @@
+uuid: c40a960f-df7e-48a8-9e36-b08b1a21e758
+langcode: en
+status: true
+dependencies:
+  module:
+    - eck
+id: location.address_plus_notes
+label: 'Address plus notes'
+targetEntityType: location
+cache: true

--- a/web/themes/custom/sfgovpl/templates/eck/eck-entity--location--physical--address-plus-notes.html.twig
+++ b/web/themes/custom/sfgovpl/templates/eck/eck-entity--location--physical--address-plus-notes.html.twig
@@ -1,0 +1,21 @@
+{#
+/**
+ * @file
+ * Template override for 'Address' (in_person_location) paragraph when rendered
+ * with 'Address only' view mode.
+ */
+#}
+{% extends 'eck-entity--location--physical.html.twig' %}
+{% block content %}
+  {% if content.field_address|render %}
+    <div class="sfgov-location__address">
+      {{ content.field_address }}
+    </div>
+  {% endif %}
+
+  {% if content.field_text|render %}
+    <div class="sfgov-location__notes">
+      {{ content.field_text }}
+    </div>
+  {% endif %}
+{% endblock %}

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--in-person-location.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--in-person-location.html.twig
@@ -28,7 +28,7 @@ boolean value. #}
       {% endif %}
     {% else %}
       {# Render with 'address_only' view mode. #}
-      {{ drupal_entity('location', pid, 'address_only') }}
+      {{ drupal_entity('location', pid, 'address_plus_notes') }}
     {% endif %}
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
SG# 1872
Setup new view mode for address with notes, apply view mode to "in_person_location" address output template.

Config import
Clear caches
Review locations added to sidebars