### PR TITLE
Prevent the form page from showing a confirmation when a draft is saved

### DIFF
--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -259,7 +259,10 @@
             }
           }
 
-          if (confirmationURL) {
+          // we want to navigate to the confirmation page only on final submission.
+          // saving a draft also triggers the submitDone event, but we want to keep
+          // the user on the current page in that case.
+          if (confirmationURL && submission.state !== 'draft') {
             // see: <https://github.com/formio/formio.js/pull/3592> for more details
             var formLang = form.language || form.options.language
             var lang = formLanguageMap[formLang] || formLang


### PR DESCRIPTION
This is currently being worked around with some code in the OOC forms that manipulates the event listeners array directly, but it would be better for this code to do the right thing.