### PR TITLE
[SG-2008] -- Add Cancelled flags to Meetings cards and teasers output

### DIFF
--- a/web/themes/custom/sfgovpl/src/sass/node/_node-meeting.scss
+++ b/web/themes/custom/sfgovpl/src/sass/node/_node-meeting.scss
@@ -257,7 +257,7 @@
       line-height: 24px;
       margin-bottom: 10px;
     }
-    
+
     .field__item {
       margin-bottom: 20px;
     }
@@ -285,6 +285,23 @@
       background-position: left 0;
       padding-left: 26px;
       margin-bottom: 20px;
+    }
+  }
+}
+
+.meeting {
+  &--card,
+  &--teaser {
+    .cancelled {
+      font-size: 12px;
+      text-transform: uppercase;
+      background: $c-yellow-3;
+      padding: 4px;
+      border-radius: 2px;
+      margin-bottom: 10px;
+      display: inline-block;
+      line-height: 12px;
+      color: $c-slate;
     }
   }
 }

--- a/web/themes/custom/sfgovpl/src/sass/node/_node-public-body.scss
+++ b/web/themes/custom/sfgovpl/src/sass/node/_node-public-body.scss
@@ -404,7 +404,7 @@
   content: 'Unpublished';
   font-size: 12px;
   text-transform: uppercase;
-  background: red;
+  background: $c-red-4;
   padding: 4px;
   border-radius: 2px;
   margin-bottom: 10px;

--- a/web/themes/custom/sfgovpl/templates/node/node--meeting--card.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--meeting--card.html.twig
@@ -1,16 +1,20 @@
 {% extends 'node.html.twig' %}
 
-{% 
+{%
   set utilityClasses = [
     'block',
     'p-20',
     'text-white',
-    'no-underline'
+    'no-underline',
+    node.get('field_meeting_cancel').value ? bundle ~ '--cancelled',
   ]
 %}
 
 {% block node %}
   <a href="{{ url }}"{{ attributes.addClass(classes|merge(utilityClasses))|without('id', 'role') }}>
+    {% if node.get('field_meeting_cancel').value %}
+      <span class="cancelled">{{ 'Cancelled'|t }}</span>
+    {% endif %}
     <p class="title p-0 m-0 font-medium lg:pb-28 lg:text-title-xs">{{ node.label }}</p>
       {% if content.field_smart_date[0]['#date'] %}
         {# field_smart_date uses a custom field formatter defined in sfgov_dates module #}

--- a/web/themes/custom/sfgovpl/templates/node/node--meeting--teaser.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--meeting--teaser.html.twig
@@ -72,6 +72,9 @@
 
 <div class="meeting--teaser">
   <div class="meeting-details">
+    {% if node.get('field_meeting_cancel').value %}
+      <span class="cancelled">{{ 'Cancelled'|t }}</span>
+    {% endif %}
     <a class="inline-block font-medium mb-8 text-title-xs" href="{{ url }}" rel="bookmark">{{ label }}</a>
     <div class="mb-8 font-medium text-body">
       {{ content.field_smart_date[0]['#date'] }}


### PR DESCRIPTION
[SG-2008]

Add Cancelled flags to Meetings cards and teasers output.

Instructions:
- Clear cache
- Visit a department with cancelled upcoming or past meetings, like Election commission
- Review the "Cancelled" flag on the cards, and on the teaser display (on the complete past meetings list)