### PR TITLE
[SG-2013] [SG-2012] [SG-2010] -- Profile content type/paragraph type changes

### DIFF
--- a/config/core.entity_form_display.node.person.default.yml
+++ b/config/core.entity_form_display.node.person.default.yml
@@ -50,7 +50,7 @@ third_party_settings:
       label: 'Contact footer'
       region: content
       parent_name: ''
-      weight: 12
+      weight: 11
       format_type: fieldset
       format_settings:
         classes: ''
@@ -64,7 +64,7 @@ third_party_settings:
       label: 'Optional content'
       region: content
       parent_name: group_items
-      weight: 17
+      weight: 11
       format_type: accordion_item
       format_settings:
         classes: ''
@@ -77,7 +77,7 @@ third_party_settings:
       label: 'OC Accordion'
       region: content
       parent_name: ''
-      weight: 13
+      weight: 12
       format_type: accordion
       format_settings:
         classes: ''
@@ -92,7 +92,7 @@ mode: default
 content:
   body:
     type: text_textarea_with_summary
-    weight: 8
+    weight: 7
     region: content
     settings:
       rows: 5
@@ -112,7 +112,7 @@ content:
         maxlength_js_truncate_html: false
   created:
     type: datetime_timestamp
-    weight: 16
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -133,7 +133,7 @@ content:
     third_party_settings: {  }
   field_city_department:
     type: entity_reference_autocomplete
-    weight: 6
+    weight: 5
     region: content
     settings:
       match_operator: CONTAINS
@@ -143,7 +143,7 @@ content:
     third_party_settings: {  }
   field_direct_external_url:
     type: link_default
-    weight: 14
+    weight: 13
     region: content
     settings:
       placeholder_url: ''
@@ -222,7 +222,7 @@ content:
     third_party_settings: {  }
   field_primary_email:
     type: email_default
-    weight: 9
+    weight: 8
     region: content
     settings:
       placeholder: ''
@@ -230,14 +230,14 @@ content:
     third_party_settings: {  }
   field_primary_phone_number:
     type: telephone_default
-    weight: 10
+    weight: 9
     region: content
     settings:
       placeholder: ''
     third_party_settings: {  }
   field_profile_photo:
     type: entity_browser_entity_reference
-    weight: 7
+    weight: 6
     region: content
     settings:
       entity_browser: image
@@ -248,12 +248,6 @@ content:
       open: false
       field_widget_display_settings: {  }
       selection_mode: selection_append
-    third_party_settings: {  }
-  field_profile_type:
-    type: options_select
-    weight: 3
-    region: content
-    settings: {  }
     third_party_settings: {  }
   field_pronouns:
     type: string_textfield
@@ -268,7 +262,7 @@ content:
         maxlength_js_label: (<strong>@count</strong>/@limit)
   field_social_media:
     type: paragraphs
-    weight: 11
+    weight: 10
     region: content
     settings:
       title: Paragraph
@@ -306,7 +300,7 @@ content:
     third_party_settings: {  }
   field_sub_title:
     type: string_textfield
-    weight: 5
+    weight: 4
     region: content
     settings:
       size: 60
@@ -314,7 +308,7 @@ content:
     third_party_settings: {  }
   field_title:
     type: string_textfield
-    weight: 4
+    weight: 3
     region: content
     settings:
       size: 60
@@ -322,13 +316,13 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 20
+    weight: 19
     region: content
     settings: {  }
     third_party_settings: {  }
   path:
     type: path
-    weight: 18
+    weight: 17
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -341,19 +335,19 @@ content:
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 25
+    weight: 24
     region: content
     settings: {  }
     third_party_settings: {  }
   publish_state:
     type: scheduler_moderation
-    weight: 23
+    weight: 22
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 21
+    weight: 20
     region: content
     settings:
       display_label: true
@@ -367,20 +361,20 @@ content:
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: 22
+    weight: 21
     region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
   translation:
-    weight: 17
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }
   translation_notes:
     type: string_textarea
-    weight: 102
+    weight: 27
     region: content
     settings:
       rows: 4
@@ -388,14 +382,14 @@ content:
     third_party_settings: {  }
   translation_outdated:
     type: boolean_checkbox
-    weight: 101
+    weight: 26
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 15
+    weight: 14
     region: content
     settings:
       match_operator: CONTAINS
@@ -405,18 +399,18 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 24
+    weight: 23
     region: content
     settings: {  }
     third_party_settings: {  }
   unpublish_state:
     type: scheduler_moderation
-    weight: 26
+    weight: 25
     region: content
     settings: {  }
     third_party_settings: {  }
   url_redirects:
-    weight: 19
+    weight: 18
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -424,4 +418,5 @@ hidden:
   field_biography: true
   field_photo: true
   field_profile_positions_held: true
+  field_profile_type: true
   langcode: true

--- a/config/core.entity_form_display.paragraph.public_body_profiles.default.yml
+++ b/config/core.entity_form_display.paragraph.public_body_profiles.default.yml
@@ -24,12 +24,6 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-  field_position_type:
-    type: options_select
-    weight: 2
-    region: content
-    settings: {  }
-    third_party_settings: {  }
   field_profile:
     type: entity_reference_autocomplete
     weight: 0
@@ -41,7 +35,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   translation:
-    weight: 3
+    weight: 2
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -49,6 +43,7 @@ hidden:
   created: true
   field_department: true
   field_ending_year: true
+  field_position_type: true
   field_starting_year: true
   field_title: true
   status: true

--- a/config/core.entity_form_display.paragraph.public_body_profiles.profile_position.yml
+++ b/config/core.entity_form_display.paragraph.public_body_profiles.profile_position.yml
@@ -13,7 +13,6 @@ dependencies:
     - field.field.paragraph.public_body_profiles.field_title
     - paragraphs.paragraphs_type.public_body_profiles
   module:
-    - datetime
     - maxlength
 id: paragraph.public_body_profiles.profile_position
 targetEntityType: paragraph
@@ -38,24 +37,6 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-  field_ending_year:
-    type: datetime_default
-    weight: 5
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  field_position_type:
-    type: options_select
-    weight: 3
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  field_starting_year:
-    type: datetime_default
-    weight: 4
-    region: content
-    settings: {  }
-    third_party_settings: {  }
   field_title:
     type: string_textfield
     weight: 0
@@ -68,11 +49,14 @@ content:
         maxlength_js: null
         maxlength_js_label: (<strong>@count</strong>/@limit)
   translation:
-    weight: 6
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
   created: true
+  field_ending_year: true
+  field_position_type: true
   field_profile: true
+  field_starting_year: true
   status: true

--- a/config/core.entity_view_display.node.person.default.yml
+++ b/config/core.entity_view_display.node.person.default.yml
@@ -31,7 +31,6 @@ dependencies:
     - image
     - link
     - media
-    - options
     - telephone_formatter
     - text
     - user
@@ -45,7 +44,7 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 19
+    weight: 18
     region: content
   content_moderation_control:
     settings: {  }
@@ -58,7 +57,7 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 17
+    weight: 16
     region: content
   field_city_department:
     type: entity_reference_label
@@ -78,7 +77,7 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    weight: 9
+    weight: 8
     region: content
   field_email:
     type: entity_reference_revisions_entity_view
@@ -87,7 +86,7 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 10
+    weight: 9
     region: content
   field_featured_items:
     type: entity_reference_revisions_entity_view
@@ -96,7 +95,7 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 12
+    weight: 11
     region: content
   field_first_name:
     type: string
@@ -121,7 +120,7 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 13
+    weight: 12
     region: content
   field_photo:
     type: image
@@ -139,7 +138,7 @@ content:
     label: above
     settings: {  }
     third_party_settings: {  }
-    weight: 15
+    weight: 14
     region: content
   field_primary_phone_number:
     type: telephone_formatter
@@ -149,7 +148,7 @@ content:
       link: true
       default_country: null
     third_party_settings: {  }
-    weight: 16
+    weight: 15
     region: content
   field_profile_photo:
     type: media_thumbnail
@@ -169,14 +168,7 @@ content:
       view_mode: profile_position
       link: ''
     third_party_settings: {  }
-    weight: 18
-    region: content
-  field_profile_type:
-    type: list_default
-    label: above
-    settings: {  }
-    third_party_settings: {  }
-    weight: 8
+    weight: 17
     region: content
   field_pronouns:
     type: string
@@ -184,7 +176,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 20
+    weight: 19
     region: content
   field_social_media:
     type: entity_reference_revisions_entity_view
@@ -193,7 +185,7 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 14
+    weight: 13
     region: content
   field_spotlight:
     type: entity_reference_revisions_entity_view
@@ -202,7 +194,7 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 11
+    weight: 10
     region: content
   field_sub_title:
     type: string
@@ -222,6 +214,7 @@ content:
     region: content
 hidden:
   field_biography: true
+  field_profile_type: true
   langcode: true
   links: true
   search_api_excerpt: true

--- a/config/core.entity_view_display.paragraph.public_body_profiles.default.yml
+++ b/config/core.entity_view_display.paragraph.public_body_profiles.default.yml
@@ -11,9 +11,6 @@ dependencies:
     - field.field.paragraph.public_body_profiles.field_starting_year
     - field.field.paragraph.public_body_profiles.field_title
     - paragraphs.paragraphs_type.public_body_profiles
-  module:
-    - datetime
-    - options
 id: paragraph.public_body_profiles.default
 targetEntityType: paragraph
 bundle: public_body_profiles
@@ -25,7 +22,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 1
+    weight: 0
     region: content
   field_department:
     type: entity_reference_label
@@ -33,48 +30,12 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 6
-    region: content
-  field_ending_year:
-    type: datetime_default
-    label: above
-    settings:
-      timezone_override: ''
-      format_type: medium
-    third_party_settings: {  }
-    weight: 4
-    region: content
-  field_position_type:
-    type: list_default
-    label: above
-    settings: {  }
-    third_party_settings: {  }
-    weight: 2
-    region: content
-  field_profile:
-    type: entity_reference_label
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    weight: 5
-    region: content
-  field_starting_year:
-    type: datetime_default
-    label: above
-    settings:
-      timezone_override: ''
-      format_type: medium
-    third_party_settings: {  }
-    weight: 3
-    region: content
-  field_title:
-    type: string
-    label: above
-    settings:
-      link_to_entity: false
-    third_party_settings: {  }
-    weight: 7
+    weight: 1
     region: content
 hidden:
+  field_ending_year: true
+  field_position_type: true
+  field_profile: true
+  field_starting_year: true
+  field_title: true
   search_api_excerpt: true

--- a/config/core.entity_view_display.paragraph.public_body_profiles.profile_position.yml
+++ b/config/core.entity_view_display.paragraph.public_body_profiles.profile_position.yml
@@ -12,9 +12,6 @@ dependencies:
     - field.field.paragraph.public_body_profiles.field_starting_year
     - field.field.paragraph.public_body_profiles.field_title
     - paragraphs.paragraphs_type.public_body_profiles
-  module:
-    - datetime
-    - options
 id: paragraph.public_body_profiles.profile_position
 targetEntityType: paragraph
 bundle: public_body_profiles
@@ -36,32 +33,10 @@ content:
     third_party_settings: {  }
     weight: 1
     region: content
-  field_ending_year:
-    type: datetime_default
-    label: hidden
-    settings:
-      timezone_override: ''
-      format_type: medium
-    third_party_settings: {  }
-    weight: 4
-    region: content
-  field_position_type:
-    type: list_default
-    label: hidden
-    settings: {  }
-    third_party_settings: {  }
-    weight: 2
-    region: content
-  field_starting_year:
-    type: datetime_default
-    label: hidden
-    settings:
-      timezone_override: ''
-      format_type: medium
-    third_party_settings: {  }
-    weight: 3
-    region: content
 hidden:
+  field_ending_year: true
+  field_position_type: true
   field_profile: true
+  field_starting_year: true
   field_title: true
   search_api_excerpt: true

--- a/web/themes/custom/sfgovpl/src/sass/node/_node-person.scss
+++ b/web/themes/custom/sfgovpl/src/sass/node/_node-person.scss
@@ -4,6 +4,7 @@
   .profile--container-narrow {
     @include contain-1090;
     @include clearfix;
+    padding-top: 60px;
     margin-bottom: 60px;
   }
 
@@ -17,10 +18,10 @@
     display: none;
   }
 
-  #block-sfgovpl-content {
-    border-top: 3px solid $c-border;
-    padding-top: 60px;
-  }
+  //#block-sfgovpl-content {
+  //  border-top: 3px solid $c-border;
+  //  padding-top: 60px;
+  //}
 
   .main-content-container {
     @include clearfix;
@@ -146,28 +147,38 @@
         @include media($medium-screen) {
           @include fs-title-3;
         }
-      }
-      .profile--job .city-employee {
-        @include fs-big-description-mobile;
         a {
           text-decoration: none;
         }
         @include media($medium-screen) {
           @include fs-big-description;
         }
+        .profile--job__title, .profile--job__sub-title, .profile--role-agency-title {
+          @include fs-title-3;
+          font-weight: 600;
+          display: block;
+        }
+        .profile--job__sub-title {
+          font-weight: 400;
+        }
+      }
+
+      .profile--roles--label {
+        @include fs-title-5;
+        font-weight: 400;
+        margin: 0;
       }
 
       .profile--role {
         @include fs-big-description;
-        margin-bottom: 25px;
-        div {
-          display: inline-block;
+        margin-bottom: 1rem;
+        span {
+          display: inline;
         }
         .role-title {
           font-weight: 400;
         }
         .role-agency-title {
-          display: block;
           a {
             text-decoration: none;
           }
@@ -226,6 +237,13 @@
         padding-left: 0;
         padding-right: 0;
       }
+      .__featured-items {
+        > div.flex {
+          > a.group {
+            flex: 1 1 32%;
+          }
+        }
+      }
     }
 
     .profile--container-wide.additional-roles {
@@ -264,7 +282,7 @@
       }
     }
 
-    .profile--contact.city-employee {
+    .profile--contact {
       border-top: none;
       padding-top: 0;
       .contact-address {

--- a/web/themes/custom/sfgovpl/templates/field/field--node--field-profile-positions-held.html.twig
+++ b/web/themes/custom/sfgovpl/templates/field/field--node--field-profile-positions-held.html.twig
@@ -37,8 +37,10 @@
  */
 #}
 {% set profileType = element['#object'].get('field_profile_type').value %}
+<div class="profile--roles">
+  {# <div class="profile--roles--label">{{ 'Additional groups and roles'|t }}</div> #}
 
-{% for item in items %}
+  {% for item in items %}
   {% set paragraph = item.content['#paragraph'] %}
   {% set positionType = paragraph.field_position_type.value %}
   {% set positionTitle = paragraph.field_commission_position.value %}
@@ -47,42 +49,18 @@
   {% set positionStart = paragraph.field_starting_year.value %}
   {% set positionEnd = paragraph.field_ending_year.value %}
 
-  {% if profileType|lower == 'city employee' %}
-    <div class="profile--additional-role">
-      {% if positionTitle is not empty %}
-        <div class="additional-role-title">{{ positionTitle }},</div>
-      {% endif %}
-      <div class="additional-role-agency-title">
-        <a href="{{ positionAgencyUrl }}">{{ positionAgency }}</a>
-      </div>
-    </div>
-  {% endif %}
-
-  {% if profileType|lower == 'external' %}
-    <div class="profile--role">
-      <div class="role-title">
-        {{ positionTitle }}
-      </div>
-      <div class="role-agency-title">
-        <a href="{{ positionAgencyUrl }}"> {{ positionAgency }} </a>
-      </div>
-      <div class="role-time">
-        {%- if positionType is not empty -%}
-          {{- positionType -}}
-        {%- endif -%}
-        {%- if positionType is not empty and (positionStart is not empty or positionEnd is not empty) -%}
-          {{- ": " -}}
-        {%- endif -%}
-        {% if positionStart is not empty %}
-          {{ positionStart|date('Y') }}
-        {% endif %}
-        {% if positionStart is not empty and positionEnd is not empty %}
-          -
-        {% endif %}
-        {% if positionEnd is not empty %}
-          {{ positionEnd|date('Y') }}
-        {% endif %}
-      </div>
-    </div>
-  {% endif %}
+  <div class="profile--role">
+    {%- if positionTitle is not empty -%}
+      <span class="role-title">
+        {{- positionTitle -}}
+        {%- if positionAgency is not empty -%}, {%- endif -%}
+      </span>
+    {%- endif -%}
+    {%- if positionAgency is not empty -%}
+      <span class="role-agency-title">
+        <a href="{{ positionAgencyUrl }}">{{- positionAgency -}}</a>
+      </span>
+    {%- endif -%}
+  </div>
 {% endfor %}
+</div>

--- a/web/themes/custom/sfgovpl/templates/node/node--person--full.html.twig
+++ b/web/themes/custom/sfgovpl/templates/node/node--person--full.html.twig
@@ -16,13 +16,16 @@
 
   {{ attach_library('sfgovpl/sfgov-person') }}
 
+  <span class="hero-banner--border"><span class="hero-banner--border-contain"></span></span>
+
   <div class="profile--container-narrow">
 
     <div class="profile--info">
+
       <h1 class="profile--name">
         <div>{{ node.field_first_name.0.value|striptags }} {{ node.field_last_name.0.value|striptags }}</div>
         {%- if content.field_pronouns|render|striptags|trim -%}
-          <div class="tracking-0 font-regular text-big-desc mt-16 lg:text-big-desc-desktop">({{- node.field_pronouns.value|replace({'(': '', ')': ''})|lower -}})</div>
+          <div class="profile--pronouns tracking-0 font-regular text-big-desc lg:text-big-desc-desktop">({{- node.field_pronouns.value|replace({'(': '', ')': ''})|lower -}})</div>
         {%- endif -%}
       </h1>
 
@@ -65,196 +68,180 @@
       </div>
 
       <div class="profile--job">
-        {% if profile_type == 'City Employee' %}
-        <div class="city-employee">
-          {% else %}
-          <div class="commissioner">
-            {% endif %}
-            {% if node.field_title.value|length %}
-              {{ node.field_title.value|striptags }}{% if (node.field_title.value|length) and (node.field_sub_title.value) %}<br>{% endif %}
-            {% endif %}
-            {% if node.field_sub_title.value %}
-              {{ node.field_sub_title.value|striptags }}
-            {% endif %}
-
-            {% if profile_type == 'City Employee' %}
-              {% if (node.field_city_department.entity.title.value) and (node.field_city_department.entity.nid.value != node.nid.value) %}
-                <div class="role-agency-title">
-                  <a href="{{ path('entity.node.canonical', {'node': node.field_city_department.entity.nid.value}) }}">
-                    {# translate entity reference title if it exists #}
-                    {# variable language is exposed via hook_preprocess_node #}
-                    {# @see web/themes/custom/sfgovpl/includes/node.inc #}
-                    {% if node.field_city_department.entity.hasTranslation(language) %}
-                      {{ node.field_city_department.entity.translation(language).title.value }}
-                    {% else %}
-                      {{ node.field_city_department.entity.title.value }}
-                    {% endif %}
-                  </a>
-                </div>
+        {% if node.field_title.value|length %}
+          <span class="profile--job__title">
+            {{- node.field_title.value|striptags|trim -}}
+            {% if (node.field_city_department.entity.title.value) and (node.field_city_department.entity.nid.value != node.nid.value) or (node.field_sub_title.value) %}{{- ',' -}}{% endif %}
+          </span>
+        {% endif %}
+        {% if node.field_sub_title.value %}
+          <span class="profile--job__sub-title">
+            {{- node.field_sub_title.value|striptags|trim -}}
+          </span>
+        {% endif %}
+        {% if (node.field_city_department.entity.title.value) and (node.field_city_department.entity.nid.value != node.nid.value) %}
+          <span class="profile--role-agency-title">
+            <a href="{{ path('entity.node.canonical', {'node': node.field_city_department.entity.nid.value}) }}">
+              {# translate entity reference title if it exists #}
+              {# variable language is exposed via hook_preprocess_node #}
+              {# @see web/themes/custom/sfgovpl/includes/node.inc #}
+              {% if node.field_city_department.entity.hasTranslation(language) %}
+                {{- node.field_city_department.entity.translation(language).title.value|trim -}}
+              {% else %}
+                {{- node.field_city_department.entity.title.value|trim -}}
               {% endif %}
-            {% endif %}
-
-          </div>
-        </div>
-
-        {% if profile_type == 'External' %}
-          {{ content.field_profile_positions_held }}
+            </a>
+          </span>
         {% endif %}
-
-        {% if profile_fields.biotrim|length %}
-          {% if node.body.value|length %}
-            <div class="profile--bio">
-              <div class="bio-trimmed">
-                {{ profile_fields.biotrim }}
-              </div>
-              <div class="bio-full">
-                {{ content.body }}
-              </div>
-              <div class="show-bio">{{ 'Show more'|t }}</div>
-              <div class="hide-bio">{{ 'Show less'|t }}</div>
-            </div>
-          {% endif %}
-        {% elseif node.body.value|length %}
-          <div class="profile--bio">
-            <div class="biography">
-              {{ content.body }}
-            </div>
-          </div>
-        {% endif %}
-
-        <div class="profile--optional-content">
-          {{ content.field_spotlight }}
-          {{ content.field_featured_items }}
-        </div>
       </div>
-    </div>
 
-    {% if (profile_type == 'City Employee' and content.field_profile_positions_held|render) %}
-      <div class="profile--container-wide additional-roles">
-        <div class="profile--container-narrow">
-          <div class="profile--additional-roles">
-            <h2>{{ 'Additional city roles'|t }}</h2>
-            {{ content.field_profile_positions_held }}
-          </div>
-        </div>
-      </div>
-    {% endif %}
-
-    {% if hasAddress or hasPhone or hasEmail %}
-    <div class="profile--container-narrow">
-      <div class="profile--contact city-employee">
-        <h2>{{ 'Contact'|t }}</h2>
-        <div class="contact-wrapper">
-          <div class="sfgov-container-three-column">
-            {% if hasAddress %}
-              <div class="contact-address sfgov-container-item">
-                <div class="sfgov-contact-section address">
-                  <label>{{ profile_fields.address.title }}</label>
-                  <p>
-                    {% if profile_fields.address.organization %}
-                      {{ profile_fields.address.organization }} <br/>
-                    {% endif %}
-                    {% if profile_fields.address.addressee %}
-                      {{ profile_fields.address.addressee }} <br/>
-                    {% endif %}
-                    {% if profile_fields.address.location_name %}
-                      {{ profile_fields.address.location_name }} <br/>
-                    {% endif %}
-                    {% if profile_fields.address.line1 %}
-                      {{ profile_fields.address.line1 }} <br/>
-                    {% endif %}
-                    {% if profile_fields.address.line2 %}
-                      {{ profile_fields.address.line2 }} <br/>
-                    {% endif %}
-                    {% if (profile_fields.address.city) or (profile_fields.address.state) %}
-                      {{ profile_fields.address.city }}, {{ profile_fields.address.state }} {{ profile_fields.address.zip }}
-                    {% endif %}
-                  </p>
-
-                  {% if profile_fields.map %}
-                    <div class="map">
-                      {% if profile_fields.map.map_img_url %}
-                        <div class="simple-gmap-static-map">
-                          <a href="{{ profile_fields.map.map_site_url }}"><img src="{{ profile_fields.map.map_img_url }}" alt="{{ 'View location on google maps'|t }}"/></a>
-                        </div>
-                      {% endif %}
-                      {% if profile_fields.map.map_directions_url %}
-                        <p class="simple-gmap-link">
-                          <a href="{{ profile_fields.map.map_directions_url }}">{{ 'Get directions'|t }}</a>
-                        </p>
-                      {% endif %}
-                    </div>
-                  {% endif %}
-
-                </div>
-              </div>
-            {% endif %}
-
-            {% if hasPhone %}
-              <div class="contact-phone sfgov-container-item">
-                <div class="sfgov-contact-section phone">
-                  <label>{{ 'Phone'|t }}</label>
-
-                  {% for key, item in node.field_city_department[0].entity.field_phone_numbers if key|first != '#'%}
-                    <div class="phone-wrapper">
-                      {% if item.entity.field_tel.value %}
-                        <div class="phone-title">
-                          {{ item.entity.field_owner.value|raw }}
-                        </div>
-                        <div class="phone-number">
-                          <a href="tel:+{{ item.entity.field_tel.value|raw }}">
-                            {{ item.entity.field_tel.value|raw }}
-                          </a>
-                        </div>
-                        <div class="phone-desc">
-                          {{ item.entity.field_text.value|raw }}
-                        </div>
-                      {% endif %}
-                    </div>
-                  {% endfor %}
-
-                  {% if content.field_phone_numbers %}
-                    {{ content.field_phone_numbers }}
-                  {% endif %}
-
-                </div>
-              </div>
-            {% endif %}
-
-            {% if hasEmail %}
-              <div class="contact-email sfgov-container-item">
-                <div class="sfgov-contact-section email">
-                  <label>{{ 'Email'|t }}</label>
-
-                  {% for key, item in node.field_city_department[0].entity.field_email if key|first != '#'%}
-                    <div class="email-wrapper">
-                      {% if item.entity.field_email.value %}
-                        <div class="email-title">
-                          {{ item.entity.field_title.value|raw }}
-                        </div>
-                        <div class="email-email">
-                          <a href="mailto:{{ node.field_city_department[0].entity.field_email[0].entity.field_email.value|raw }}">
-                            {{ item.entity.field_email.value|raw }}
-                          </a>
-                        </div>
-                      {% endif %}
-                    </div>
-                  {% endfor %}
-
-                  {% if content.field_email %}
-                    {{ content.field_email }}
-                  {% endif %}
-
-                </div>
-              </div>
-            {% endif %}
-          </div>
-        </div>
-      </div>
+      {% if (node.field_profile_positions_held.value|length) %}
+        {{ content.field_profile_positions_held }}
       {% endif %}
 
+      {% if profile_fields.biotrim|length %}
+        {% if node.body.value|length %}
+          <div class="profile--bio">
+            <div class="bio-trimmed">
+              {{ profile_fields.biotrim }}
+            </div>
+            <div class="bio-full">
+              {{ content.body }}
+            </div>
+            <div class="show-bio">{{ 'Show more'|t }}</div>
+            <div class="hide-bio">{{ 'Show less'|t }}</div>
+          </div>
+        {% endif %}
+      {% elseif node.body.value|length %}
+        <div class="profile--bio">
+          <div class="biography">
+            {{ content.body }}
+          </div>
+        </div>
+      {% endif %}
 
+      <div class="profile--optional-content">
+        {{ content.field_spotlight }}
+        {{ content.field_featured_items }}
+      </div>
     </div>
+  </div>
+
+  {% if hasAddress or hasPhone or hasEmail %}
+    <div class="profile--container-narrow">
+    <div class="profile--contact city-employee">
+      <h2>{{ 'Contact'|t }}</h2>
+      <div class="contact-wrapper">
+        <div class="sfgov-container-three-column">
+          {% if hasAddress %}
+            <div class="contact-address sfgov-container-item">
+              <div class="sfgov-contact-section address">
+                <label>{{ profile_fields.address.title }}</label>
+                <p>
+                  {% if profile_fields.address.organization %}
+                    {{ profile_fields.address.organization }} <br/>
+                  {% endif %}
+                  {% if profile_fields.address.addressee %}
+                    {{ profile_fields.address.addressee }} <br/>
+                  {% endif %}
+                  {% if profile_fields.address.location_name %}
+                    {{ profile_fields.address.location_name }} <br/>
+                  {% endif %}
+                  {% if profile_fields.address.line1 %}
+                    {{ profile_fields.address.line1 }} <br/>
+                  {% endif %}
+                  {% if profile_fields.address.line2 %}
+                    {{ profile_fields.address.line2 }} <br/>
+                  {% endif %}
+                  {% if (profile_fields.address.city) or (profile_fields.address.state) %}
+                    {{ profile_fields.address.city }}, {{ profile_fields.address.state }} {{ profile_fields.address.zip }}
+                  {% endif %}
+                </p>
+
+                {% if profile_fields.map %}
+                  <div class="map">
+                    {% if profile_fields.map.map_img_url %}
+                      <div class="simple-gmap-static-map">
+                        <a href="{{ profile_fields.map.map_site_url }}"><img src="{{ profile_fields.map.map_img_url }}" alt="{{ 'View location on google maps'|t }}"/></a>
+                      </div>
+                    {% endif %}
+                    {% if profile_fields.map.map_directions_url %}
+                      <p class="simple-gmap-link">
+                        <a href="{{ profile_fields.map.map_directions_url }}">{{ 'Get directions'|t }}</a>
+                      </p>
+                    {% endif %}
+                  </div>
+                {% endif %}
+
+              </div>
+            </div>
+          {% endif %}
+
+          {% if hasPhone %}
+            <div class="contact-phone sfgov-container-item">
+              <div class="sfgov-contact-section phone">
+                <label>{{ 'Phone'|t }}</label>
+
+                {% for key, item in node.field_city_department[0].entity.field_phone_numbers if key|first != '#'%}
+                  <div class="phone-wrapper">
+                    {% if item.entity.field_tel.value %}
+                      <div class="phone-title">
+                        {{ item.entity.field_owner.value|raw }}
+                      </div>
+                      <div class="phone-number">
+                        <a href="tel:+{{ item.entity.field_tel.value|raw }}">
+                          {{ item.entity.field_tel.value|raw }}
+                        </a>
+                      </div>
+                      <div class="phone-desc">
+                        {{ item.entity.field_text.value|raw }}
+                      </div>
+                    {% endif %}
+                  </div>
+                {% endfor %}
+
+                {% if content.field_phone_numbers %}
+                  {{ content.field_phone_numbers }}
+                {% endif %}
+
+              </div>
+            </div>
+          {% endif %}
+
+          {% if hasEmail %}
+            <div class="contact-email sfgov-container-item">
+              <div class="sfgov-contact-section email">
+                <label>{{ 'Email'|t }}</label>
+
+                {% for key, item in node.field_city_department[0].entity.field_email if key|first != '#'%}
+                  <div class="email-wrapper">
+                    {% if item.entity.field_email.value %}
+                      <div class="email-title">
+                        {{ item.entity.field_title.value|raw }}
+                      </div>
+                      <div class="email-email">
+                        <a href="mailto:{{ node.field_city_department[0].entity.field_email[0].entity.field_email.value|raw }}">
+                          {{ item.entity.field_email.value|raw }}
+                        </a>
+                      </div>
+                    {% endif %}
+                  </div>
+                {% endfor %}
+
+                {% if content.field_email %}
+                  {{ content.field_email }}
+                {% endif %}
+
+              </div>
+            </div>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  {% endif %}
+
+
+  </div>
   </div>
   </div>
 


### PR DESCRIPTION
[SG-2013]
[SG-2012]
[SG-2010]

Profile content type/paragraph type changes

- Removed profile type field from Profile content type
- Removed support for city/external employee type. This required some changes to how the templates work for content output
- Appointment years are removed from output.

Instructions:
- clear cache
- config import
- Review profiles with different content and setups to see how things look.
- Create new profile to test out all content field.

[SG-2013]: https://sfgovdt.jira.com/browse/SG-2013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SG-2012]: https://sfgovdt.jira.com/browse/SG-2012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SG-2010]: https://sfgovdt.jira.com/browse/SG-2010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ