### PR TITLE
[SG-2000] -- Hide the language selector for non-admin editors.

### DIFF
--- a/web/modules/custom/sfgov_admin/sfgov_admin.module
+++ b/web/modules/custom/sfgov_admin/sfgov_admin.module
@@ -135,11 +135,13 @@ function sfgov_admin_block_access(\Drupal\block\Entity\Block $block, $operation,
  * Implements hook_form_FORM_ID_alter().
  */
 function sfgov_admin_form_node_form_alter(&$form, &$form_state, $form_id) {
+  $user = \Drupal::currentUser();
 
   // Get the node object being used on the form.
   $node = $form_state->getFormObject()->getEntity();
+  $bundle = $node->getType();
   // Get the node type object for the form.
-  $node_type = \Drupal\node\Entity\NodeType::load($node->getType());
+  $node_type = \Drupal\node\Entity\NodeType::load($bundle);
 
   // SG-1870 -- setup title description.
   // Move the content type "submission help" text into the title field
@@ -181,7 +183,7 @@ function sfgov_admin_form_node_form_alter(&$form, &$form_state, $form_id) {
                     // remove any forbidden html tags...
                     $text = $form[$field_name]['widget'][$delta]['#default_value'] ?? '';
                     if ($allowed_format == 'plain_text') {
-                      $text = strip_tags($text);
+                      $text = !empty($text) ? strip_tags($text) : $text;
                     }
                     // Apply the allowed format to the text value...
                     $filtered_text = check_markup($text, $allowed_format, $langcode);
@@ -190,9 +192,9 @@ function sfgov_admin_form_node_form_alter(&$form, &$form_state, $form_id) {
                     // more time to clear out any html tags generated from the
                     // filtering.
                     if ($allowed_format == 'plain_text') {
-                      $filtered_text = strip_tags($filtered_text);
+                      $filtered_text = !empty($filtered_text) ? strip_tags($filtered_text) : $filtered_text;
                     }
-  
+
                     // Reapply the formatted text to the default value. This will
                     // help avoid issues with formatters being broken on body type
                     // fields. This setup only applies to those fields out of sync.
@@ -211,6 +213,27 @@ function sfgov_admin_form_node_form_alter(&$form, &$form_state, $form_id) {
     }
   }
 
+  // SG-2000 -- hide language picker from editors (writer and publisher roles,
+  // basically anyone who isn't an admin or in digital services)
+  $bundles_to_hide_language_picker = [
+    'transaction',
+    'location',
+    'campaign',
+    'department_table',
+    'about',
+    'data_story',
+    'topic',
+    'page',
+    'landing',
+  ];
+
+  if (in_array($bundle, $bundles_to_hide_language_picker)) {
+    $roles = $user->getRoles();
+    if (!in_array('administrator' , $roles) &&
+        !in_array('digital_services' , $roles)) {
+      $form['langcode']['#access'] = FALSE;
+    }
+  }
 }
 
 /**
@@ -369,9 +392,9 @@ function sfgov_admin_field_widget_entity_reference_paragraphs_form_alter(&$eleme
                     // remove any forbidden html tags...
                     $text = $element['subform'][$field_name]['widget'][$delta]['#default_value'] ?? '';
                     if ($allowed_format == 'plain_text') {
-                      $text = strip_tags($text);
+                      $text = !empty($text) ? strip_tags($text) : $text;
                     }
-  
+
                     // Apply the allowed format to the text value...
                     $filtered_text = check_markup($text, $allowed_format, $langcode);
                     $filtered_text = is_object($filtered_text) ? $filtered_text->__toString() : $filtered_text;
@@ -380,9 +403,9 @@ function sfgov_admin_field_widget_entity_reference_paragraphs_form_alter(&$eleme
                     // more time to clear out any html tags generated from the
                     // filtering.
                     if ($allowed_format == 'plain_text') {
-                      $filtered_text = strip_tags($filtered_text);
+                      $filtered_text = !empty($filtered_text) ? strip_tags($filtered_text) : $filtered_text;
                     }
-  
+
                     // Reapply the formatted text to the default value. This will
                     // help avoid issues with formatters being broken on body type
                     // fields. This setup only applies to those fields out of sync.

--- a/web/modules/custom/sfgov_admin/src/Plugin/Field/FieldWidget/SfgovParagraphsWidget.php
+++ b/web/modules/custom/sfgov_admin/src/Plugin/Field/FieldWidget/SfgovParagraphsWidget.php
@@ -181,7 +181,7 @@ class SfgovParagraphsWidget extends ParagraphsWidget {
           $row_content = $child_paragraph->bundle() === "powerbi_embed" ? $item_bundles[$child_paragraph->bundle()]['label'] : '';
           if (!$heading && $child_paragraph->hasField('field_text')) {
             if ($text = $localized_paragraph->get('field_text')->value) {
-              $text = strip_tags($text);
+              $text = !empty($text) ? strip_tags($text) : $text;
               $row_content = $text;
             }
           }

--- a/web/modules/custom/sfgov_alerts/sfgov_alerts.module
+++ b/web/modules/custom/sfgov_alerts/sfgov_alerts.module
@@ -54,7 +54,7 @@ function _sfgov_alerts_notify($entity) {
       $message = t(
         '<div class="message-alert-updated" data-alertmessage="message" data-style="@type" data-exp="@expiration" data-user="@current_user"><em>@type</em>Alert Expiration Date has changed from <b>@expiration_original</b> to <b>@expiration.</b><br> Alert Text: <b>@text</b></div>', [
         '@type' => $entity->label(),
-        '@text' => strip_tags($entity->field_alert_text->value),
+        '@text' => !empty($entity->field_alert_text->value) ? strip_tags($entity->field_alert_text->value) : $entity->field_alert_text->value,
         '@expiration' => $expiration_updated,
         '@expiration_original' => $expiration_original,
         '@current_user' => \Drupal::currentUser()->getAccountName(),

--- a/web/modules/custom/sfgov_formio/sfgov_formio.module
+++ b/web/modules/custom/sfgov_formio/sfgov_formio.module
@@ -93,7 +93,7 @@ function _sfgov_formiojs_source() {
   // Check for query parameters first.
   if (\Drupal::request()->query) {
     $query = \Drupal::request()->query->get('formiojsVersion');
-    $query = strip_tags($query);
+    $query = !empty($query) ? strip_tags($query) : $query;
   }
 
   // Prefer source from query params.
@@ -122,7 +122,7 @@ function _sfgov_formio_sfds_source() {
   // Check for query parameters.
   if (\Drupal::request()->query) {
     $query = \Drupal::request()->query->get('formio-sfdsVersion');
-    $query = strip_tags($query);
+    $query = !empty($query) ? strip_tags($query) : $query;
   }
 
   // Prefer version from query params, if available.


### PR DESCRIPTION
[SG-2000]

Hide the language selector for non-admin editors (writers and publishers) on specific content types.

Content types include:
- Transactions
- Location
- Campaign
- Department table
- About
- Data Story
- Topic
- Basic Page
- SF.gov Landing page

Also added some checks on strip_tags to make sure that the function always receives non-empty content. In some cases, NULL gets passed to strip_tags and causes notices and warnings

[SG-2000]: https://sfgovdt.jira.com/browse/SG-2000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ