### PR TITLE
feature(forms): merge form.io urls from schema.formio

### DIFF
--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -83,6 +83,17 @@
     }
     Formio.createForm(el, dataSource, options)
       .then(function(form) {
+
+        /**
+         * form.form is the schema object fetched from the dataSource URL.
+         * If this schema came from the platform it should include a "formio"
+         * object that we can merge into the form's Formio instance, which
+         * defines the URLs for submissions and file uploads.
+         */
+        if (form.form.formio instanceof Object) {
+          Object.assign(form.formio, form.form.formio)
+        }
+
         var sfoptions = options.sfoptions || {}
         // perform sfoptions, hide certain elements
         if (sfoptions.hide instanceof Object) {


### PR DESCRIPTION
This is pre-work for using platform-hosted form.io schemas on SF.gov from Drupal. In a nutshell:

After a form is loaded from its data source URL, we look for a `formio` property in the form schema. If it's present and it's an object, we merge its properties into the form's [Formio] instance, which is basically the "controller" class that makes HTTP requests in response to form interactions. Specifically, the `submissionsUrl` and `formUrl` properties of this object determine where submissions are sent and files should be uploaded (respectively).

This will not affect existing forms, but will give us the ability to progressively enhance form schemas served from the platform API so that both submissions and file uploads (not the file contents themselves, but the signed URLs to which files will be uploaded) go through the platform. The default behavior for these forms will be to proxy the underlying API endpoints from `formio.sfgov.org`, but once we have our hooks in we can incrementally move the business logic from formio actions and onto the platform.

### Spec
- Given a form on the platform with slug `my_cool_form` and a data source URL of `https://formio.sfgov.org/some_project/some_form`
- And a platform API endpoint `https://api.sf.gov/forms/{slug}/schema` that looks up the form page by its slug, fetches the schema from its data source URL, and adds the `formio` property with the value:
    ```json
    {
      "formUrl": "https://api.sf.gov/forms/my_cool_form",
      "submissionsUrl": "https://api.sf.gov/forms/my_cool_form/submission"
    }
    ```
- And a Drupal form page with the data source URL `https://api.sf.gov/forms/my_cool_form/schema`
- When Drupal renders the form page
- Then formiojs should render the schema of `https://formio.sfgov.org/some_project/some_form`
- When a file is uploaded
    - Then the form should request file upload URL from `https://api.sf.gov/forms/my_cool_form/storage/azure`
- When the form is submitted
    - Then the form should submit to `https://api.sf.gov/forms/my_cool_form/submission`
    - And the submission should be made to the underlying form via the platform

[Formio]: https://github.com/formio/formio.js/blob/4.19.x/src/Formio.js#L44