### PR TITLE
SG-1681 -- Highlight pull quotes (blockquote) on the body field of report nodes

### DIFF
--- a/web/themes/custom/sfgovpl/src/sass/_mixins.scss
+++ b/web/themes/custom/sfgovpl/src/sass/_mixins.scss
@@ -155,6 +155,17 @@
   }
 }
 
+@mixin blockquote-full {
+  @include blockquote;
+  line-height: 2rem;
+  @include media($narrow-screen) {
+    @include fs-big-description;
+    clear: unset;
+    float: unset;
+    width: 100%;
+  }
+}
+
 @mixin button {
   background: $c-bright-blue;
   border-radius: 8px;

--- a/web/themes/custom/sfgovpl/src/sass/node/_node-report.scss
+++ b/web/themes/custom/sfgovpl/src/sass/node/_node-report.scss
@@ -235,6 +235,10 @@
         display: block;
       }
     }
+
+    blockquote {
+      @include blockquote-full;
+    }
   }
 
   .toc-responsive {


### PR DESCRIPTION
SG-1681

Highlight pull quotes (blockquote) on the body field of report nodes.

Instructions:
- Clear cache
- Add a quote to a test report node or find an existing report node with an existing blockquote
- Confirm style change