### PR TITLE
[SG-1944] -- Update the label/help text for Direct external link field.

### DIFF
--- a/config/field.field.node.department.field_direct_external_url.yml
+++ b/config/field.field.node.department.field_direct_external_url.yml
@@ -6,21 +6,17 @@ dependencies:
     - field.storage.node.field_direct_external_url
     - node.type.department
   module:
-    - datalayer
     - link
     - tmgmt_content
 third_party_settings:
-  datalayer:
-    expose: 0
-    label: field_direct_external_url
   tmgmt_content:
     excluded: false
 id: node.department.field_direct_external_url
 field_name: field_direct_external_url
 entity_type: node
 bundle: department
-label: 'Direct External Link'
-description: ''
+label: 'Redirect this page to'
+description: 'Type in an SF.gov page title to look up, or enter an external URL.'
 required: false
 translatable: true
 default_value: {  }

--- a/config/field.field.node.news.field_direct_external_url.yml
+++ b/config/field.field.node.news.field_direct_external_url.yml
@@ -7,12 +7,16 @@ dependencies:
     - node.type.news
   module:
     - link
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
 id: node.news.field_direct_external_url
 field_name: field_direct_external_url
 entity_type: node
 bundle: news
-label: 'Direct External Link'
-description: 'Link to news on another City website (no external news).'
+label: 'Redirect this page to'
+description: 'Link to news on another City website (no external news). Type in an SF.gov page title to look up, or enter an external URL.'
 required: false
 translatable: true
 default_value: {  }

--- a/config/field.field.node.person.field_direct_external_url.yml
+++ b/config/field.field.node.person.field_direct_external_url.yml
@@ -7,12 +7,16 @@ dependencies:
     - node.type.person
   module:
     - link
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
 id: node.person.field_direct_external_url
 field_name: field_direct_external_url
 entity_type: node
 bundle: person
-label: 'Direct External URL'
-description: ''
+label: 'Redirect this page to'
+description: 'Type in an SF.gov page title to look up, or enter an external URL.'
 required: false
 translatable: true
 default_value: {  }

--- a/config/field.field.node.transaction.field_direct_external_url.yml
+++ b/config/field.field.node.transaction.field_direct_external_url.yml
@@ -7,12 +7,16 @@ dependencies:
     - node.type.transaction
   module:
     - link
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
 id: node.transaction.field_direct_external_url
 field_name: field_direct_external_url
 entity_type: node
 bundle: transaction
-label: 'Direct External URL'
-description: ''
+label: 'Redirect this page to'
+description: 'Type in an SF.gov page title to look up, or enter an external URL.'
 required: false
 translatable: true
 default_value: {  }


### PR DESCRIPTION
SG-1944

Updated the label and help text for the "Direct external link" field to be: label: Redirect this page to
help text: (Any pre-existing text). Type in an SF.gov page title to look up, or enter an external URL.

Instructions:
- Clear cache
- Config import
- Visit an Agency, News, Profile and Transaction node to confirm the field label change.