### PR TITLE
[SG-1960] -- Remove "edit" button from address embeds

### DIFF
--- a/config/core.entity_form_display.node.department.default.yml
+++ b/config/core.entity_form_display.node.department.default.yml
@@ -196,7 +196,7 @@ content:
     settings:
       entity_browser: location_physical
       field_widget_display: label
-      field_widget_edit: true
+      field_widget_edit: false
       field_widget_remove: true
       field_widget_replace: false
       open: false

--- a/config/core.entity_form_display.node.event.default.yml
+++ b/config/core.entity_form_display.node.event.default.yml
@@ -87,7 +87,7 @@ content:
     settings:
       entity_browser: location_event_address
       field_widget_display: rendered_entity
-      field_widget_edit: true
+      field_widget_edit: false
       field_widget_remove: true
       field_widget_replace: false
       open: true
@@ -297,6 +297,21 @@ content:
     weight: 11
     region: content
     settings: {  }
+    third_party_settings: {  }
+  translation_notes:
+    type: string_textarea
+    weight: 102
+    region: content
+    settings:
+      rows: 4
+      placeholder: ''
+    third_party_settings: {  }
+  translation_outdated:
+    type: boolean_checkbox
+    weight: 101
+    region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default

--- a/config/core.entity_form_display.node.location.default.yml
+++ b/config/core.entity_form_display.node.location.default.yml
@@ -162,7 +162,7 @@ content:
     settings:
       entity_browser: location_physical
       field_widget_display: rendered_entity
-      field_widget_edit: true
+      field_widget_edit: false
       field_widget_remove: true
       field_widget_replace: false
       open: true
@@ -384,6 +384,21 @@ content:
     weight: 9
     region: content
     settings: {  }
+    third_party_settings: {  }
+  translation_notes:
+    type: string_textarea
+    weight: 102
+    region: content
+    settings:
+      rows: 4
+      placeholder: ''
+    third_party_settings: {  }
+  translation_outdated:
+    type: boolean_checkbox
+    weight: 101
+    region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete

--- a/config/core.entity_form_display.node.meeting.default.yml
+++ b/config/core.entity_form_display.node.meeting.default.yml
@@ -128,7 +128,7 @@ content:
     settings:
       entity_browser: location_physical
       field_widget_display: rendered_entity
-      field_widget_edit: true
+      field_widget_edit: false
       field_widget_remove: true
       field_widget_replace: false
       open: false
@@ -340,6 +340,21 @@ content:
     weight: 14
     region: content
     settings: {  }
+    third_party_settings: {  }
+  translation_notes:
+    type: string_textarea
+    weight: 102
+    region: content
+    settings:
+      rows: 4
+      placeholder: ''
+    third_party_settings: {  }
+  translation_outdated:
+    type: boolean_checkbox
+    weight: 101
+    region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default

--- a/config/core.entity_form_display.node.person.default.yml
+++ b/config/core.entity_form_display.node.person.default.yml
@@ -123,7 +123,7 @@ content:
     settings:
       entity_browser: location_physical
       field_widget_display: rendered_entity
-      field_widget_edit: true
+      field_widget_edit: false
       field_widget_remove: true
       field_widget_replace: false
       open: false
@@ -377,6 +377,21 @@ content:
     weight: 17
     region: content
     settings: {  }
+    third_party_settings: {  }
+  translation_notes:
+    type: string_textarea
+    weight: 102
+    region: content
+    settings:
+      rows: 4
+      placeholder: ''
+    third_party_settings: {  }
+  translation_outdated:
+    type: boolean_checkbox
+    weight: 101
+    region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete

--- a/config/core.entity_form_display.node.public_body.default.yml
+++ b/config/core.entity_form_display.node.public_body.default.yml
@@ -109,7 +109,7 @@ content:
     settings:
       entity_browser: location_physical
       field_widget_display: rendered_entity
-      field_widget_edit: true
+      field_widget_edit: false
       field_widget_remove: true
       field_widget_replace: false
       open: true
@@ -339,6 +339,21 @@ content:
     weight: 10
     region: content
     settings: {  }
+    third_party_settings: {  }
+  translation_notes:
+    type: string_textarea
+    weight: 102
+    region: content
+    settings:
+      rows: 4
+      placeholder: ''
+    third_party_settings: {  }
+  translation_outdated:
+    type: boolean_checkbox
+    weight: 101
+    region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete

--- a/config/core.entity_form_display.paragraph.in_person_location.default.yml
+++ b/config/core.entity_form_display.paragraph.in_person_location.default.yml
@@ -27,7 +27,7 @@ content:
     settings:
       entity_browser: location_physical
       field_widget_display: rendered_entity
-      field_widget_edit: true
+      field_widget_edit: false
       field_widget_remove: true
       field_widget_replace: false
       open: true


### PR DESCRIPTION
SG-1960

Instructions:
- Cache clear
- Config import
- Check on some of the content add pages and confirm that the "edit" button is removed from the address embeds