### PR TITLE
[SG-2019] -- Changed the output of people card images to render a specific image style.

### DIFF
--- a/web/themes/custom/sfgovpl/templates/components/person-card.twig
+++ b/web/themes/custom/sfgovpl/templates/components/person-card.twig
@@ -9,8 +9,10 @@
 {% endif %}
 
 <div class="person-card person-container">
-  <div class="person-photo" style="background-image:url({{ photo }});" title="{{ first_name }} {{ last_name }}">
-    <img src="" alt="{{ first_name }} {{ last_name }}"/>
+  <div class="person-photo"
+       style="background-image:url({{ photo }});"
+       title="{{ first_name }} {{ last_name }}">
+    <img src="{{ photo }}" alt="{{ first_name }} {{ last_name }}"/>
   </div>
   <div class="person-bio">
   {% if commission_position %}

--- a/web/themes/custom/sfgovpl/templates/node/node--person--card.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--person--card.html.twig
@@ -3,8 +3,14 @@
 {% block title %}
 {% endblock title %}
 
-{% if node.field_profile_photo|file_url %}
-  {% set photo_url = file_url(node.field_profile_photo|file_url) %}
+{% set photo_url = '' %}
+
+{#{% if node.field_profile_photo|file_url %}#}
+{#  {% set photo_url = file_url(node.field_profile_photo|file_url) %}#}
+{#{% endif %}#}
+
+{% if node.field_profile_photo[0].entity.field_media_image.entity.fileuri %}
+  {% set photo_url = node.field_profile_photo[0].entity.field_media_image.entity.fileuri|image_style('profile') %}
 {% endif %}
 
 {% if node.field_photo.entity.fileuri %}


### PR DESCRIPTION
[SG-2019]

Changed the output of people card images to render a specific image style, rather that just rendering the original image, which could be very large.

Instructions
- clear cache
- Reload homepage and view that the image used in the mayor profile, and other profiles use a smaller image with the profile image style url

[SG-2019]: https://sfgovdt.jira.com/browse/SG-2019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ