### PR TITLE
[SG-1907] -- Data stories and location nodes set to have pathauto patterns follow url naming conventions

### DIFF
--- a/config/pathauto.pattern.data_story.yml
+++ b/config/pathauto.pattern.data_story.yml
@@ -7,7 +7,7 @@ dependencies:
 id: data_story
 label: 'Data story'
 type: 'canonical_entities:node'
-pattern: 'data/[node:title]'
+pattern: 'data/[node:source:title]'
 selection_criteria:
   51dc9c35-f202-493c-bdf9-3aca304e1915:
     id: 'entity_bundle:node'

--- a/config/pathauto.pattern.locations.yml
+++ b/config/pathauto.pattern.locations.yml
@@ -7,7 +7,7 @@ dependencies:
 id: locations
 label: Locations
 type: 'canonical_entities:node'
-pattern: '/location/[node:title]'
+pattern: 'location/[node:source:title]'
 selection_criteria:
   fd414694-d652-4bfb-b47e-4d342b3797ff:
     id: 'entity_bundle:node'


### PR DESCRIPTION
Data stories and location nodes set to have pathauto patterns follow url naming conventions

Instructions:
- Config import
- Clear cache
- Via the content admin page, Bulk resave all location and data story nodes to trigger the pathauto updates
- Confirm that a translated data story follows the url pattern for a translation