### PR TITLE
[SG-1966] -- Address section translation fixes

### DIFF
--- a/web/themes/custom/sfgovpl/includes/paragraph.inc
+++ b/web/themes/custom/sfgovpl/includes/paragraph.inc
@@ -29,6 +29,7 @@ function sfgovpl_preprocess_paragraph__form(&$variables) {
 
     }
 }
+
 /**
  * Implements template_preprocess_paragraph().
  */
@@ -49,6 +50,9 @@ function sfgovpl_preprocess_paragraph__process_step(&$variables) {
   }
 }
 
+/**
+ * Implements template_preprocess_paragraph().
+ */
 function sfgovpl_preprocess_paragraph(&$variables) {
   $paragraph = $variables['paragraph'];
   $paragraph_type = $paragraph->getType();
@@ -57,13 +61,16 @@ function sfgovpl_preprocess_paragraph(&$variables) {
     $preprocess($variables);
   }
 
-  if($paragraph_type == 'mailing_address') {
+  $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
+  $variables['current_language'] = $language;
+
+  if ($paragraph_type == 'mailing_address') {
       // Get node info for use in twig templates
       $node = \Drupal::request()->attributes->get('node');
       $variables['nodetype'] = $node->getType();
   }
 
-  if($paragraph_type == 'mailing_address') {
+  if ($paragraph_type == 'mailing_address') {
       // Get node info for use in twig templates
       $node = \Drupal::request()->attributes->get('node');
       $variables['nodetype'] = $node->getType();
@@ -326,7 +333,7 @@ function sfgovpl_preprocess_paragraph__resource_entity(&$variables) {
   }
 }
 
-/*
+/**
  * Implements hook_preprocess_paragraph().
  */
 function sfgovpl_preprocess_paragraph__form_io(&$variables) {

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--in-person-location.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--in-person-location.html.twig
@@ -10,12 +10,11 @@ boolean value. #}
 {% set display_map = paragraph.field_address_display.value %}
 {% set display_map = (display_map is empty or display_map == 1) ? true : false %}
 {% set contact_type = display_map ? 'in-person-location' : 'mailing-address' %}
-{% set attrcibutes = attributes.setAttribute('data-contact', contact_type) %}
+{% set attributes = attributes.setAttribute('data-contact', contact_type) %}
 {% set parent = paragraph.getParentEntity() %}
 {% set classes = ['parent--bundle--' ~ parent.bundle|clean_class] %}
 {% set pid = paragraph.field_location.entity.id() %}
 {% set parentNode = paragraph.parentEntity.bundle %}
-
 {% if parentNode is not empty and parentNode == 'department' %}
   {% set display_map = false %}
 {% endif %}
@@ -26,14 +25,14 @@ boolean value. #}
     {% if display_map %}
       {% if parent.bundle in ['step'] %}
         {# Render with 'default_h4' view mode. #}
-        {{ drupal_entity('location', pid, 'default_h4') }}
+        {{ drupal_entity('location', pid, 'default_h4', current_language) }}
       {% else %}
         {# Render with 'default' view mode. #}
         {{ content }}
       {% endif %}
     {% else %}
       {# Render with 'address_only' view mode. #}
-      {{ drupal_entity('location', pid, 'address_plus_notes') }}
+      {{ drupal_entity('location', pid, 'address_plus_notes', current_language) }}
     {% endif %}
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
SG-1966

Changes to the render code to better output translated versions of the locations/address entities on transactions.

Instructions:
- Clear cache
- Translate a location/address on a transaction, and confirm that the language renders properly for set language