### PR TITLE
fix: accessCheck for sfgov_utilities

### DIFF
--- a/web/modules/custom/sfgov_utilities/sfgov_utilities.module
+++ b/web/modules/custom/sfgov_utilities/sfgov_utilities.module
@@ -423,6 +423,7 @@ function sfgov_utilities_cron() {
 
   // Find all tmgmt jobs from the xtm provider and save them with a valid provider.
   $ids = \Drupal::entityQuery('tmgmt_job')
+    ->accessCheck(FALSE)
     ->condition('translator', ['xtm', 'xtm_test'], 'IN')
     ->execute();
   if (!empty($ids)) {


### PR DESCRIPTION
hotfix from prod because of cron error for deprecated method of querying