### PR TITLE
SG-2139 - use auto instead of scroll for x overflow

### DIFF
--- a/web/themes/custom/sfgovpl/src/sass/components/_video-embed.scss
+++ b/web/themes/custom/sfgovpl/src/sass/components/_video-embed.scss
@@ -60,7 +60,7 @@ $video_height_desktop: 405px;
       }
       .inner {
         height: 100%;
-        overflow: scroll;
+        overflow: auto;
         border: 2px solid $c-grey-3;
         transition: all 0.3s ease-in-out;
         padding: 27px 22px;

--- a/web/themes/custom/sfgovpl/src/sass/node/_node-report.scss
+++ b/web/themes/custom/sfgovpl/src/sass/node/_node-report.scss
@@ -611,7 +611,7 @@
 
   .sfgov-table-wrapper {
     margin-bottom: 50px;
-    overflow-x: scroll;
+    overflow-x: auto;
     overflow-y: hidden;
     background-color: white;
     width: 100%;

--- a/web/themes/custom/sfgovpl/src/sass/node/_node-report.scss
+++ b/web/themes/custom/sfgovpl/src/sass/node/_node-report.scss
@@ -344,7 +344,7 @@
 
     .sfgov-toc-tree {
       flex: 1;
-      overflow: scroll;
+      overflow: auto;
 
       > ol ol {
         display: block;


### PR DESCRIPTION
SG-2139

use `auto` for overflow instead of `scroll` for potentially layout-breaking tables on report pages