### PR TITLE
[SG-2007] -- Changed "exclude from gtranslate" strings to only prevent translation of "Breed" when there is at least 1 space before the word.

### DIFF
--- a/web/themes/custom/sfgovpl/src/js/exclude-from-gtranslate.js
+++ b/web/themes/custom/sfgovpl/src/js/exclude-from-gtranslate.js
@@ -6,7 +6,7 @@
     'London Nicole Breed',
     'Mayor Breed',
     'London Breed',
-    'Breed'
+    ' Breed'
   ].map(str => [
     str,
     new RegExp(`(?!<span class="notranslate>)${str}(?!</span>)`, 'g'),


### PR DESCRIPTION
[SG-2007]

Changed "exclude from gtranslate" strings to only prevent translation of "Breed" when there is at least 1 space before the word.

This should prevent file names and urls with breed in the string from being wrapped in a gtranslate span. That span is what caused the display oddities to occur.

[SG-2007]: https://sfgovdt.jira.com/browse/SG-2007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ