### PR TITLE
[SG-1997] -- Set "See more news" and "Learn more about us" to translatable

### DIFF
--- a/web/modules/custom/sfgov_about/sfgov_about.module
+++ b/web/modules/custom/sfgov_about/sfgov_about.module
@@ -119,7 +119,7 @@ function sfgov_about_preprocess_node(&$variables) {
         $variables['about_page_link'] = [
           '#type' => 'link',
           '#url' => $about_node->toUrl(),
-          '#title' => "Learn more about us"
+          '#title' => t("Learn more about us"),
         ];
 
         // Add cachable dependency.

--- a/web/themes/custom/sfgovpl/includes/views.inc
+++ b/web/themes/custom/sfgovpl/includes/views.inc
@@ -71,6 +71,8 @@ function sfgovpl_preprocess_views_view__news__news_block_depts(&$variables) {
       ),
     );
     $variables['more']['#url']->setOptions($url_options);
+
+    $variables['more']['#title'] = t('See more news', [], ['context' => 'News Block - Dept']);
   }
 }
 
@@ -96,7 +98,7 @@ function sfgovpl_preprocess_views_view__events__block(&$variables, $display_id) 
   if (!empty($view->args[0])) {
     $node = $node_manager->load($view->args[0]);
     if ($node instanceof Node) {
-      
+
       // Get some managers ready for later use.
       $view_manager = \Drupal::entityTypeManager()->getStorage('view');
 


### PR DESCRIPTION
[SG-1997]
 
Set "See more news" and "Learn more about us" to translatable.

Instructions:
- Clear cache
- Go to the UI translation interface section, and search for the strings "See more news" and "Learn more about us"
- Confirm that they appear and are translatable.

[SG-1997]: https://sfgovdt.jira.com/browse/SG-1997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ