### PR TITLE
SG-2127 - external link module config from production

### DIFF
--- a/config/extlink.settings.yml
+++ b/config/extlink.settings.yml
@@ -28,5 +28,7 @@ whitelisted_domains:
   - staging.social.sf.gov
   - social.sf.gov
   - social.staging.dev.sf.gov
+  - www.sf.gov
+  - sf.gov
 links: 'fa fa-external-link'
 mailto: 'fa fa-envelope-o'


### PR DESCRIPTION
Config export from live, updates whitelist domain for `www.sf.gov`