### PR TITLE
SG-1890 - About sections on campaign pages are incorrectly getting trimmed

### DIFF
--- a/config/core.entity_view_display.node.campaign.default.yml
+++ b/config/core.entity_view_display.node.campaign.default.yml
@@ -53,10 +53,9 @@ content:
     weight: 0
     region: content
   field_campaign_about:
-    type: text_trimmed
+    type: text_default
     label: above
-    settings:
-      trim_length: 600
+    settings: {  }
     third_party_settings: {  }
     weight: 7
     region: content


### PR DESCRIPTION
SG-1890 - About sections on campaign pages are incorrectly set to trimmed/600 characters

This changes the output to default print all.

Instructions:
config import
clear caches