### PR TITLE
feat: mobile card fix

### DIFF
--- a/web/themes/custom/sfgovpl/templates/components/card.twig
+++ b/web/themes/custom/sfgovpl/templates/components/card.twig
@@ -1,4 +1,4 @@
-<a href="{{ url }}" class="bg-white text-body no-underline p-20 border-grey-2 border-3 border-solid rounded hocus:border-blue-bright">
+<a href="{{ url }}" class="block bg-white text-body no-underline p-20 border-grey-2 border-3 border-solid rounded hocus:border-blue-bright">
   <p class="text-action font-medium underline m-0 mb-8">{{ title }}</p>
   <p class="m-0 description text-slate-4">
     {{ description }}


### PR DESCRIPTION
Adding display block to cards so when on mobile they card border/background do no break SG-2030