### PR TITLE
SG-2091 - disable editor survey block

### DIFF
--- a/config/block.block.editorsurvey.yml
+++ b/config/block.block.editorsurvey.yml
@@ -1,6 +1,6 @@
 uuid: aff90d1a-362b-4fcc-8bca-752aaa08c9e9
 langcode: en
-status: true
+status: false
 dependencies:
   config:
     - simple_block.simple_block.editor_survey


### PR DESCRIPTION
SG-2091

config export to disable editor survey block by default