### PR TITLE
SG-1974 - go back to toc for h2 and h3 only

### DIFF
--- a/config/toc_api.toc_type.default.yml
+++ b/config/toc_api.toc_type.default.yml
@@ -12,14 +12,14 @@ options:
   block: false
   header_count: 1
   header_min: 2
-  header_max: 4
+  header_max: 3
   header_allowed_tags: ''
   header_id: title
   header_id_prefix: section
   header_exclude_xpath: ''
   top_label: 'Back to top'
   top_min: 2
-  top_max: 4
+  top_max: 3
   number_path: true
   number_path_separator: .
   number_path_truncate: true

--- a/config/user.role.digital_services.yml
+++ b/config/user.role.digital_services.yml
@@ -140,6 +140,7 @@ permissions:
   - 'administer menu'
   - 'administer meta tags'
   - 'administer modules'
+  - 'administer mohcd pages'
   - 'administer nodes'
   - 'administer pathauto'
   - 'administer protected pages configuration'
@@ -512,4 +513,3 @@ permissions:
   - 'view unpublished eck entities'
   - 'view unpublished paragraphs'
   - 'view video media revisions'
-  - 'administer mohcd pages'


### PR DESCRIPTION
SG-1974

* reconfigures table of contents default settings to generate for h2 and h3 only