### PR TITLE
[SG: 1902] -- Remove Agency section divisions and subcommittees if the section title is set to None

### DIFF
--- a/config/field.field.node.department.field_agency_sections.yml
+++ b/config/field.field.node.department.field_agency_sections.yml
@@ -21,7 +21,7 @@ field_name: field_agency_sections
 entity_type: node
 bundle: department
 label: 'Divisions or subcommittees'
-description: 'Choose if your department has Divisions or Subcommittees under this agency. This parent agency will be listed as “part of” on any division and subcommittee landing pages. Only add agencies that are under your agency.'
+description: 'Choose if your department has Divisions or Subcommittees under this agency. This parent agency will be listed as “part of” on any division and subcommittee landing pages. Only add agencies that are under your agency. If “Section title“ is set to “- None -“, any previously assigned Agency Divisions and Subcommittees will be removed.'
 required: false
 translatable: false
 default_value: {  }

--- a/web/modules/custom/sfgov_departments/sfgov_departments.module
+++ b/web/modules/custom/sfgov_departments/sfgov_departments.module
@@ -242,6 +242,10 @@ function sfgov_departments_form_node_department_edit_form_alter(&$form, FormStat
   ];
 
   $form['#validate'][] = '_sfgov_departments_dept_req_public_records_form_validate';
+
+  // Get this submit handler to run first to alter the agency values before
+  // default processing.
+  array_unshift($form['actions']['submit']['#submit'], '_sfgov_departments_agency_sections_alter_submit');
 }
 
 /**
@@ -283,6 +287,31 @@ function _sfgov_departments_dept_req_public_records_form_validate($form, FormSta
       $form_state->setErrorByName("field_req_public_records_phone", t('Public records phone is required if request type is set to Phone.'));
     }
   }
+}
+
+/**
+ * Custom submit handler to remove agency sections if no label.
+ *
+ * @param array $form
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ */
+function _sfgov_departments_agency_sections_alter_submit(&$form, FormStateInterface $form_state) {
+  $values = $form_state->getValues();
+  $label = $values['field_agency_sections'][0]['subform']['field_section_title_list'];
+
+  // If the section title is set to "None"
+  if (empty($label) || $label[0]['value'] == '_none') {
+
+    foreach ($values['field_agency_sections'][0]['subform']['field_agencies'] as $id => $item) {
+      // Remove each agency from the agency section.
+      if (is_numeric($id)) {
+        unset($values['field_agency_sections'][0]['subform']['field_agencies'][$id]);
+      }
+    }
+  }
+
+  // Reset the form values with the removed agencies.
+  $form_state->setValues($values);
 }
 
 /**


### PR DESCRIPTION
SG-1902

If the Agency section title is set to "None", then on save of the agency, any divisions and subcommittee values will be removed from the node.

Instructions:
- Clear cache
- Visit an agency node
- If it has Agency divisions or subcommittees, then set the agency section title to None.
- Save the node, and then go back to the Edit page for the node.
- Confirm that any divisions and subcommittees are removed from the Agency section.