### PR TITLE
[SG-2020] -- Responsive image work

### DIFF
--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--campaign-spotlight.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--campaign-spotlight.html.twig
@@ -7,7 +7,7 @@
 {# Spotlight Image #}
 {% if content.field_spotlight_img|render %}
   {% set image = paragraph.field_spotlight_img.entity %}
-  {% set img_url = image ? file_url(image.field_media_image.entity.fileuri) : null %}
+  {% set img_url = image ? paragraph.field_spotlight_img[0].entity.field_media_image.entity.fileuri|image_style('836x484') : null %}
   {% set img_alt = image.field_media_image.alt|trim|default('image') %}
   {% set img_attributes = create_attribute({
     'role': 'img',

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--spotlight.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--spotlight.html.twig
@@ -3,7 +3,7 @@
 
 {% if content.field_spotlight_img|render %}
   {% set image = paragraph.field_spotlight_img.entity %}
-  {% set img_url = image ? file_url(image.field_media_image.entity.fileuri) : null %}
+  {% set img_url = image ? paragraph.field_spotlight_img[0].entity.field_media_image.entity.fileuri|image_style('836x484') : null %}
   {% set img_alt = image.field_media_image.alt|trim %}
   {% set img_attributes = create_attribute({
     'aria-label': img_alt,
@@ -47,7 +47,7 @@
       {% else %}
         <div class="sfgov-spotlight-section sfgov-spotlight-content full-width">
       {% endif %}
-      
+
         {% if content.field_title|render %}
           <h2 class="sfgov-spotlight-title">{{ content.field_title }}</h2>
         {% endif %}


### PR DESCRIPTION
[SG-2020]

Responsive image work

Set Spotlight and Campaign Spotlight image output to use a defined image style to make sure that a smaller, more appropriate sized image is in place, rather than allow the original image which could be huge.

Instructions
- Clear cache
- visit a page where a spotlight can be added
- Add a spotlight with a large sized image and save
- Confirm that a processed version of the image is output and is smaller than the original
- Repeat for campaign spotlight

[SG-2020]: https://sfgovdt.jira.com/browse/SG-2020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ