### PR TITLE
[SG-2029] -- Remove content from previous held positions display, if …

### DIFF
--- a/web/themes/custom/sfgovpl/includes/field.inc
+++ b/web/themes/custom/sfgovpl/includes/field.inc
@@ -1,5 +1,7 @@
 <?php
 
+use Drupal\paragraphs\Entity\Paragraph;
+
 /**
  * Implements template_preprocess_field().
  */
@@ -107,6 +109,30 @@ function sfgovpl_preprocess_field__paragraph__field_link(&$variables) {
     $link_title = $variables['items'][$delta]['content']['#title'];
     if (empty($variables['items'][$delta]['content']['#options']['attributes']['aria-label'])) {
       $variables['items'][$delta]['content']['#options']['attributes']['aria-label'] = $link_title . ' ' . $paragraph_title;
+    }
+  }
+}
+
+/**
+ * Implements template_preprocess_field().
+ */
+function sfgovpl_preprocess_field__node__field_profile_positions_held(&$variables) {
+  $entity_manager = \Drupal::entityTypeManager();
+
+  foreach ($variables['items'] as $delta => $content) {
+    $paragraph = $content['content']['#paragraph'] ?? NULL;
+    if ($paragraph instanceof Paragraph && $paragraph->hasField('field_department')) {
+      $value = $paragraph->get('field_department')->getValue();
+      $nid = $value[0]['target_id'];
+      $node = $entity_manager->getStorage('node')->load($nid);
+      $bundle = $node->bundle();
+
+      // If the type of the referenced node is of department or public body,
+      // then we keep the reference. If not, then we remove it from display.
+      $keep_value = ($bundle == 'department' || $bundle == 'public_body');
+      if (!$keep_value) {
+        unset($variables['items'][$delta]);
+      }
     }
   }
 }

--- a/web/themes/custom/sfgovpl/templates/field/field--node--field-profile-positions-held.html.twig
+++ b/web/themes/custom/sfgovpl/templates/field/field--node--field-profile-positions-held.html.twig
@@ -36,31 +36,33 @@
  * @see template_preprocess_field()
  */
 #}
+
 {% set profileType = element['#object'].get('field_profile_type').value %}
+
 <div class="profile--roles">
   {# <div class="profile--roles--label">{{ 'Additional groups and roles'|t }}</div> #}
 
   {% for item in items %}
-  {% set paragraph = item.content['#paragraph'] %}
-  {% set positionType = paragraph.field_position_type.value %}
-  {% set positionTitle = paragraph.field_commission_position.value %}
-  {% set positionAgency = paragraph.field_department.entity.label %}
-  {% set positionAgencyUrl = url('entity.node.canonical', {'node': paragraph.field_department.target_id}) %}
-  {% set positionStart = paragraph.field_starting_year.value %}
-  {% set positionEnd = paragraph.field_ending_year.value %}
+    {% set paragraph = item.content['#paragraph'] %}
+    {% set positionType = paragraph.field_position_type.value %}
+    {% set positionTitle = paragraph.field_commission_position.value %}
+    {% set positionAgency = paragraph.field_department.entity.label %}
+    {% set positionAgencyUrl = url('entity.node.canonical', {'node': paragraph.field_department.target_id}) %}
+    {% set positionStart = paragraph.field_starting_year.value %}
+    {% set positionEnd = paragraph.field_ending_year.value %}
 
-  <div class="profile--role">
-    {%- if positionTitle is not empty -%}
-      <span class="role-title">
-        {{- positionTitle -}}
-        {%- if positionAgency is not empty -%}, {%- endif -%}
-      </span>
-    {%- endif -%}
-    {%- if positionAgency is not empty -%}
-      <span class="role-agency-title">
-        <a href="{{ positionAgencyUrl }}">{{- positionAgency -}}</a>
-      </span>
-    {%- endif -%}
-  </div>
-{% endfor %}
+    <div class="profile--role">
+      {%- if positionTitle is not empty -%}
+        <span class="role-title">
+          {{- positionTitle -}}
+          {%- if positionAgency is not empty -%}, {%- endif -%}
+        </span>
+      {%- endif -%}
+      {%- if positionAgency is not empty -%}
+        <span class="role-agency-title">
+          <a href="{{ positionAgencyUrl }}">{{- positionAgency -}}</a>
+        </span>
+      {%- endif -%}
+    </div>
+  {% endfor %}
 </div>


### PR DESCRIPTION
[SG-2029]

Remove content from previous held positions display, if it is referencing content that is not a department or public body

Instructions:
- Clear cache
- Review the mayor bio page and/or any other bio pages where the news item is showing
- Confirm it does not display the errored content, and that it does not display anywhere else.

[SG-2029]: https://sfgovdt.jira.com/browse/SG-2029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ