### PR TITLE
[SG-1982] -- Figure margins are incorrect.

### DIFF
--- a/web/themes/custom/sfgovpl/src/sass/_base.scss
+++ b/web/themes/custom/sfgovpl/src/sass/_base.scss
@@ -75,6 +75,10 @@ img {
   max-width: 100%;
 }
 
+figure {
+  margin-inline: 0;
+}
+
 .sfgov-list-link {
   @include link-colors($c-bright-blue, $c-dark-blue);
   @include fs-title;


### PR DESCRIPTION
[SG-1982]

Figure margins are incorrect.

Inline (left and right) margins need to be set to 0.

[SG-1982]: https://sfgovdt.jira.com/browse/SG-1982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ