### PR TITLE
[SG-1954] -- Add agency filter to meetings content admin view.

### DIFF
--- a/config/views.view.content.yml
+++ b/config/views.view.content.yml
@@ -2616,6 +2616,50 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        field_departments_target_id:
+          id: field_departments_target_id
+          table: node__field_departments
+          field: field_departments_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: sfgov_admin_content_type_filter
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_departments_target_id_op
+            label: 'Related agency'
+            description: ''
+            use_operator: false
+            operator: field_departments_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_departments_target_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              writer: '0'
+              publisher: '0'
+              digital_services: '0'
+              administrator: '0'
+            reduce: 0
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       filter_groups:
         operator: AND
         groups:


### PR DESCRIPTION
SG-1954

Config import and review the meetings tab in the content admin section.