### PR TITLE
[SG-1957] -- Set all text in campaign about section to render as white text.

### DIFF
--- a/web/themes/custom/sfgovpl/src/sass/node/_node-campaign.scss
+++ b/web/themes/custom/sfgovpl/src/sass/node/_node-campaign.scss
@@ -63,6 +63,12 @@
           @include fs-big-description;
         }
 
+        h2,
+        h3,
+        h4,
+        h5,
+        h6,
+        p,
         a {
           color: #fff;
         }


### PR DESCRIPTION
SG-1957

Changed css to account for all headings, paragraphs, and links in the campaign about section, and make them all white colored.