### PR TITLE
[SG-1965] -- Setup different title/label type fields to remove "&nbsp;" from the frontend output.

### DIFF
--- a/web/themes/custom/sfgovpl/includes/field.inc
+++ b/web/themes/custom/sfgovpl/includes/field.inc
@@ -65,3 +65,30 @@ function sfgovpl_preprocess_field__node__field_departments(&$variables) {
   $bundle = $variables['element']['#bundle'];
   $variables['label'] = t('Departments', [], ['context' => 'Related departments field label for ' . $bundle]);
 }
+
+/**
+ * Implements template_preprocess_field().
+ */
+function sfgovpl_preprocess_field__node__title(&$variables) {
+  foreach ($variables['items'] as $key => $value) {
+    $variables['items'][$key]['content']['#context']['value'] = _sfgovpl_remove_nbsp($variables['items'][$key]['content']['#context']['value']) . ' BACON';
+  }
+}
+
+/**
+ * Implements template_preprocess_field().
+ */
+function sfgovpl_preprocess_field__paragraph__field_title(&$variables) {
+  foreach ($variables['items'] as $key => $value) {
+    $variables['items'][$key]['content']['#context']['value'] = _sfgovpl_remove_nbsp($variables['items'][$key]['content']['#context']['value']);
+  }
+}
+
+/**
+ * Implements template_preprocess_field().
+ */
+function sfgovpl_preprocess_field__paragraph__field_owner(&$variables) {
+  foreach ($variables['items'] as $key => $value) {
+    $variables['items'][$key]['content']['#context']['value'] = _sfgovpl_remove_nbsp($variables['items'][$key]['content']['#context']['value']);
+  }
+}

--- a/web/themes/custom/sfgovpl/sfgovpl.theme
+++ b/web/themes/custom/sfgovpl/sfgovpl.theme
@@ -70,7 +70,7 @@ function _sfgovpl_node_object(&$variables) {
   }
 }
 
-/** 
+/**
  * If the current language matches an existing Drupal translation,
  * show the Drupal-translated node and do not let Google translate it.
  */
@@ -104,4 +104,15 @@ function _sfgovpl_node_notranslate($node, $view_mode) {
     }
   }
   return $variables;
+}
+
+/**
+ * Remove &nbsp; from strings.
+ *
+ * @param $text
+ *
+ * @return array|string|string[]
+ */
+function _sfgovpl_remove_nbsp($text) {
+  return str_replace('&nbsp;', ' ', $text);
 }

--- a/web/themes/custom/sfgovpl/templates/components/hero-banner-color.twig
+++ b/web/themes/custom/sfgovpl/templates/components/hero-banner-color.twig
@@ -5,7 +5,8 @@
         {{ banner.label|raw }}
       </div>
     {% endif %}
-    <h1>{{ banner.title|raw }}</h1>
+    {% set title = banner.title|render %}
+    <h1>{{ title|striptags|raw }}</h1>
     {% if banner.text %}
       <p class="lead-paragraph">{{ banner.text|striptags|raw }}</p>
     {% endif %}

--- a/web/themes/custom/sfgovpl/templates/field/field--paragraph--field-owner--phone.html.twig
+++ b/web/themes/custom/sfgovpl/templates/field/field--paragraph--field-owner--phone.html.twig
@@ -1,0 +1,41 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ */
+#}
+{% for item in items %}
+  {{ item.content }}
+{% endfor %}

--- a/web/themes/custom/sfgovpl/templates/field/field--paragraph--field-title--email.html.twig
+++ b/web/themes/custom/sfgovpl/templates/field/field--paragraph--field-title--email.html.twig
@@ -1,0 +1,41 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ */
+#}
+{% for item in items %}
+  {{ item.content }}
+{% endfor %}


### PR DESCRIPTION
[SG-1965]

Setup different title/label type fields to remove "&nbsp;" from the frontend output.

Instructions:
- Clear caches
- Check content admin page and search for any title with "&nbsp;"
- If any appear, visit that page and see if it displays on the frontend.

[SG-1965]: https://sfgovdt.jira.com/browse/SG-1965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ