### PR TITLE
[SG-1955] -- Don't display events on agencies/topics if no upcoming and no past events

### DIFF
--- a/web/themes/custom/sfgovpl/templates/node/node--department--full.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--department--full.html.twig
@@ -201,16 +201,33 @@
   {% endif %}
 
   {% set events_view = drupal_view('events', 'block_1', node.id)|render %}
+  {% set has_events = drupal_view_result('events', 'block_1', node.id) %}
+  {% set has_past_events = drupal_view_result('events', 'page_6', node.id) %}
+  {% set event_heading = 'Events'|t({}, {'context' : 'Agency event section heading'})  %}
+  {% if has_events is empty and has_past_events is not empty%}
     <div class="odd:bg-grey-1 py-40 lg:py-60">
       <div class="responsive-container">
-        {% if drupal_view_result('events', 'block_1', node.id) is empty %}
-          <h2 class="text-title-xl m-0 mb-40 lg:text-title-xl-desktop">Events</h2>
-          <p>There are no upcoming events right now.</p>
-          <br>
-        {% endif %}
+        <h2 class="text-title-xl m-0 mb-40 lg:text-title-xl-desktop">{{ event_heading }}</h2>
+        <p>There are no upcoming events right now.</p>
+        <br>
         {{ events_view }}
       </div>
     </div>
+  {% elseif has_events is empty and has_past_events is empty %}
+    <div class="odd:bg-grey-1 py-40 lg:py-60">
+      <div class="responsive-container">
+        <h2 class="text-title-xl m-0 mb-40 lg:text-title-xl-desktop">{{ event_heading }}</h2>
+        <p>There are no upcoming events right now.</p>
+        <br>
+      </div>
+    </div>
+  {% elseif has_events is not empty %}
+    <div class="odd:bg-grey-1 py-40 lg:py-60">
+      <div class="responsive-container">
+        {{ events_view }}
+      </div>
+    </div>
+  {% endif %}
 
   {% set hasAboutSection = "false" %}
   {% set hasAgencySection = division_list|length > 0 %}

--- a/web/themes/custom/sfgovpl/templates/node/node--department--full.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--department--full.html.twig
@@ -213,14 +213,6 @@
         {{ events_view }}
       </div>
     </div>
-  {% elseif has_events is empty and has_past_events is empty %}
-    <div class="odd:bg-grey-1 py-40 lg:py-60">
-      <div class="responsive-container">
-        <h2 class="text-title-xl m-0 mb-40 lg:text-title-xl-desktop">{{ event_heading }}</h2>
-        <p>There are no upcoming events right now.</p>
-        <br>
-      </div>
-    </div>
   {% elseif has_events is not empty %}
     <div class="odd:bg-grey-1 py-40 lg:py-60">
       <div class="responsive-container">

--- a/web/themes/custom/sfgovpl/templates/node/node--topic--full-template-1.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--topic--full-template-1.html.twig
@@ -37,17 +37,34 @@
     </div>
     {% endif %}
 
-    {% set events_view = drupal_view('events', 'events_block_topics')|render %}
-    <div class="sfgov-full-bleed white card-container">
-      <div class="sfgov-section-container">
-        {% if drupal_view_result('events', 'events_block_topics', node.id) is empty %}
-          <h2 class="text-title-xl m-0 mb-40 lg:text-title-xl-desktop">Events</h2>
+    {% set events_view = drupal_view('events', 'events_block_topics', node.id)|render %}
+    {% set has_events = drupal_view_result('events', 'events_block_topics', node.id) %}
+    {% set has_past_events = drupal_view_result('events', 'page_5', node.id) %}
+    {% set event_heading = 'Events'|t({}, {'context' : 'Topic template 1 event section heading'})  %}
+    {% if has_events is empty and has_past_events is not empty%}
+      <div class="sfgov-full-bleed white card-container">
+        <div class="sfgov-section-container">
+          <h2 class="text-title-xl m-0 mb-40 lg:text-title-xl-desktop">{{ event_heading }}</h2>
           <p>There are no upcoming events right now.</p>
           <br>
-        {% endif %}
-        {{ events_view }}
+          {{ events_view }}
+        </div>
       </div>
-    </div>
+    {% elseif has_events is empty and has_past_events is empty %}
+      <div class="sfgov-full-bleed white card-container">
+        <div class="sfgov-section-container">
+          <h2 class="text-title-xl m-0 mb-40 lg:text-title-xl-desktop">{{ event_heading }}</h2>
+          <p>There are no upcoming events right now.</p>
+          <br>
+        </div>
+      </div>
+    {% elseif has_events is not empty %}
+      <div class="sfgov-full-bleed white card-container">
+        <div class="sfgov-section-container">
+          {{ events_view }}
+        </div>
+      </div>
+    {% endif %}
 
     {% if content.field_content['#items'] %}
       <div class="sfgov-full-bleed card-container">

--- a/web/themes/custom/sfgovpl/templates/node/node--topic--full-template-1.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--topic--full-template-1.html.twig
@@ -50,14 +50,6 @@
           {{ events_view }}
         </div>
       </div>
-    {% elseif has_events is empty and has_past_events is empty %}
-      <div class="sfgov-full-bleed white card-container">
-        <div class="sfgov-section-container">
-          <h2 class="text-title-xl m-0 mb-40 lg:text-title-xl-desktop">{{ event_heading }}</h2>
-          <p>There are no upcoming events right now.</p>
-          <br>
-        </div>
-      </div>
     {% elseif has_events is not empty %}
       <div class="sfgov-full-bleed white card-container">
         <div class="sfgov-section-container">

--- a/web/themes/custom/sfgovpl/templates/node/node--topic--full-template-2.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--topic--full-template-2.html.twig
@@ -20,14 +20,6 @@
           {{ events_view }}
         </div>
       </div>
-    {% elseif has_events is empty and has_past_events is empty %}
-      <div class="sfgov-full-bleed white card-container">
-        <div class="sfgov-section-container">
-          <h2 class="text-title-xl m-0 mb-40 lg:text-title-xl-desktop">{{ event_heading }}</h2>
-          <p>There are no upcoming events right now.</p>
-          <br>
-        </div>
-      </div>
     {% elseif has_events is not empty %}
       <div class="sfgov-full-bleed light-green card-container">
         <div class="sfgov-section-container">

--- a/web/themes/custom/sfgovpl/templates/node/node--topic--full-template-2.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--topic--full-template-2.html.twig
@@ -7,17 +7,34 @@
       </div>
     {% endif %}
 
-    {% set events_view = drupal_view('events', 'events_block_topics')|render %}
+    {% set events_view = drupal_view('events', 'events_block_topics', node.id)|render %}
+    {% set has_events = drupal_view_result('events', 'events_block_topics', node.id) %}
+    {% set has_past_events = drupal_view_result('events', 'page_5', node.id) %}
+    {% set event_heading = 'Events'|t({}, {'context' : 'Topic template 2 event section heading'})  %}
+    {% if has_events is empty and has_past_events is not empty%}
       <div class="sfgov-full-bleed light-green card-container">
         <div class="sfgov-section-container">
-        {% if drupal_view_result('events', 'events_block_topics', node.id) is empty %}
-          <h2 class="text-title-xl m-0 mb-40 lg:text-title-xl-desktop">Events</h2>
+          <h2 class="text-title-xl m-0 mb-40 lg:text-title-xl-desktop">{{ event_heading }}</h2>
           <p>There are no upcoming events right now.</p>
           <br>
-        {% endif %}
-        {{ events_view }}
+          {{ events_view }}
         </div>
       </div>
+    {% elseif has_events is empty and has_past_events is empty %}
+      <div class="sfgov-full-bleed white card-container">
+        <div class="sfgov-section-container">
+          <h2 class="text-title-xl m-0 mb-40 lg:text-title-xl-desktop">{{ event_heading }}</h2>
+          <p>There are no upcoming events right now.</p>
+          <br>
+        </div>
+      </div>
+    {% elseif has_events is not empty %}
+      <div class="sfgov-full-bleed light-green card-container">
+        <div class="sfgov-section-container">
+          {{ events_view }}
+        </div>
+      </div>
+    {% endif %}
 
     {% set services_field = content.field_department_services %}
     {% set services_view = services_exclude ? drupal_view('services', 'topics_more_services', node.id, services_exclude) : drupal_view('services', 'block_1') %}

--- a/web/themes/custom/sfgovpl/templates/node/node--topic--full-template-3.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--topic--full-template-3.html.twig
@@ -45,17 +45,34 @@
     </div>
     {% endif %}
 
-    {% set events_view = drupal_view('events', 'events_block_topics')|render %}
+    {% set events_view = drupal_view('events', 'events_block_topics', node.id)|render %}
+    {% set has_events = drupal_view_result('events', 'events_block_topics', node.id) %}
+    {% set has_past_events = drupal_view_result('events', 'page_5', node.id) %}
+    {% set event_heading = 'Events'|t({}, {'context' : 'Topic template 3 event section heading'})  %}
+    {% if has_events is empty and has_past_events is not empty%}
       <div class="sfgov-full-bleed white card-container">
         <div class="sfgov-section-container">
-        {% if drupal_view_result('events', 'events_block_topics', node.id) is empty %}
-          <h2 class="text-title-xl m-0 mb-40 lg:text-title-xl-desktop">Events</h2>
+          <h2 class="text-title-xl m-0 mb-40 lg:text-title-xl-desktop">{{ event_heading }}</h2>
           <p>There are no upcoming events right now.</p>
           <br>
-        {% endif %}
-        {{ events_view }}
+          {{ events_view }}
         </div>
       </div>
+    {% elseif has_events is empty and has_past_events is empty %}
+      <div class="sfgov-full-bleed white card-container">
+        <div class="sfgov-section-container">
+          <h2 class="text-title-xl m-0 mb-40 lg:text-title-xl-desktop">{{ event_heading }}</h2>
+          <p>There are no upcoming events right now.</p>
+          <br>
+        </div>
+      </div>
+    {% elseif has_events is not empty %}
+      <div class="sfgov-full-bleed white card-container">
+        <div class="sfgov-section-container">
+          {{ events_view }}
+        </div>
+      </div>
+    {% endif %}
 
     {% if content.field_content|render is not empty %}
       <div class="sfgov-full-bleed card-container">

--- a/web/themes/custom/sfgovpl/templates/node/node--topic--full-template-3.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--topic--full-template-3.html.twig
@@ -58,14 +58,6 @@
           {{ events_view }}
         </div>
       </div>
-    {% elseif has_events is empty and has_past_events is empty %}
-      <div class="sfgov-full-bleed white card-container">
-        <div class="sfgov-section-container">
-          <h2 class="text-title-xl m-0 mb-40 lg:text-title-xl-desktop">{{ event_heading }}</h2>
-          <p>There are no upcoming events right now.</p>
-          <br>
-        </div>
-      </div>
     {% elseif has_events is not empty %}
       <div class="sfgov-full-bleed white card-container">
         <div class="sfgov-section-container">


### PR DESCRIPTION
SG-1955

Goal:
- If there upcoming events, show the full teaser display with a more events link.
- If there are no upcoming events, but there are past events, display the "No upcoming events" message with the more events link.
- If there are no upcoming or past events, do not display the more events link.

Instructions
- Clear cache
- Review agency and topic nodes, each with confirmed upcoming events, no upcoming and past events, and with neither upcoming or past events.