### PR TITLE
[SG-1962] -- Removed the formio json content field from the translation services sources

### DIFF
--- a/config/field.field.node.form_page.field_formio_json_content.yml
+++ b/config/field.field.node.form_page.field_formio_json_content.yml
@@ -5,6 +5,11 @@ dependencies:
   config:
     - field.storage.node.field_formio_json_content
     - node.type.form_page
+  module:
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: true
 id: node.form_page.field_formio_json_content
 field_name: field_formio_json_content
 entity_type: node
@@ -12,7 +17,7 @@ bundle: form_page
 label: 'Formio Json Content'
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/web/modules/custom/sfgov_translation/sfgov_translation.module
+++ b/web/modules/custom/sfgov_translation/sfgov_translation.module
@@ -1,5 +1,6 @@
 <?php
 
+use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\Core\Ajax\MessageCommand;
@@ -197,6 +198,28 @@ function sfgov_translation_entity_presave($entity) {
         $translated_node->set('translation_outdated', 0);
         $translated_node->save();
       }
+    }
+  }
+}
+
+/**
+ * Implements hook_tmgmt_translatable_fields_alter().
+ */
+function sfgov_translation_tmgmt_translatable_fields_alter(ContentEntityInterface $entity, array &$translatable_fields) {
+
+  // Fields to remove from the tmgmt translation source.
+  //
+  // For example, remove the formio json content field from form pages, because
+  // it's just a duplicate and the individual strings are already pulled into
+  // their own sources. This will help reduce the word/character count for
+  // translation services.
+  $excluded_fields = [
+    'field_formio_json_content'
+  ];
+
+  foreach ($excluded_fields as $field) {
+    if (isset($translatable_fields[$field])) {
+      unset($translatable_fields[$field]);
     }
   }
 }


### PR DESCRIPTION
SG-1962

Removing the field helps to remove the duplication of translatable content occurring on lionbridge source translations.

Clear cache
Submit a test job to lionbridge
Confirm in either the UI or in the export that the large formio json content string no longer appears in the source, and that the translation still works