### PR TITLE
[SG-1946] -- Service section accordions need to be bold on mobile

### DIFF
--- a/web/themes/custom/sfgovpl/purgecss.config.js
+++ b/web/themes/custom/sfgovpl/purgecss.config.js
@@ -14,9 +14,7 @@ module.exports = {
       // background color utilities
       /bg-(black|white|slate|blue|green|red|purple|yellow|grey)/,
       // text color utilities
-      /text-(black|white|slate|blue|green|red|purple|yellow|grey|secondary)/,
-      // font-weight utilities
-      /font-(medium|light|regular)/
+      /text-(black|white|slate|blue|green|red|purple|yellow|grey|secondary)/
     ]
   }
 }

--- a/web/themes/custom/sfgovpl/purgecss.config.js
+++ b/web/themes/custom/sfgovpl/purgecss.config.js
@@ -14,7 +14,9 @@ module.exports = {
       // background color utilities
       /bg-(black|white|slate|blue|green|red|purple|yellow|grey)/,
       // text color utilities
-      /text-(black|white|slate|blue|green|red|purple|yellow|grey|secondary)/
+      /text-(black|white|slate|blue|green|red|purple|yellow|grey|secondary)/,
+      // font-weight utilities
+      /font-(medium|light|regular)/
     ]
   }
 }

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--department-service-section.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--department-service-section.html.twig
@@ -59,7 +59,9 @@
   <div {{ attributes.addClass(classes) }}>
     {% block content %}
     {% if content.field_dept_service_section_title %}
-      <h3 class="m-0 mb-20 font-regular text-big-desc lg:text-big-desc-desktop">{{ content.field_dept_service_section_title }}</h3>
+      <h3 class="m-0 mb-20 font-medium lg:font-regular text-big-desc lg:text-big-desc-desktop">
+        {{ content.field_dept_service_section_title }}
+      </h3>
     {% endif %}
       <div class="sfgov-dept-services-section-content grid gap-20 lg:grid-cols-3">
         {{ content.field_dept_service_sect_services }}


### PR DESCRIPTION
SG-1946

On mobile display, the accordions in service sections, like on departments/agencies and topics, need to be bolder (font: 600) Changed tailwind config to allow for versions of font-regular, font-medium, and font-light for different breakpoints.

Instructions:
- clear cache
- visit a topic or department/agency with a service section (with accordions) and confirm that styling is working.