### PR TITLE
[SG-1887] -- Internal linking in an external resource not working

### DIFF
--- a/web/themes/custom/sfgovpl/includes/paragraph.inc
+++ b/web/themes/custom/sfgovpl/includes/paragraph.inc
@@ -319,10 +319,10 @@ function sfgovpl_preprocess_paragraph__resource_entity(&$variables) {
     $resource_storage = \Drupal::entityTypeManager()->getStorage('resource');
     /** @var \Drupal\eck\Entity\EckEntity $resource */
     $resource = $resource_storage->load($paragraph->get('field_resource')[0]->target_id);
-    $uri = $resource->get('field_url')->uri ?? '';
+    $uri = $resource->get('field_url')->uri ?? NULL;
     $variables['title'] = $resource->get('title')->value;
-    $variables['description'] = $resource->get('field_description') ?? render($resource->get('field_description')->value);
-    $variables['url'] = $uri;
+    $variables['description'] = $resource->get('field_description') ?? \Drupal::service('renderer')->render($resource->get('field_description')->value);
+    $variables['url'] = $uri ? Url::fromUri($uri)->setAbsolute()->toString() : '';
   }
 }
 


### PR DESCRIPTION
SG-1887

The resource entity external resource has a url field. It was not rendering the url correctly if the url was referencing an internal page. This update passed the content the right Url methods to generate a proper url

Instructions:
Clear cache