### PR TITLE
[SG-1894] - Truncation in a description when a campaign is used in Related.

### DIFF
--- a/config/core.entity_view_display.node.campaign.teaser.yml
+++ b/config/core.entity_view_display.node.campaign.teaser.yml
@@ -33,7 +33,7 @@ content:
     type: smart_trim
     label: hidden
     settings:
-      trim_length: 100
+      trim_length: 200
       trim_type: chars
       trim_suffix: ''
       wrap_output: true
@@ -43,7 +43,7 @@ content:
       more_text: More
       summary_handler: full
       trim_options:
-        text: true
+        text: false
         trim_zero: false
     third_party_settings: {  }
     weight: 1

--- a/web/themes/custom/sfgovpl/includes/field.inc
+++ b/web/themes/custom/sfgovpl/includes/field.inc
@@ -38,8 +38,16 @@ function sfgovpl_preprocess_field__node__field_related_content(&$variables) {
       // tries to grab a teaser version of the about field, trimmed down to 100
       // characters.
       elseif ($urlObject['entity']->hasField('field_campaign_about')) {
-        $variables['items'][$key]['content'][] = $urlObject['entity']->get('field_campaign_about')
+        $string = $urlObject['entity']->get('field_campaign_about')
           ->view('teaser');
+        // Grab the first <p> section from the content. The field is set to 200
+        // characters to allow for more content, but still needs to be cut into
+        // a summary paragraph. This snippet looks for the first closing p tag a
+        // sets that as the cutoff length.
+        $opening_p_point = strpos($string[0]['#text'], "<p");
+        $closing_p_point = strpos($string[0]['#text'], "</p>")+4;
+        $string[0]['#text'] = substr($string[0]['#text'], $opening_p_point, $closing_p_point);
+        $variables['items'][$key]['content'][] = $string;
       }
     }
   }

--- a/web/themes/custom/sfgovpl/includes/field.inc
+++ b/web/themes/custom/sfgovpl/includes/field.inc
@@ -38,16 +38,7 @@ function sfgovpl_preprocess_field__node__field_related_content(&$variables) {
       // tries to grab a teaser version of the about field, trimmed down to 100
       // characters.
       elseif ($urlObject['entity']->hasField('field_campaign_about')) {
-        $string = $urlObject['entity']->get('field_campaign_about')
-          ->view('teaser');
-        // Grab the first <p> section from the content. The field is set to 200
-        // characters to allow for more content, but still needs to be cut into
-        // a summary paragraph. This snippet looks for the first closing p tag a
-        // sets that as the cutoff length.
-        $opening_p_point = strpos($string[0]['#text'], "<p");
-        $closing_p_point = strpos($string[0]['#text'], "</p>")+4;
-        $string[0]['#text'] = substr($string[0]['#text'], $opening_p_point, $closing_p_point);
-        $variables['items'][$key]['content'][] = $string;
+        // SG-1894 Removed the description from campaign about field.
       }
     }
   }


### PR DESCRIPTION
SG-1894

This setup changes the way it grabs the summary from an About section. The character length was increased to potentially grab a larger paragraph, and then a snippet was added to try to pull out the first <p></p> content in the about text. This will need to be checked, and maybe some About content will still need to be edited, in order for this to best work for all cases.

Instructions:
- Config import
- Clear cache
- Visit a information page, or any type that allows for campaigns to be added to the Resource sidebar
- Confirm that the text is no longer cutoff

Note:
- Edit any campaign about sections to make sure the first about paragraph fits in the character limits.