### PR TITLE
[SG-2002] -- Disable mastadon field on social media paragraphs, on agency nodes.

### DIFF
--- a/config/core.entity_form_display.paragraph.social_media.default.yml
+++ b/config/core.entity_form_display.paragraph.social_media.default.yml
@@ -31,14 +31,6 @@ content:
       placeholder_url: ''
       placeholder_title: ''
     third_party_settings: {  }
-  field_mastodon:
-    type: link_default
-    weight: 11
-    region: content
-    settings:
-      placeholder_url: ''
-      placeholder_title: ''
-    third_party_settings: {  }
   field_twitter:
     type: link_default
     weight: 1
@@ -48,10 +40,11 @@ content:
       placeholder_title: ''
     third_party_settings: {  }
   translation:
-    weight: 10
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
   created: true
+  field_mastodon: true
   status: true

--- a/config/core.entity_view_display.paragraph.social_media.default.yml
+++ b/config/core.entity_view_display.paragraph.social_media.default.yml
@@ -39,18 +39,6 @@ content:
     third_party_settings: {  }
     weight: 2
     region: content
-  field_mastodon:
-    type: link
-    label: above
-    settings:
-      trim_length: 80
-      url_only: false
-      url_plain: false
-      rel: ''
-      target: ''
-    third_party_settings: {  }
-    weight: 3
-    region: content
   field_twitter:
     type: link
     label: above
@@ -64,4 +52,5 @@ content:
     weight: 1
     region: content
 hidden:
+  field_mastodon: true
   search_api_excerpt: true


### PR DESCRIPTION
[SG-2002]

Disable mastadon field on social media paragraphs, on agency nodes. Will be re-enabled in future.

[SG-2002]: https://sfgovdt.jira.com/browse/SG-2002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ