### PR TITLE
[SG: 1929] -- Add separating borders to table headers

### DIFF
--- a/web/themes/custom/sfgovpl/src/sass/components/_table.scss
+++ b/web/themes/custom/sfgovpl/src/sass/components/_table.scss
@@ -14,9 +14,21 @@
     background: $c-slate;
     color: $c-white;
     text-align: left;
+
+    // First row header
+    tr {
+      th {
+        border-right: 1px solid $c-white;
+        border-bottom: 1px solid $c-white;
+        &:last-child {
+          border-right: 0;
+        }
+      }
+    }
   }
 
   th {
+
     @include fs-body-bold;
     padding: 15px 20px;
 
@@ -41,6 +53,15 @@
   }
 
   tbody {
+
+    // First column header
+    tr {
+      th {
+        border-right: 1px solid white;
+        border-bottom: 1px solid white;
+      }
+    }
+
     td {
       border-color: $c-slate;
       border-style: solid;


### PR DESCRIPTION
SG-1929

Add borders to both row headers and column headers for tables in wysiwgs

Instructions:
- Clear cache
- Visit page or create page with a table. Make sure headers are added to the table.
- Confirm style updates