### PR TITLE
[SG-2003] -- The position field is not longer appearing in the agency page

### DIFF
--- a/config/core.entity_form_display.paragraph.public_body_profiles.default.yml
+++ b/config/core.entity_form_display.paragraph.public_body_profiles.default.yml
@@ -11,8 +11,6 @@ dependencies:
     - field.field.paragraph.public_body_profiles.field_starting_year
     - field.field.paragraph.public_body_profiles.field_title
     - paragraphs.paragraphs_type.public_body_profiles
-  module:
-    - datetime
 id: paragraph.public_body_profiles.default
 targetEntityType: paragraph
 bundle: public_body_profiles
@@ -25,12 +23,6 @@ content:
     settings:
       size: 60
       placeholder: ''
-    third_party_settings: {  }
-  field_ending_year:
-    type: datetime_default
-    weight: 4
-    region: content
-    settings: {  }
     third_party_settings: {  }
   field_position_type:
     type: options_select
@@ -48,19 +40,15 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-  field_starting_year:
-    type: datetime_default
-    weight: 3
-    region: content
-    settings: {  }
-    third_party_settings: {  }
   translation:
-    weight: 10
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
   created: true
   field_department: true
+  field_ending_year: true
+  field_starting_year: true
   field_title: true
   status: true

--- a/web/modules/custom/sfgov_profiles/sfgov_profiles.module
+++ b/web/modules/custom/sfgov_profiles/sfgov_profiles.module
@@ -13,8 +13,8 @@ function sfgov_profiles_field_widget_entity_reference_paragraphs_form_alter(&$el
   if ($element['#paragraph_type'] == 'public_body_profiles') {
     $node = \Drupal::routeMatch()->getParameter('node');
     if ($node && $node->bundle() != 'public_body') {
-      $element['subform']['field_commission_position']['#access'] = FALSE;
-      $element['subform']['field_position_type']['#access'] = FALSE;
+      // $element['subform']['field_commission_position']['#access'] = FALSE;
+      // $element['subform']['field_position_type']['#access'] = FALSE;
       $element['subform']['field_ending_year']['#access'] = FALSE;
       $element['subform']['field_starting_year']['#access'] = FALSE;
     }


### PR DESCRIPTION
[SG-2003]

The position field is not longer appearing in the agency page. Moved the start and ending field to disabled on the paragraph type. Commented out code that was causing the position and type field to be hidden.

[SG-2003]: https://sfgovdt.jira.com/browse/SG-2003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ