### PR TITLE
[SG: 1941] -- Adjust paragraph spacing in Meetings:Things to know items on Agency/Department pages

### DIFF
--- a/web/themes/custom/sfgovpl/src/sass/node/_node-dept.scss
+++ b/web/themes/custom/sfgovpl/src/sass/node/_node-dept.scss
@@ -7,6 +7,16 @@
     padding: 0;
   }
 
+  .meeting__thing-to-know {
+    p {
+      margin-bottom: 1rem;
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
+  }
+
   // more link
   .more-link {
     a {

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--thing-to-know--department-paragraph.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--thing-to-know--department-paragraph.html.twig
@@ -40,10 +40,7 @@
 #}
 {%
   set classes = [
-    'paragraph',
-    'paragraph--type--' ~ paragraph.bundle|clean_class,
-    view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
-    not paragraph.isPublished() ? 'paragraph--unpublished'
+    'meeting__thing-to-know',
   ]|merge(classes|default([]))
 %}
 
@@ -52,7 +49,7 @@
 
 {% block paragraph %}
   {% if title is not empty and text is not empty %}
-    <div>
+    <div{{ attributes.addClass(classes) }}>
       {% if title is not empty %}
         <p class="p-0 m-0 mb-8 font-medium lg:text-title-xs">{{ title }}</p>
       {% endif %}


### PR DESCRIPTION
SG-1941

New class and css applied to Things to know items on agency pages

Instructions:
- Clear cache
- Visit an agency with a meetings section and things to know items
- Confirm that paragraphs have better spacing between them. May have to add test content to fully test.