### PR TITLE
Expand margin + padding utility class greedy pattern

### DIFF
--- a/web/themes/custom/sfgovpl/purgecss.config.js
+++ b/web/themes/custom/sfgovpl/purgecss.config.js
@@ -9,7 +9,7 @@ module.exports = {
   defaultExtractor: content => content.match(/[\w-:./]+(?<!:)/g) || [],
   safelist: {
     greedy: [
-      // preserve all margin and padding utilities (for forms)
+      // preserve all margin and padding utilities for forms
       /[mp][trblxy]?-\d+/,
       // background color utilities
       /bg-(black|white|slate|blue|green|red|purple|yellow|grey)/,

--- a/web/themes/custom/sfgovpl/purgecss.config.js
+++ b/web/themes/custom/sfgovpl/purgecss.config.js
@@ -9,8 +9,8 @@ module.exports = {
   defaultExtractor: content => content.match(/[\w-:./]+(?<!:)/g) || [],
   safelist: {
     greedy: [
-      // preserve all "basic" margin and padding utilities (for forms)
-      /\b[mp][trblxy]?-\d+/,
+      // preserve all margin and padding utilities (for forms)
+      /[mp][trblxy]?-\d+/,
       // background color utilities
       /bg-(black|white|slate|blue|green|red|purple|yellow|grey)/,
       // text color utilities


### PR DESCRIPTION
@nlsfds noted in Slack that the `p-40` utility class isn't currently working on forms. I checked the live CSS and confirmed that there's no `.p-40` declaration, so I _think_ what we need to do is loosen up the greedy list pattern in our PurgeCSS config, but I'd like to test it with the form page in question.