### PR TITLE
[SG-1928] -- Set Sf.gov to respect prefers "reduced" motion/animation.

### DIFF
--- a/web/modules/custom/sfgov_doc_html/js/docsearch.js
+++ b/web/modules/custom/sfgov_doc_html/js/docsearch.js
@@ -93,12 +93,13 @@
       }
 
       function jumpToMatch(index) {
+        let animationSpeed = window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 0 : 500;
         const $el = $('mark').eq( (index == 0) ? index : index - 1 );
         $('mark').removeClass('current');
         $el.addClass('current');
         $('html, body').stop().animate({
           scrollTop: $el.offset().top - 100
-        }, 500);
+        }, animationSpeed);
       }
 
       function resultsInfo() {

--- a/web/modules/custom/sfgov_doc_html/js/docsearch.js
+++ b/web/modules/custom/sfgov_doc_html/js/docsearch.js
@@ -93,7 +93,7 @@
       }
 
       function jumpToMatch(index) {
-        let animationSpeed = window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 0 : 500;
+        const animationSpeed = window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 0 : 500;
         const $el = $('mark').eq( (index == 0) ? index : index - 1 );
         $('mark').removeClass('current');
         $el.addClass('current');

--- a/web/modules/custom/sfgov_vaccine/js/filter_sites.js
+++ b/web/modules/custom/sfgov_vaccine/js/filter_sites.js
@@ -252,7 +252,7 @@
       // Scroll to Top.
       function scrollUp (speed) {
         // Set animation speed based on motion preference.
-        let animationSpeed = window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 0 : speed;
+        const animationSpeed = window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 0 : speed;
         const newPosition = sectionCount.offset().top - 150
         $('html, body').animate({ scrollTop: newPosition }, animationSpeed)
       }

--- a/web/modules/custom/sfgov_vaccine/js/filter_sites.js
+++ b/web/modules/custom/sfgov_vaccine/js/filter_sites.js
@@ -251,8 +251,10 @@
 
       // Scroll to Top.
       function scrollUp (speed) {
+        // Set animation speed based on motion preference.
+        let animationSpeed = window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 0 : speed;
         const newPosition = sectionCount.offset().top - 150
-        $('html, body').animate({ scrollTop: newPosition }, speed)
+        $('html, body').animate({ scrollTop: newPosition }, animationSpeed)
       }
 
       function getSiteData (el) {

--- a/web/modules/custom/sfgov_vaccine/js/filter_sites.js
+++ b/web/modules/custom/sfgov_vaccine/js/filter_sites.js
@@ -252,7 +252,7 @@
       // Scroll to Top.
       function scrollUp (speed) {
         // Set animation speed based on motion preference.
-        const animationSpeed = window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 0 : speed;
+        const animationSpeed = window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 0 : speed
         const newPosition = sectionCount.offset().top - 150
         $('html, body').animate({ scrollTop: newPosition }, animationSpeed)
       }

--- a/web/themes/custom/sfgovpl/src/js/back-to-top.js
+++ b/web/themes/custom/sfgovpl/src/js/back-to-top.js
@@ -10,7 +10,7 @@
     attach: function (context) {
 
       // Set animation speed based on motion preference.
-      let animationSpeed = window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 0 : 300;
+      const animationSpeed = window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 0 : 300;
 
       $('#back-to-top', context).on('click', e => {
         e.preventDefault()

--- a/web/themes/custom/sfgovpl/src/js/back-to-top.js
+++ b/web/themes/custom/sfgovpl/src/js/back-to-top.js
@@ -8,13 +8,12 @@
 (function ($, Drupal) {
   Drupal.behaviors.backToTop = {
     attach: function (context) {
-
       // Set animation speed based on motion preference.
-      const animationSpeed = window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 0 : 300;
+      const animationSpeed = window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 0 : 300
 
       $('#back-to-top', context).on('click', e => {
         e.preventDefault()
-        $('html, body', context).animate({scrollTop: 0}, animationSpeed)
+        $('html, body', context).animate({ scrollTop: 0 }, animationSpeed)
       })
 
       $(window, context).on('load', () => {

--- a/web/themes/custom/sfgovpl/src/js/back-to-top.js
+++ b/web/themes/custom/sfgovpl/src/js/back-to-top.js
@@ -7,10 +7,14 @@
  */
 (function ($, Drupal) {
   Drupal.behaviors.backToTop = {
-    attach (context) {
+    attach: function (context) {
+
+      // Set animation speed based on motion preference.
+      let animationSpeed = window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 0 : 300;
+
       $('#back-to-top', context).on('click', e => {
         e.preventDefault()
-        $('html, body', context).animate({ scrollTop: 0 }, '300')
+        $('html, body', context).animate({scrollTop: 0}, animationSpeed)
       })
 
       $(window, context).on('load', () => {
@@ -20,8 +24,7 @@
           now = $(window, context).scrollTop()
           if (then > now && now > 700) {
             $('#back-to-top').addClass('show')
-          }
-          else {
+          } else {
             $('#back-to-top').removeClass('show')
           }
           then = now

--- a/web/themes/custom/sfgovpl/src/js/data-story.js
+++ b/web/themes/custom/sfgovpl/src/js/data-story.js
@@ -48,6 +48,9 @@
       const $anchors = $toc.find('a')
       const $content = $('.sfgov-section--content', context)
 
+      // Set animation speed based on motion preference.
+      const animationSpeed = window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 0 : 1000;
+
       const locationPath = filterPath(location.pathname)
       $anchors.each(function () {
         const thisPath = filterPath(this.pathname) || locationPath
@@ -58,7 +61,7 @@
             if (target) {
               $(this).click(event => {
                 event.preventDefault()
-                $('html, body').animate({ scrollTop: $target.offset().top }, 1000, () => {
+                $('html, body').animate({ scrollTop: $target.offset().top }, animationSpeed, () => {
                   location.hash = target
                   $target.focus()
                   if ($target.is(':focus')) {

--- a/web/themes/custom/sfgovpl/src/js/data-story.js
+++ b/web/themes/custom/sfgovpl/src/js/data-story.js
@@ -49,7 +49,7 @@
       const $content = $('.sfgov-section--content', context)
 
       // Set animation speed based on motion preference.
-      const animationSpeed = window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 0 : 1000;
+      const animationSpeed = window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 0 : 1000
 
       const locationPath = filterPath(location.pathname)
       $anchors.each(function () {

--- a/web/themes/custom/sfgovpl/src/js/dept-homepage.js
+++ b/web/themes/custom/sfgovpl/src/js/dept-homepage.js
@@ -1,8 +1,7 @@
 (function ($) {
   $('body.page-node-type-department').each(() => {
-
     // Set animation speed based on motion preference.
-    const animationSpeed = window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 0 : 300;
+    const animationSpeed = window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 0 : 300
 
     // an array of selectors for the dept homepage sections
     const sections = [

--- a/web/themes/custom/sfgovpl/src/js/dept-homepage.js
+++ b/web/themes/custom/sfgovpl/src/js/dept-homepage.js
@@ -1,5 +1,9 @@
 (function ($) {
   $('body.page-node-type-department').each(() => {
+
+    // Set animation speed based on motion preference.
+    const animationSpeed = window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 0 : 300;
+
     // an array of selectors for the dept homepage sections
     const sections = [
       { selector: '#sfgov-dept-services', label: 'Services' },
@@ -15,7 +19,7 @@
     const scrollTo = function (elemSelector) {
       $scrollElem.animate({
         scrollTop: $(elemSelector).offset().top
-      }, 300)
+      }, animationSpeed)
       return false
     }
 

--- a/web/themes/custom/sfgovpl/src/js/toc.js
+++ b/web/themes/custom/sfgovpl/src/js/toc.js
@@ -52,6 +52,9 @@
       const $anchors = $toc.find('a')
       const $content = $('.sfgov-section--content', context)
 
+      // Set animation speed based on motion preference.
+      const animationSpeed = window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 0 : 1000;
+
       const locationPath = filterPath(location.pathname)
       $anchors.each(function () {
         const thisPath = filterPath(this.pathname) || locationPath
@@ -62,7 +65,7 @@
             if (target) {
               $(this).click(event => {
                 event.preventDefault()
-                $('html, body').animate({ scrollTop: $target.offset().top }, 1000, () => {
+                $('html, body').animate({ scrollTop: $target.offset().top }, animationSpeed, () => {
                   location.hash = target
                   $target.focus()
                   if ($target.is(':focus')) {

--- a/web/themes/custom/sfgovpl/src/js/toc.js
+++ b/web/themes/custom/sfgovpl/src/js/toc.js
@@ -53,7 +53,7 @@
       const $content = $('.sfgov-section--content', context)
 
       // Set animation speed based on motion preference.
-      const animationSpeed = window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 0 : 1000;
+      const animationSpeed = window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 0 : 1000
 
       const locationPath = filterPath(location.pathname)
       $anchors.each(function () {

--- a/web/themes/custom/sfgovpl/src/sass/_base.scss
+++ b/web/themes/custom/sfgovpl/src/sass/_base.scss
@@ -1,6 +1,16 @@
 /* purgecss start ignore */
 html {
   font-size: $base-font-size * 1px;
+  scroll-behavior: smooth;
+}
+
+/**
+ * Disable smooth scrolling when users have prefers-reduced-motion enabled.
+ */
+@media screen and (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
 }
 
 *,

--- a/web/themes/custom/sfgovpl/src/sass/_search.scss
+++ b/web/themes/custom/sfgovpl/src/sass/_search.scss
@@ -13,7 +13,7 @@
   box-shadow: rgba(0,0,0,.25) 0px 5px 5px 2px;
   text-align: left;
   border-radius: 0 0 8px 8px;
-  @include media($medium-screen) {  
+  @include media($medium-screen) {
     width: calc(100% - 129px);
   }
 }
@@ -127,10 +127,10 @@
       }
     }
     @include media($medium-screen) {
-      
+
     }
   }
-  
+
   .sfgov-search-misspelled {
     @include fs-title-5;
     margin-bottom: 20px;
@@ -166,7 +166,7 @@
           position: relative;
         }
       }
-  
+
       .next {
         a {
           &::after {
@@ -181,7 +181,7 @@
           }
         }
       }
-  
+
       .previous {
         a {
           margin-left: 0;
@@ -201,7 +201,7 @@
           }
         }
       }
-  
+
       .page-num {
         &.more-prev::before,
         &.more-next::after {
@@ -209,7 +209,7 @@
           color: $c-slate;
         }
       }
-  
+
       ul {
         list-style-type: none;
         padding: 0;
@@ -334,6 +334,11 @@
 .loader[data-text][data-blink]:before{
   animation:blink 1s linear infinite alternate
 }
+@media (prefers-reduced-motion: reduce) {
+  .loader[data-text][data-blink]:before{
+    animation:none;
+  }
+}
 .loader-default[data-text]:before{
   top:calc(50% - 63px)
 }
@@ -354,6 +359,11 @@
 }
 .loader-default[data-inverse]:after{
   animation-direction:reverse
+}
+@media (prefers-reduced-motion: reduce) {
+  .loader-default:after{
+    animation:none;
+  }
 }
 // end loading css
 /* purgecss end ignore */

--- a/web/themes/custom/sfgovpl/templates/components/header.twig
+++ b/web/themes/custom/sfgovpl/templates/components/header.twig
@@ -4,7 +4,7 @@
       {{ [page.header.sfgovpl_branding] }}
       <div class="head-right--container">
         {# <button class="sfgov-mobile-translate sfgov-mobile-nav-btn"></button> #}
-        <button class="sfgov-mobile-search sfgov-mobile-nav-btn"></button>
+        <button class="sfgov-mobile-search sfgov-mobile-nav-btn" aria-label="Search"></button>
         <button class="sfgov-menu-btn sfgov-mobile-nav-btn">Menu</button>
         {{ [page.header.sfgovpl_main_menu, page.header.gtranslate, page.header.sfgovsearchblock] }}
       </div>


### PR DESCRIPTION
SG-1928

Set animation in all theme and custom module javascript to first determine if motion is reduced, and then set animation speeds accordingly.

Set most animations in css to try to respect reduced motion. Not sure if all animations have been found.

Instructions
- Clear cache
- Review "back to top" functionality and "table of content jumping" on reports (and any other node type with table of content menus.
- Set your OS to reduce motion/animation.
- Review previous functionality again and confirm its following the OS settings.