### PR TITLE
[Fix] -- Patch to address a php error involving undefined index values on "Manage Form Display" pages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -278,7 +278,8 @@
                 "Allow tokens in entity reference views selection arguments": "https://www.drupal.org/files/issues/2023-05-03/1699378-249.patch",
                 "User can't reference unpublished content even when they have access to it": "https://www.drupal.org/files/issues/2022-06-17/2845144-67.patch",
                 "Notice: Undefined index: #type in Drupal\\Core\\Form\\FormHelper::processStates()": "https://www.drupal.org/files/issues/2021-05-12/2700667-133a.patch",
-                "TranslatableMarkup for Invalid Argument Exception: $string (Array) must be a string.": "https://www.drupal.org/files/issues/2019-04-01/2719553-26-null_for_string.patch"
+                "TranslatableMarkup for Invalid Argument Exception: $string (Array) must be a string.": "https://www.drupal.org/files/issues/2019-04-01/2719553-26-null_for_string.patch",
+                "FieldUiTable preRender undefined values causing an error on entity manage form display page.": "patches/undefined-values-in-fielduitable-prerender.patch"
             },
             "drupal/amplitude": {
                 "Page scroll depth": "patches/amplitude-scroll-depth.patch",

--- a/patches/undefined-values-in-fielduitable-prerender.patch
+++ b/patches/undefined-values-in-fielduitable-prerender.patch
@@ -1,0 +1,30 @@
+diff --git a/core/modules/field_ui/src/Element/FieldUiTable.php b/core/modules/field_ui/src/Element/FieldUiTableChange.php
+--- a/core/modules/field_ui/src/Element/FieldUiTable.php
++++ b/core/modules/field_ui/src/Element/FieldUiTable.php
+@@ -61,7 +61,7 @@
+     while ($list) {
+       foreach ($list as $name) {
+         $row = &$elements[$name];
+-        $parent = $row['parent_wrapper']['parent']['#value'];
++        $parent = $row['parent_wrapper']['parent']['#value'] ?? '';
+         // Proceed if parent is known.
+         if (empty($parent) || isset($parents[$parent])) {
+           // Grab parent, and remove the row from the next iteration.
+@@ -69,7 +69,7 @@
+           unset($list[$name]);
+
+           // Determine the region for the row.
+-          $region_name = call_user_func_array($row['#region_callback'], [&$row]);
++          $region_name = $row['#region_callback'] ? call_user_func_array($row['#region_callback'], [&$row]) : '';
+
+           // Add the element in the tree.
+           // phpcs:ignore DrupalPractice.CodeAnalysis.VariableAnalysis.UnusedVariable
+@@ -77,7 +77,7 @@
+           foreach ($parents[$name] as $key) {
+             $target = &$target['children'][$key];
+           }
+-          $target['children'][$name] = ['name' => $name, 'weight' => $row['weight']['#value']];
++          $target['children'][$name] = ['name' => $name, 'weight' => $row['weight']['#value'] ?? '0'];
+
+           // Add tabledrag indentation to the first row cell.
+           if ($depth = count($parents[$name])) {


### PR DESCRIPTION
[Fix]
Custom patch to address a php error involving undefined index values that is killing the "Manage Form Display" pages for media, taxonomy term, eck, and paragraph entities.

An undefined value for #value and #region_callback caused a php error in the 'call_user_func_array' function in FieldUiTable.php