### PR TITLE
chore: downgrade token to 1.12 to fix busted smart date range tokens

### DIFF
--- a/composer-manifest.yaml
+++ b/composer-manifest.yaml
@@ -170,7 +170,7 @@ packages:
     drupal/tmgmt_xtm: 6.3.0
     drupal/toc_api: 1.4.0
     drupal/toc_filter: 2.1.0
-    drupal/token: 1.13.0
+    drupal/token: 1.12.0
     drupal/twig_field_value: 2.0.2
     drupal/twig_tweak: 2.10.0
     drupal/upgrade_status: 3.19.0

--- a/composer.json
+++ b/composer.json
@@ -139,6 +139,7 @@
         "drupal/tmgmt_xtm": "^6.1",
         "drupal/toc_api": "^1.0",
         "drupal/toc_filter": "^2.0",
+        "drupal/token": "1.12",
         "drupal/twig_field_value": "^2.0",
         "drupal/twig_tweak": "^2.0",
         "drupal/variationcache": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5a41223c61aec98e1c463f8fba20c171",
+    "content-hash": "c3fb3e9cbb8cbdb5eab543757f8aa57f",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -9292,17 +9292,17 @@
         },
         {
             "name": "drupal/token",
-            "version": "1.13.0",
+            "version": "1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/token.git",
-                "reference": "8.x-1.13"
+                "reference": "8.x-1.12"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/token-8.x-1.13.zip",
-                "reference": "8.x-1.13",
-                "shasum": "f2a074b51726de3727c1d900237d6d471806a4d2"
+                "url": "https://ftp.drupal.org/files/projects/token-8.x-1.12.zip",
+                "reference": "8.x-1.12",
+                "shasum": "cefe1b203b793682f74ea43e18d0a814cf768763"
             },
             "require": {
                 "drupal/core": "^9.2 || ^10"
@@ -9310,8 +9310,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.13",
-                    "datestamp": "1697885927",
+                    "version": "8.x-1.12",
+                    "datestamp": "1688015262",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -9319,7 +9319,7 @@
                 },
                 "drush": {
                     "services": {
-                        "drush.services.yml": ">=9"
+                        "drush.services.yml": "^9 || ^10"
                     }
                 }
             },


### PR DESCRIPTION
SG-1234

upgrading to Token 1.13 broke the smart date tokens.

issue conversation here: https://www.drupal.org/project/smart_date/issues/3402367