### PR TITLE
SG-1958 - profile missing agency reference

### DIFF
--- a/web/modules/custom/sfgov_profiles/sfgov_profiles.module
+++ b/web/modules/custom/sfgov_profiles/sfgov_profiles.module
@@ -201,11 +201,6 @@ function sortProfilePositions($positions) {
 }
 
 function updateProfileNode($position, $removed = false) {
-  // check the agency id. if it's a department, skip it
-  if ((Node::load($position['agencyNid']))->bundle() !== 'public_body') {
-    return;
-  }
-
   // load profile node
   if (!empty($position['profileNid'])) {
     $profile = Node::load($position['profileNid']);

--- a/web/themes/custom/sfgovpl/templates/field/field--node--field-profile-positions-held.html.twig
+++ b/web/themes/custom/sfgovpl/templates/field/field--node--field-profile-positions-held.html.twig
@@ -47,8 +47,6 @@
   {% set positionStart = paragraph.field_starting_year.value %}
   {% set positionEnd = paragraph.field_ending_year.value %}
 
-  {# {{ kint(paragraph.field_department.entity.label|view) }} #}
-
   {% if profileType|lower == 'city employee' %}
     <div class="profile--additional-role">
       {% if positionTitle is not empty %}


### PR DESCRIPTION
SG-1958

When public body was converted to agency, profiles lost the Profile group sync.  This pr removes the the restriction.