### PR TITLE
[SG-1989]: News list view gets redirect loop

### DIFF
--- a/web/modules/custom/sfgov_utilities/sfgov_utilities.install
+++ b/web/modules/custom/sfgov_utilities/sfgov_utilities.install
@@ -146,3 +146,65 @@ function sfgov_utilities_update_8706() {
     $original_paragraph->save();
   }
 }
+
+/**
+ * Fix path aliases for topic and news pages.
+ */
+function sfgov_utilities_update_8707(&$sandbox) {
+  $pathAliasManager = \Drupal::entityTypeManager()->getStorage('path_alias');
+
+  if (!isset($sandbox['progress'])) {
+    $resultsNews = $pathAliasManager->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('alias', '^/news/\\d+$', 'REGEXP')
+      ->condition('langcode', 'en')
+      ->execute();
+    $resultsTopics = $pathAliasManager->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('alias', '^/news/topics/\d+$', 'REGEXP')
+      ->condition('langcode', 'en')
+      ->execute();
+
+    $sandbox['progress'] = 0;
+    $sandbox['max'] = count($resultsNews) + count($resultsTopics);
+    $sandbox['ids'] = $resultsNews + $resultsTopics;
+  }
+
+  // Slice the $results array into chunks of 20 and iterate over each.
+  $ids = array_slice($sandbox['ids'], $sandbox['progress'], 20);
+
+  /* @var $aliases \Drupal\path_alias\PathAliasInterface[] */
+  $aliases = $pathAliasManager->loadMultiple($ids);
+  foreach ($aliases as $alias) {
+    $parts = explode('/', $alias->getPath());
+    $nid = end($parts);
+    $entity_path_root = in_array('topics', $parts) ? '/news/topics/' : '/news/';
+    $node_alias = \Drupal::service('path_alias.manager')
+      ->getAliasByPath('/node/' . $nid, 'en');
+    if ($node_alias) {
+      $position = strrpos($node_alias, '/');
+      $existing_alias = $position === FALSE ? $node_alias : substr($node_alias, $position + 1);
+      $updated_alias = $entity_path_root . $existing_alias;
+      $alias->setAlias($updated_alias);
+      $alias->save();
+    }
+    else {
+      $alias->delete();
+    }
+
+    $sandbox['progress']++;
+  }
+
+  $sandbox['#finished'] = empty($sandbox['max']) ? 1 : ($sandbox['progress'] / $sandbox['max']);
+}
+
+/**
+ * Delete possible redirect loops.
+ */
+function sfgov_utilities_update_8708(&$sandbox) {
+  $query = Drupal::database()->delete('redirect');
+  $query->where("redirect_redirect__uri = CONCAT(:prefix, redirect_source__path)", [
+    ':prefix' => 'internal:/',
+  ]);
+  $query->execute();
+}

--- a/web/modules/custom/sfgov_utilities/sfgov_utilities.module
+++ b/web/modules/custom/sfgov_utilities/sfgov_utilities.module
@@ -6,10 +6,7 @@ use Drupal\user\Entity\User;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\pathauto\PathautoState;
 use Drupal\Core\Render\Element;
-use Drupal\Core\Cache\Cache;
-use Drupal\node\NodeInterface;
 use Drupal\node\Entity\Node;
-use Drush\Drush;
 
 /**
  * Implements hook_template_preprocess_default_variables_alter().
@@ -198,11 +195,14 @@ function sfgov_utilities_entity_insert(EntityInterface $entity) {
   // Enforcing URL generation even when "Generate automatic URL alias" is unchecked.
   // This will make sure to apply transliteration cleanup and appropirate URL patterns.
   // @see SG-1154
-  if(!empty($entity->path)) {
-    if ($entity->path->pathauto == PathautoState::SKIP) {
-      \Drupal::service('pathauto.generator')->updateEntityAlias($entity, 'insert');
-    }
+  if (
+    $entity->hasField('path') &&
+    !empty($entity->path) &&
+    ($entity->path->pathauto == PathautoState::SKIP)
+  ) {
+    \Drupal::service('pathauto.generator')->updateEntityAlias($entity, 'insert');
   }
+
   if ($entity->bundle() === 'department' || $entity->bundle() === 'topic') {
     sfgov_utilities_entity_update($entity);
   }
@@ -236,11 +236,14 @@ function sfgov_utilities_entity_update(EntityInterface $entity) {
   // Enforcing URL generation even when "Generate automatic URL alias" is unchecked.
   // This will make sure to apply transliteration cleanup and appropirate URL patterns.
   // @see SG-1154
-  if (!empty($entity->path)) {
-    if ($entity->path->pathauto == PathautoState::SKIP) {
-      \Drupal::service('pathauto.generator')->updateEntityAlias($entity, 'update');
-    }
+  if (
+    $entity->hasField('path') &&
+    !empty($entity->path) &&
+    ($entity->path->pathauto == PathautoState::SKIP)
+  ) {
+    \Drupal::service('pathauto.generator')->updateEntityAlias($entity, 'update');
   }
+
   // Add or edit redirects for news view pages.
   if ($entity->bundle() === 'department' || $entity->bundle() === 'topic') {
     if ($entity->bundle() === 'department') {
@@ -251,7 +254,7 @@ function sfgov_utilities_entity_update(EntityInterface $entity) {
     }
     $entity_path = $entity_path_root . $entity->id();
     $path_alias_manager = \Drupal::entityTypeManager()->getStorage('path_alias');
-    /* @var $alias_objects PathAliasInterface */
+    /* @var $alias_objects \Drupal\path_alias\PathAliasInterface */
     $alias_objects = $path_alias_manager->loadByProperties([
       'path' => $entity_path,
       'langcode' => 'en',
@@ -272,15 +275,18 @@ function sfgov_utilities_entity_update(EntityInterface $entity) {
         foreach ($alias_objects as $alias_object) {
           if ($alias_object->getPath() == $entity_path) {
             $retrieved_alias = $alias_object->getAlias();
-            $news_alias = \Drupal::service('path_alias.manager')->getAliasByPath('/node/' . $entity->id());
-            $position = strrpos($news_alias, '/');
-            $existing_alias = $position === FALSE ? $news_alias : substr($news_alias, $position + 1);
-            if ($retrieved_alias != $news_alias) {
+            $node_alias = \Drupal::service('path_alias.manager')->getAliasByPath('/node/' . $entity->id(), 'en');
+            $position = strrpos($node_alias, '/');
+            $existing_alias = $position === FALSE ? $node_alias : substr($node_alias, $position + 1);
+            $updated_alias = $entity_path_root . $existing_alias;
+            if ($retrieved_alias != $updated_alias) {
               // Note that redirect module will create a new redirect for us, from the
               // old alias to the subpage path, in the process of this save.
-              $updated_alias = $entity_path_root . $existing_alias;
-              $alias_object->setAlias($updated_alias);
-              $alias_object->save();
+              // Prevent saving infinite redirects from the path to the alias.
+              if ($alias_object->getPath() != $updated_alias) {
+                $alias_object->setAlias($updated_alias);
+                $alias_object->save();
+              }
             }
           }
         }

--- a/web/modules/custom/sfgov_utilities/sfgov_utilities.module
+++ b/web/modules/custom/sfgov_utilities/sfgov_utilities.module
@@ -1,5 +1,6 @@
 <?php
 
+use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\path_alias\Entity\PathAlias;
 use Drupal\user\Entity\User;
@@ -196,6 +197,7 @@ function sfgov_utilities_entity_insert(EntityInterface $entity) {
   // This will make sure to apply transliteration cleanup and appropirate URL patterns.
   // @see SG-1154
   if (
+    ($entity instanceof ContentEntityInterface) &&
     $entity->hasField('path') &&
     !empty($entity->path) &&
     ($entity->path->pathauto == PathautoState::SKIP)
@@ -237,6 +239,7 @@ function sfgov_utilities_entity_update(EntityInterface $entity) {
   // This will make sure to apply transliteration cleanup and appropirate URL patterns.
   // @see SG-1154
   if (
+    ($entity instanceof ContentEntityInterface) &&
     $entity->hasField('path') &&
     !empty($entity->path) &&
     ($entity->path->pathauto == PathautoState::SKIP)


### PR DESCRIPTION
SG-1989
Agency pages are creating infinite redirects when the translations are added or updated.

To reproduce bug on current site:

1. Create a new agency page in English and save.
2. Node should have a URL like `/department/[title]`
3. A news listing page is automatically created for it under `/news/[title]`
4. Add a node translation for the agency.
5. BUG: the news listing page now redirects to: `/news/[agency-nid]` instead of`/news/[title]`
6. Edit the same translation and save.
7. BUG: the news listing page now creates a redirect loop and is unavailable.

This PR should fix that.