### PR TITLE
Upgrade formio-sfds to v10.0.0

### DIFF
--- a/config/sfgov_formio.settings.yml
+++ b/config/sfgov_formio.settings.yml
@@ -1,3 +1,3 @@
 formio_version: 4.13.2
-formio_sfds_version: 9.2.7
+formio_sfds_version: 10.0.0
 formio_translations_api_url: 'https://formio-sfds.herokuapp.com/api/strings?format=drupal&formUrl=[form_url]'


### PR DESCRIPTION
This is primarily a CSS maintenance release to work around issues with this repo's purge-css safelist not working as expected. There are breaking changes, but they're downstream and will only affect individual forms with outdated utility classes. See the [release notes](https://github.com/SFDigitalServices/formio-sfds/releases/tag/v10.0.0) for more info.

@aekong FYI, I've already updated the [form.io config](https://sf.gov/admin/config/services/sfgov_formio) on sf.gov 🪄 