### PR TITLE
[SG-1999] -- "Free" cost option for Transaction pages not translatable

### DIFF
--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--cost.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--cost.html.twig
@@ -53,7 +53,7 @@
       {% endblock title %}
       {% if cost_type == 'free' %}
         {% block costfree %}
-          <div>{{ paragraph.field_cost_type.0.value|capitalize ~ '.' }}</div>
+          {{ '@free.'|t({'@free': content.field_cost_type[0]['#markup']}) }}
         {% endblock costfree %}
       {% endif %}
       {% if cost_type == 'flat' %}


### PR DESCRIPTION
[SG-1999] 

"Free" cost option for Transaction pages not translatable

[SG-1999]: https://sfgovdt.jira.com/browse/SG-1999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ