### PR TITLE
Enable form.io submission editing on form pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,4 @@ Thumbs.db
 
 /drush/drush.yml
 .lando.local.yml
+node_modules

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -197,6 +197,14 @@
 
     time = Date.now()
     var dataSource = el.getAttribute('data-source')
+    var params = new URL(location).searchParams
+    if (params.submission) {
+      dataSource += `/submission/${params.submission}`
+      // options.saveDraft = true
+      Formio.setUser({
+        _id: '123'
+      })
+    }
     Formio.createForm(el, dataSource, options)
       .then(function(form) {
         amp('form.load', { load_time: Date.now() - time })

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -198,12 +198,8 @@
     time = Date.now()
     var dataSource = el.getAttribute('data-source')
     var params = new URL(location).searchParams
-    if (params.submission) {
-      dataSource += `/submission/${params.submission}`
-      // options.saveDraft = true
-      Formio.setUser({
-        _id: '123'
-      })
+    if (params.submission_id) {
+      dataSource += `/submission/${params.submission_id}`
     }
     Formio.createForm(el, dataSource, options)
       .then(function(form) {

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -197,9 +197,11 @@
 
     time = Date.now()
     var dataSource = el.getAttribute('data-source')
-    var params = new URL(location).searchParams
-    if (params.submission_id) {
-      dataSource += `/submission/${params.submission_id}`
+    let url = new URL(location)
+    var params = new URLSearchParams(url.search)
+    let submission_id = params.get('submission_id')
+    if (submission_id) {
+      dataSource += `/submission/${submission_id}`
     }
     Formio.createForm(el, dataSource, options)
       .then(function(form) {

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -197,11 +197,10 @@
 
     time = Date.now()
     var dataSource = el.getAttribute('data-source')
-    let url = new URL(location)
-    var params = new URLSearchParams(url.search)
-    let submission_id = params.get('submission_id')
-    if (submission_id) {
-      dataSource += `/submission/${submission_id}`
+    var params = new URL(location).searchParams
+    var submissionId = params.get('submission_id')
+    if (submissionId) {
+      dataSource += `/submission/${submissionId}`
     }
     Formio.createForm(el, dataSource, options)
       .then(function(form) {

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -198,7 +198,7 @@
     time = Date.now()
     var dataSource = el.getAttribute('data-source')
     var params = new URL(location).searchParams
-    var submissionId = params.get('submission_id')
+    var submissionId = params.get('submission')
     if (submissionId) {
       dataSource += `/submission/${submissionId}`
     }


### PR DESCRIPTION
For PUBX-313, this update to our form.io template to editing previously submitted form.io submissions. Here's how it works:

1. When we create a form in form.io, we add a button that triggers saving the submission as a draft
1. We receive a webhook with the submission id (`_id`, specifically) and send a draft confirmation email with a "magic link"  to the form's URL appended with `?submission={{ _id }}` in the email template
1. If the form page finds a `submission` query string parameter, it appends `/submission/{submission}` to the form URL, which tells form.io to load that submission for editing

You can see how this works in [the original CodePen](https://codepen.io/shawnbot/pen/zYayWNa) and @fwextensions's [CodePen](https://codepen.io/fwextensions/pen/XWxeNNq?submission_id=64532608441c66b7bca0c731&form_id=oocEquityIncubator).

### Future enhancements
* We've discussed preventing submission edits if they're not marked explicitly as a "draft", but can't do this until we agree on what (data-wise) distinguishes a draft submission from a completed one.
* We've decided not to add support for the `page` query string parameter in this PR, but may do so in a future pass.
