### PR TITLE
[SG-1935] -- Block/Suppress functionality of TOC from screen readers

### DIFF
--- a/web/modules/custom/sfgov_doc_html/templates/docsearch.html.twig
+++ b/web/modules/custom/sfgov_doc_html/templates/docsearch.html.twig
@@ -11,7 +11,7 @@
 <div{{ attributes.addClass('docsearch') }}>
   <form id="docsearch" role="search" data-search-target="{{ search_target }}">
     <label for="keywords" class="visually-hidden">{{ "Search this page"|t }}</label>
-    <input type="text" id="keywords" name="keywords" spellcheck="false" aria-label="{{ "Enter keywords to search in the report"|t }}" placeholder="{{ "Search this page"|t }}">
+    <input type="text" id="keywords" name="keywords" spellcheck="false" aria-label="{{ "Enter keywords to search in the report"|t }}" placeholder="{{ "Search this page"|t }}" aria-hidden="true" tabindex="-1">
     <div class="results-info">
       <div class="results-index"></div>
       <div class="results-nav">


### PR DESCRIPTION
SG-1935

The TOC isn't contextually useful or helpful for a screen reader. Aria hidden and tabindex of -1 were added to force screen readers to ingnore the input.

Instructions:
- Clear cache
- visit a TOC page, like /reports/november-2021/digital-accessibility-and-inclusion-standard
- try to tab into the TOC form, or activate a screen reader tool and try to keyboard/tab nav into the TOC input. It should be skipped.