### PR TITLE
[SG-1969] -- Better TOC default settings

### DIFF
--- a/config/toc_api.toc_type.default.yml
+++ b/config/toc_api.toc_type.default.yml
@@ -7,18 +7,19 @@ _core:
 id: default
 label: Default
 options:
-  template: tree
+  template: responsive
   title: Sections
   block: false
-  header_count: 2
+  header_count: 1
   header_min: 2
-  header_max: 3
+  header_max: 4
   header_allowed_tags: ''
   header_id: title
   header_id_prefix: section
+  header_exclude_xpath: ''
   top_label: 'Back to top'
   top_min: 2
-  top_max: 2
+  top_max: 4
   number_path: true
   number_path_separator: .
   number_path_truncate: true


### PR DESCRIPTION
SG-1969

Better default table-of-content settings. 
Changed to only need 1 highest item to build out. 
Changed to except up to h4.
Changed to responsive setup.

Instructions
- Clear cache
- Config import
- Observe pages and confirm proper changes