### PR TITLE
updates to handle pantheon sra (secure runtime access)

### DIFF
--- a/.circleci/scripts/pantheon/02-init-site-under-test-clone-existing
+++ b/.circleci/scripts/pantheon/02-init-site-under-test-clone-existing
@@ -8,6 +8,8 @@ rm -rf \
   web/modules/custom/*/node_modules \
   web/themes/custom/*/node_modules
 
+terminus -n auth:login --machine-token="$TERMINUS_TOKEN"
+
 target_env="$TERMINUS_SITE.$TERMINUS_ENV"
 source_env="$TERMINUS_SITE.dev"
 # check if the $TERMINUS_ENV already exists.  if it does, don't clone the content

--- a/.circleci/scripts/saml/saml-dependencies
+++ b/.circleci/scripts/saml/saml-dependencies
@@ -19,6 +19,8 @@ syncEnv="dev"
 mkdir -pv $samlVendorConfig
 mkdir -pv $samlVendorMetadata
 
+terminus -n auth:login --machine-token="$TERMINUS_TOKEN"
+
 # copy the common saml config and metadata from pantheon to respective vendor directory
 if [[ ! -z "$TERMINUS_SITE" ]]; then
   terminus rsync $TERMINUS_SITE.$syncEnv:$samlRemoteCommonConfigDir $samlVendorConfig

--- a/.circleci/scripts/saml/saml-dependencies
+++ b/.circleci/scripts/saml/saml-dependencies
@@ -19,10 +19,9 @@ syncEnv="dev"
 mkdir -pv $samlVendorConfig
 mkdir -pv $samlVendorMetadata
 
-terminus -n auth:login --machine-token="$TERMINUS_TOKEN"
-
 # copy the common saml config and metadata from pantheon to respective vendor directory
 if [[ ! -z "$TERMINUS_SITE" ]]; then
+  terminus -n auth:login --machine-token="$TERMINUS_TOKEN"
   terminus rsync $TERMINUS_SITE.$syncEnv:$samlRemoteCommonConfigDir $samlVendorConfig
   terminus rsync $TERMINUS_SITE.$syncEnv:$samlRemoteCommonMetadataDir $samlVendorMetadata
 fi

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,7 +9,7 @@ jobs:
   checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: 16


### PR DESCRIPTION
some changes to accommodate flipping on [pantheon sra](https://docs.pantheon.io/guides/secure-development/secure-runtime-access):

* `terminus auth:login` before running any terminus commands
* **additional step not in this pr**: create a new ssh key pair between circleci and pantheon.  some terminus commands require this (eg `rsync`)