### PR TITLE
[SG-1990] -- Set the titles for "About" content type nodes to be translatable.

### DIFF
--- a/web/themes/custom/sfgovpl/templates/node/node--about--full.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--about--full.html.twig
@@ -3,7 +3,7 @@
 <article{{ attributes.addClass(classes) }}>
   {% include '@theme/hero-banner-color.twig' with {
     'banner': {
-      'title': 'About us',
+      'title': 'About us'|t,
       'label': 'Part of <a href="@url">@parent</a>'|t({'@parent': node.field_parent_department.entity.label(), '@url': path('entity.node.canonical', {node: node.field_parent_department.entity.id() })})
     }
   } %}


### PR DESCRIPTION
[SG-1990]

Set the titles for "About" content type nodes to be translatable.

The title is hard-set in the template and just needed to have the translation function applied

[SG-1990]: https://sfgovdt.jira.com/browse/SG-1990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ