### PR TITLE
[SG-1916] -- Fix alert background color on vaccine-site page

### DIFF
--- a/web/themes/custom/sfgovpl/templates/components/alert.twig
+++ b/web/themes/custom/sfgovpl/templates/components/alert.twig
@@ -4,6 +4,8 @@
   {% set bgClass = 'bg-blue-2' %}
 {% elseif style == 'critical' %}
   {% set bgClass = 'bg-red-3 text-white' %}
+{% elseif style == 'warning' %}
+  {% set bgClass = 'bg-yellow-3' %}
 {% endif %}
 
 {% set dsClasses = [

--- a/web/themes/custom/sfgovpl/templates/components/vaccine/vaccine-widget--alert.twig
+++ b/web/themes/custom/sfgovpl/templates/components/vaccine/vaccine-widget--alert.twig
@@ -6,7 +6,7 @@
 
 {% include '@theme/alert.twig' with {
   date_exp: 'now'|date('Y-m-d'),
-  style: 'department',
+  style: style ?? 'department',
   content: {
     field_alert_text: text
   }

--- a/web/themes/custom/sfgovpl/templates/misc/vaccine-widget.html.twig
+++ b/web/themes/custom/sfgovpl/templates/misc/vaccine-widget.html.twig
@@ -3,14 +3,16 @@
 {{ attach_library('sfgov_vaccine/location') }}
 
 {% include '@theme/vaccine/vaccine-widget--header.twig' %}
-{% include '@theme/vaccine/vaccine-widget--alert.twig' %}
+{% include '@theme/vaccine/vaccine-widget--alert.twig' with {
+  style: 'warning'
+} %}
 {% include '@theme/vaccine/vaccine-widget--filters.twig' %}
 
 <!-- Microservice info. {{ api_data.api_url }} {{ api_data.timestamp }} -->
 <div class="sfgov-full-bleed vaccine-filter__body py-20">
   <div class="sfgov-section-container">
     {% include '@theme/vaccine/vaccine-widget--count.twig' %}
-    <div class="group--right mb-60"></div>
+    <div class="group--right mb-60 p-0"></div>
     <div class="group--left mb-60">
       {{ api_data.error }}
       {% include '@theme/vaccine/vaccine-widget--sites.twig' %}


### PR DESCRIPTION
[SG-1916]

Applied yellow background to the alert for the /vaccine-site page

[SG-1916]: https://sfgovdt.jira.com/browse/SG-1916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ