### PR TITLE
[SG-1369] -- Remove duplicate publication status bars on event full pages

### DIFF
--- a/web/themes/custom/sfgovpl/templates/node/node--event--full.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--event--full.html.twig
@@ -68,7 +68,7 @@
             </div>
           {% endif %}
 
-          {{ content | without(
+          {{ content|without(
             'field_cost',
             'field_address',
             'field_call_to_action',
@@ -78,7 +78,8 @@
             'field_description',
             'field_image',
             'field_location_in_person',
-            'field_location_online'
+            'field_location_online',
+            'content_moderation_control',
           ) }}
         </div>
         <div class="event--content-sidebar">


### PR DESCRIPTION
[SG-1369]

Remove duplicate publication status bars on event full pages

Event full pages render the content moderation bar twice (header and just above body field). The content moderation field needed to be added to the list of items to not render in the content variable on the template. This item is specifically called out to be rendered in the header, so it does not need to be included in the generic content render.

Instructions
- clear cache
- visit any draft/unpublished event node as an editor
- confirm that the moderation bar only renders once

[SG-1369]: https://sfgovdt.jira.com/browse/SG-1369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ