### PR TITLE
EPR-760 Update Formio js package

### DIFF
--- a/web/modules/custom/sfgov_formio/README.md
+++ b/web/modules/custom/sfgov_formio/README.md
@@ -28,7 +28,7 @@ It's possible to test different versions, without having to edit the above setti
 
 | Parameter name | Example Query String | Resulting Source |
 | :--- | :--- | :---
-| `formiojsVersion` | `/home?formiojsVersion=4.11.2` | `https://unpkg.com/formiojs@4.11.2/dist/formio.full.min.js` |
+| `formiojsVersion` | `/home?formiojsVersion=4.11.2` | `https://unpkg.com/formiojs@4.11.2/dist/formio.form.min.js` |
 | `formio-sfdsVersion` | `/home?formio-sfdsVersion=7.0.2` | `https://unpkg.com/formio-sfds@7.0.2/dist/formio-sfds.standalone.js` |
 
 ## Content

--- a/web/modules/custom/sfgov_formio/sfgov_formio.module
+++ b/web/modules/custom/sfgov_formio/sfgov_formio.module
@@ -88,7 +88,7 @@ function sfgov_formio_page_attachments(array &$attachments) {
  */
 function _sfgov_formiojs_source() {
   // Fallback (latest version).
-  $source = 'https://unpkg.com/formiojs/dist/formio.full.min.js';
+  $source = 'https://unpkg.com/formiojs/dist/formio.form.min.js';
 
   // Check for query parameters first.
   if (\Drupal::request()->query) {
@@ -98,12 +98,12 @@ function _sfgov_formiojs_source() {
 
   // Prefer source from query params.
   if (!empty($query)) {
-    $source = 'https://unpkg.com/formiojs@' . $query . '/dist/formio.full.min.js';
+    $source = 'https://unpkg.com/formiojs@' . $query . '/dist/formio.form.min.js';
   }
 
   // Use settings configured at 'admin/config/services/sfgov_formio'.
   elseif ($config = \Drupal::config('sfgov_formio.settings')->get('formio_version')) {
-    $source = 'https://unpkg.com/formiojs@' . $config . '/dist/formio.full.min.js';
+    $source = 'https://unpkg.com/formiojs@' . $config . '/dist/formio.form.min.js';
   }
 
   return $source;


### PR DESCRIPTION
We might not need to load the full javascript package from form.io. Proposing to swap `formio.full.min.js` to `formio.form.min.js` 