### PR TITLE
[SG-1945] -- Report node wysiwyg should not allow H1 tags

### DIFF
--- a/web/modules/custom/sfgov_utilities/sfgov_utilities.module
+++ b/web/modules/custom/sfgov_utilities/sfgov_utilities.module
@@ -510,3 +510,17 @@ function sfgov_utilities_create_alias($internal_path, $alias_to_generate, string
     }
   }
 }
+
+/**
+ * Implements hook_editor_js_settings_alter().
+ */
+function sfgov_utilities_editor_js_settings_alter(array &$settings) {
+
+  // Future modifications of Ckeditor output can be controlled here.
+  foreach (array_keys($settings['editor']['formats']) as $text_format) {
+    if ($text_format == 'sf_full_html_with_toc') {
+      // Limit the format tags available for sf_full_html_with_toc.
+      $settings['editor']['formats'][$text_format]['editorSettings']['format_tags'] = "p;h2;h3;h4;h5;h6";
+    }
+  }
+}


### PR DESCRIPTION
SG-1945

Programmatically removed option for H1 tags to be allowed in Report node wysiwygs. That particular wysiwyg uses the sf_full_html_with_toc format. Setup will allow for future tweaking on other formats if needed.

Instructions:
- Clear cache
- Create a new report or visit an existing one
- Confirm that H1's are not allowed in the wysiwyg.