### PR TITLE
feature: form analytics

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -17,7 +17,10 @@ jobs:
       - run: npm install
 
       - name: lint JavaScript
-        run: npm run lint-js
+        run:
+          echo "::remove-matcher owner=eslint-compact::"
+          npm run lint-js
+
 
       - name: Dangerfile
         run: npx danger ci

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,8 @@
   "[javascript]": {
     "editor.defaultFormatter": "dbaeumer.vscode-eslint",
     "editor.formatOnSave": true,
-    "editor.formatOnSaveMode": "file"
+    "editor.formatOnSaveMode": "file",
+    "editor.insertSpaces": true,
+    "editor.tabSize": 2
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1985,9 +1985,9 @@
       "dev": true
     },
     "node_modules/@types/cors": {
-      "version": "2.8.13",
-      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
-      "integrity": "sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==",
+      "version": "2.8.17",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
+      "integrity": "sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -2340,6 +2340,60 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
+    "node_modules/autoprefixer": {
+      "version": "9.8.8",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.8.tgz",
+      "integrity": "sha512-eM9d/swFopRt5gdJ7jrpCwgvEMIayITpojhkkSMRsFHYuH5bkSQ4p/9qTEHtmNudUZh22Tehu7I6CxAW0IXTKA==",
+      "dev": true,
+      "dependencies": {
+        "browserslist": "^4.12.0",
+        "caniuse-lite": "^1.0.30001109",
+        "normalize-range": "^0.1.2",
+        "num2fraction": "^1.2.2",
+        "picocolors": "^0.2.1",
+        "postcss": "^7.0.32",
+        "postcss-value-parser": "^4.1.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+      }
+    },
+    "node_modules/autoprefixer/node_modules/picocolors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+      "dev": true
+    },
+    "node_modules/autoprefixer/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/autoprefixer/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/babel-code-frame": {
       "version": "6.26.0",
       "dev": true,
@@ -2596,10 +2650,11 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "license": "MIT",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -3481,9 +3536,9 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.2.1.tgz",
-      "integrity": "sha512-ECceEFcAaNRybd3lsGQKas3ZlMVjN3cyWwMP25D2i0zWfyiytVbTpRPa34qrr+FHddtpBVOmq4H/DCv1O0lZRA==",
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.5.tgz",
+      "integrity": "sha512-C5Pn8Wk+1vKBoHghJODM63yk8MvrO9EWZUfkAt5HAqIgPE4/8FF0PEGHXtEd40l223+cE5ABWuPzm38PHFXfMA==",
       "dev": true,
       "dependencies": {
         "@types/cookie": "^0.4.1",
@@ -3494,60 +3549,30 @@
         "cookie": "~0.4.1",
         "cors": "~2.8.5",
         "debug": "~4.3.1",
-        "engine.io-parser": "~5.0.3",
-        "ws": "~8.2.3"
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=10.2.0"
       }
     },
     "node_modules/engine.io-client": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.3.tgz",
-      "integrity": "sha512-9Z0qLB0NIisTRt1DZ/8U2k12RJn8yls/nXMZLn+/N8hANT3TcYjKFKcwbw5zFQiN4NTde3TSY9zb79e1ij6j9Q==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.4.tgz",
+      "integrity": "sha512-GeZeeRjpD2qf49cZQ0Wvh/8NJNfeXkXXcoGh+F77oEAgo9gUHwT1fCRxSNU+YEEaysOJTnsFHmM5oAcPy4ntvQ==",
       "dev": true,
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.11.0",
+        "ws": "~8.17.1",
         "xmlhttprequest-ssl": "~2.0.0"
       }
     },
-    "node_modules/engine.io-client/node_modules/engine.io-parser": {
+    "node_modules/engine.io-parser": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.2.tgz",
       "integrity": "sha512-RcyUFKA93/CXH20l4SoVvzZfrSDMOTUS3bWVpTt2FuFP+XYrL8i8oonHP7WInRyVHXh0n/ORtoeiE1os+8qkSw==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/engine.io-client/node_modules/ws": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/engine.io-parser": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.4.tgz",
-      "integrity": "sha512-+nVFp+5z1E3HcToEnO7ZIj3g+3k9389DvWtvJZz0T6/eOCPIyyxehFcedoYrZQrp0LgQbD9pPXhpMBKMd5QURg==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -4156,8 +4181,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "license": "MIT",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -4889,7 +4915,8 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -5530,6 +5557,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/normalize-url": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
@@ -5690,6 +5726,12 @@
       "bin": {
         "which": "bin/which"
       }
+    },
+    "node_modules/num2fraction": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+      "integrity": "sha512-Y1wZESM7VUThYY+4W+X4ySH2maqcA+p7UR+w8VWNWVAd6lwuXXWz/w/Cz43J/dI2I+PS6wD5N+bJUF+gjWvIqg==",
+      "dev": true
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -6245,8 +6287,9 @@
     },
     "node_modules/prettier-plugin-twig-melody": {
       "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-twig-melody/-/prettier-plugin-twig-melody-0.4.6.tgz",
+      "integrity": "sha512-5/sk+0efzxQ4r4hiZiWVQ6mxqaekeOIbGpwLUUtNjcKpAO4HmWsEzXpCEIdq2GjqrgjuPDlknJaa5g4B5Qx/jg==",
       "dev": true,
-      "license": "Apache 2.0",
       "dependencies": {
         "babel-types": "^6.26.0",
         "melody-extension-core": "^1.7.5",
@@ -6988,27 +7031,32 @@
       }
     },
     "node_modules/socket.io": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.4.tgz",
-      "integrity": "sha512-m3GC94iK9MfIEeIBfbhJs5BqFibMtkRk8ZpKwG2QwxV0m/eEhPIV4ara6XCF1LWNAus7z58RodiZlAH71U3EhQ==",
+      "version": "4.7.5",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.5.tgz",
+      "integrity": "sha512-DmeAkF6cwM9jSfmp6Dr/5/mfMwb5Z5qRrSXLpo3Fq5SqyU8CMF15jIN4ZhfSwu35ksM1qmHZDQ/DK5XTccSTvA==",
       "dev": true,
       "dependencies": {
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
+        "cors": "~2.8.5",
         "debug": "~4.3.2",
-        "engine.io": "~6.2.1",
-        "socket.io-adapter": "~2.4.0",
-        "socket.io-parser": "~4.2.1"
+        "engine.io": "~6.5.2",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=10.2.0"
       }
     },
     "node_modules/socket.io-adapter": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.4.0.tgz",
-      "integrity": "sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg==",
-      "dev": true
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
+      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "~4.3.4",
+        "ws": "~8.17.1"
+      }
     },
     "node_modules/socket.io-client": {
       "version": "4.7.5",
@@ -7410,7 +7458,8 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -7696,16 +7745,16 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -7852,48 +7901,6 @@
         "node": ">= 4.0.0"
       }
     },
-    "web/themes/custom/sfgovpl/node_modules/autoprefixer": {
-      "version": "9.8.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.12.0",
-        "caniuse-lite": "^1.0.30001109",
-        "normalize-range": "^0.1.2",
-        "num2fraction": "^1.2.2",
-        "picocolors": "^0.2.1",
-        "postcss": "^7.0.32",
-        "postcss-value-parser": "^4.1.0"
-      },
-      "bin": {
-        "autoprefixer": "bin/autoprefixer"
-      },
-      "funding": {
-        "type": "tidelift",
-        "url": "https://tidelift.com/funding/github/npm/autoprefixer"
-      }
-    },
-    "web/themes/custom/sfgovpl/node_modules/autoprefixer/node_modules/picocolors": {
-      "version": "0.2.1",
-      "dev": true,
-      "license": "ISC"
-    },
-    "web/themes/custom/sfgovpl/node_modules/autoprefixer/node_modules/postcss": {
-      "version": "7.0.39",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picocolors": "^0.2.1",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      }
-    },
     "web/themes/custom/sfgovpl/node_modules/cliui": {
       "version": "7.0.4",
       "dev": true,
@@ -7911,19 +7918,6 @@
       "engines": {
         "node": ">= 0.6.0"
       }
-    },
-    "web/themes/custom/sfgovpl/node_modules/normalize-range": {
-      "version": "0.1.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "web/themes/custom/sfgovpl/node_modules/num2fraction": {
-      "version": "1.2.2",
-      "dev": true,
-      "license": "MIT"
     },
     "web/themes/custom/sfgovpl/node_modules/postcss-cli": {
       "version": "8.3.1",
@@ -8086,14 +8080,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12"
-      }
-    },
-    "web/themes/custom/sfgovpl/node_modules/source-map": {
-      "version": "0.6.1",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "web/themes/custom/sfgovpl/node_modules/yaml": {
@@ -9350,9 +9336,9 @@
       "dev": true
     },
     "@types/cors": {
-      "version": "2.8.13",
-      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
-      "integrity": "sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==",
+      "version": "2.8.17",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
+      "integrity": "sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -9578,6 +9564,45 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
+    "autoprefixer": {
+      "version": "9.8.8",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.8.tgz",
+      "integrity": "sha512-eM9d/swFopRt5gdJ7jrpCwgvEMIayITpojhkkSMRsFHYuH5bkSQ4p/9qTEHtmNudUZh22Tehu7I6CxAW0IXTKA==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.12.0",
+        "caniuse-lite": "^1.0.30001109",
+        "normalize-range": "^0.1.2",
+        "num2fraction": "^1.2.2",
+        "picocolors": "^0.2.1",
+        "postcss": "^7.0.32",
+        "postcss-value-parser": "^4.1.0"
+      },
+      "dependencies": {
+        "picocolors": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+          "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+          "dev": true
+        },
+        "postcss": {
+          "version": "7.0.39",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+          "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+          "dev": true,
+          "requires": {
+            "picocolors": "^0.2.1",
+            "source-map": "^0.6.1"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "babel-code-frame": {
       "version": "6.26.0",
       "dev": true,
@@ -9771,9 +9796,11 @@
       }
     },
     "braces": {
-      "version": "3.0.2",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "requires": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       }
     },
     "browser-sync": {
@@ -10376,9 +10403,9 @@
       }
     },
     "engine.io": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.2.1.tgz",
-      "integrity": "sha512-ECceEFcAaNRybd3lsGQKas3ZlMVjN3cyWwMP25D2i0zWfyiytVbTpRPa34qrr+FHddtpBVOmq4H/DCv1O0lZRA==",
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.5.tgz",
+      "integrity": "sha512-C5Pn8Wk+1vKBoHghJODM63yk8MvrO9EWZUfkAt5HAqIgPE4/8FF0PEGHXtEd40l223+cE5ABWuPzm38PHFXfMA==",
       "dev": true,
       "requires": {
         "@types/cookie": "^0.4.1",
@@ -10389,42 +10416,27 @@
         "cookie": "~0.4.1",
         "cors": "~2.8.5",
         "debug": "~4.3.1",
-        "engine.io-parser": "~5.0.3",
-        "ws": "~8.2.3"
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1"
       }
     },
     "engine.io-client": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.3.tgz",
-      "integrity": "sha512-9Z0qLB0NIisTRt1DZ/8U2k12RJn8yls/nXMZLn+/N8hANT3TcYjKFKcwbw5zFQiN4NTde3TSY9zb79e1ij6j9Q==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.4.tgz",
+      "integrity": "sha512-GeZeeRjpD2qf49cZQ0Wvh/8NJNfeXkXXcoGh+F77oEAgo9gUHwT1fCRxSNU+YEEaysOJTnsFHmM5oAcPy4ntvQ==",
       "dev": true,
       "requires": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.11.0",
+        "ws": "~8.17.1",
         "xmlhttprequest-ssl": "~2.0.0"
-      },
-      "dependencies": {
-        "engine.io-parser": {
-          "version": "5.2.2",
-          "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.2.tgz",
-          "integrity": "sha512-RcyUFKA93/CXH20l4SoVvzZfrSDMOTUS3bWVpTt2FuFP+XYrL8i8oonHP7WInRyVHXh0n/ORtoeiE1os+8qkSw==",
-          "dev": true
-        },
-        "ws": {
-          "version": "8.11.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-          "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-          "dev": true,
-          "requires": {}
-        }
       }
     },
     "engine.io-parser": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.4.tgz",
-      "integrity": "sha512-+nVFp+5z1E3HcToEnO7ZIj3g+3k9389DvWtvJZz0T6/eOCPIyyxehFcedoYrZQrp0LgQbD9pPXhpMBKMd5QURg==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.2.tgz",
+      "integrity": "sha512-RcyUFKA93/CXH20l4SoVvzZfrSDMOTUS3bWVpTt2FuFP+XYrL8i8oonHP7WInRyVHXh0n/ORtoeiE1os+8qkSw==",
       "dev": true
     },
     "error-ex": {
@@ -10809,7 +10821,9 @@
       }
     },
     "fill-range": {
-      "version": "7.0.1",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -11260,7 +11274,9 @@
       "version": "2.0.2"
     },
     "is-number": {
-      "version": "7.0.0"
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
     "is-number-like": {
       "version": "1.0.8",
@@ -11685,6 +11701,12 @@
     "normalize-path": {
       "version": "3.0.0"
     },
+    "normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "dev": true
+    },
     "normalize-url": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
@@ -11787,6 +11809,12 @@
           }
         }
       }
+    },
+    "num2fraction": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+      "integrity": "sha512-Y1wZESM7VUThYY+4W+X4ySH2maqcA+p7UR+w8VWNWVAd6lwuXXWz/w/Cz43J/dI2I+PS6wD5N+bJUF+gjWvIqg==",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
@@ -12080,6 +12108,8 @@
     },
     "prettier-plugin-twig-melody": {
       "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-twig-melody/-/prettier-plugin-twig-melody-0.4.6.tgz",
+      "integrity": "sha512-5/sk+0efzxQ4r4hiZiWVQ6mxqaekeOIbGpwLUUtNjcKpAO4HmWsEzXpCEIdq2GjqrgjuPDlknJaa5g4B5Qx/jg==",
       "dev": true,
       "requires": {
         "babel-types": "^6.26.0",
@@ -12591,7 +12621,7 @@
         "postcss-reporter": "^7.0.4",
         "postcss-scss": "^4.0.2",
         "prettier": "^2.5.1",
-        "prettier-plugin-twig-melody": "^0.4.6",
+        "prettier-plugin-twig-melody": "0.4.6",
         "purgecss": "^4.1.3",
         "sass-migrator": "^1.5.5",
         "sfgov-design-system": "^2.5.0",
@@ -12610,33 +12640,6 @@
           "version": "1.0.0",
           "dev": true
         },
-        "autoprefixer": {
-          "version": "9.8.8",
-          "dev": true,
-          "requires": {
-            "browserslist": "^4.12.0",
-            "caniuse-lite": "^1.0.30001109",
-            "normalize-range": "^0.1.2",
-            "num2fraction": "^1.2.2",
-            "picocolors": "^0.2.1",
-            "postcss": "^7.0.32",
-            "postcss-value-parser": "^4.1.0"
-          },
-          "dependencies": {
-            "picocolors": {
-              "version": "0.2.1",
-              "dev": true
-            },
-            "postcss": {
-              "version": "7.0.39",
-              "dev": true,
-              "requires": {
-                "picocolors": "^0.2.1",
-                "source-map": "^0.6.1"
-              }
-            }
-          }
-        },
         "cliui": {
           "version": "7.0.4",
           "dev": true,
@@ -12648,14 +12651,6 @@
         },
         "dependency-graph": {
           "version": "0.9.0",
-          "dev": true
-        },
-        "normalize-range": {
-          "version": "0.1.2",
-          "dev": true
-        },
-        "num2fraction": {
-          "version": "1.2.2",
           "dev": true
         },
         "postcss-cli": {
@@ -12757,10 +12752,6 @@
             }
           }
         },
-        "source-map": {
-          "version": "0.6.1",
-          "dev": true
-        },
         "yaml": {
           "version": "1.10.2",
           "dev": true
@@ -12809,24 +12800,29 @@
       "version": "3.0.0"
     },
     "socket.io": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.4.tgz",
-      "integrity": "sha512-m3GC94iK9MfIEeIBfbhJs5BqFibMtkRk8ZpKwG2QwxV0m/eEhPIV4ara6XCF1LWNAus7z58RodiZlAH71U3EhQ==",
+      "version": "4.7.5",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.5.tgz",
+      "integrity": "sha512-DmeAkF6cwM9jSfmp6Dr/5/mfMwb5Z5qRrSXLpo3Fq5SqyU8CMF15jIN4ZhfSwu35ksM1qmHZDQ/DK5XTccSTvA==",
       "dev": true,
       "requires": {
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
+        "cors": "~2.8.5",
         "debug": "~4.3.2",
-        "engine.io": "~6.2.1",
-        "socket.io-adapter": "~2.4.0",
-        "socket.io-parser": "~4.2.1"
+        "engine.io": "~6.5.2",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
       }
     },
     "socket.io-adapter": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.4.0.tgz",
-      "integrity": "sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg==",
-      "dev": true
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
+      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
+      "dev": true,
+      "requires": {
+        "debug": "~4.3.4",
+        "ws": "~8.17.1"
+      }
     },
     "socket.io-client": {
       "version": "4.7.5",
@@ -13092,6 +13088,8 @@
     },
     "to-regex-range": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "requires": {
         "is-number": "^7.0.0"
       }
@@ -13266,9 +13264,9 @@
       "version": "1.0.2"
     },
     "ws": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "dev": true,
       "requires": {}
     },

--- a/web/themes/custom/sfgovpl/.browserslistrc
+++ b/web/themes/custom/sfgovpl/.browserslistrc
@@ -1,3 +1,3 @@
 last 2 versions
-> 1%
+> 0.2%
 ie 11

--- a/web/themes/custom/sfgovpl/.browserslistrc
+++ b/web/themes/custom/sfgovpl/.browserslistrc
@@ -1,3 +1,2 @@
-last 2 versions
-> 0.2%
-ie 11
+# maximize browser compatibility
+> 0%

--- a/web/themes/custom/sfgovpl/babel.config.js
+++ b/web/themes/custom/sfgovpl/babel.config.js
@@ -1,2 +1,4 @@
 module.exports = {
+  extends: '../../../../babel.config.js',
+  comments: false
 }

--- a/web/themes/custom/sfgovpl/sfgovpl.libraries.yml
+++ b/web/themes/custom/sfgovpl/sfgovpl.libraries.yml
@@ -161,3 +161,10 @@ sfgov-data-story:
     - core/jquery
     - core/drupal
     - core/jquery.once
+
+formio-form-page:
+  js:
+    dist/js/formio-form-page.js:
+      attributes:
+        # this needs to be deferred to execute after formiojs
+        defer: true

--- a/web/themes/custom/sfgovpl/src/js/formio-form-page.js
+++ b/web/themes/custom/sfgovpl/src/js/formio-form-page.js
@@ -23,27 +23,28 @@
     .then(form => {
       // include form language in future measurements
       measure({
-        'form.language': form.language
+        'form.language': form.language,
+        'form.page': 0
       })
       measure('load')
 
-      // perform custom action on nextPage event
       form.on('nextPage', event => {
-        measure('nextPage', { page: event.page })
+        measure('nextPage')
+        measure({ 'form.page': event.page })
+      })
+      form.on('prevPage', event => {
+        measure('prevPage')
+        measure({ 'form.page': event.page })
       })
 
-      form.on('prevPage', event => {
-        measure('prevPage', { page: event.page })
+      form.on('saveDraft', submission => {
+        measure('saveDraft')
       })
 
       form.on('submit', (submission, saved) => {
         measure('submit', {
           'submission.state': submission.state
         })
-      })
-
-      form.on('saveDraft', submission => {
-        measure('saveDraft')
       })
 
       // What to do when the submit begins.

--- a/web/themes/custom/sfgovpl/src/js/formio-form-page.js
+++ b/web/themes/custom/sfgovpl/src/js/formio-form-page.js
@@ -1,0 +1,238 @@
+/* eslint brace-style: ['error', '1tbs'] */
+;(function () { // eslint-disable-line no-extra-semi
+  const el = document.querySelector('[id^="formio-"]')
+  const confirmationURL = el.getAttribute('data-confirmation-url')
+  const options = safeJSONParse(el.getAttribute('data-options')) || {}
+  options.i18n = safeJSONParse(el.getAttribute('data-translations')) || {}
+
+  let url = el.getAttribute('data-source')
+  const params = new URL(location).searchParams
+  const submissionId = params.get('submission')
+  if (submissionId) {
+    url += `/submission/${submissionId}`
+  }
+
+  // set these vars for all future measurements
+  measure({
+    'form.url': url
+  })
+  measure('create')
+
+  // eslint-disable-next-line no-undef
+  Formio.createForm(el, url, options)
+    .then(form => {
+      // include form language in future measurements
+      measure({
+        'form.language': form.language
+      })
+      measure('load')
+
+      const sfoptions = options.sfoptions || {}
+      // perform sfoptions, hide certain elements
+      if (sfoptions.hide instanceof Object) {
+        customHideElements(sfoptions.hide)
+      }
+      // add css class to element(by id)
+      if (sfoptions.addClass) {
+        customAddCssClassById(sfoptions.addClass)
+      }
+      // if cookies are defined, populate the form field with cookie value.
+      if (sfoptions.cookies) {
+        manageFormCookies(sfoptions.cookies, form, true)
+      }
+
+      // perform custom action on nextPage event
+      form.on('nextPage', event => {
+        measure('nextPage', { page: event.page })
+        // set form cookies, if there are any
+        if (sfoptions.cookies) {
+          manageFormCookies(sfoptions.cookies, form, false)
+        }
+      })
+
+      form.on('prevPage', event => {
+        measure('prevPage', { page: event.page })
+      })
+
+      form.on('submit', (submission, saved) => {
+        measure('submit', {
+          'submission.state': submission.state
+        })
+      })
+
+      form.on('saveDraft', submission => {
+        measure('saveDraft')
+      })
+
+      // What to do when the submit begins.
+      form.on('submitDone', submission => {
+        measure('submitDone')
+        // custom options defined in Form.io render options field
+        if (options.redirects instanceof Object) {
+          if (sfoptions.hide instanceof Object) {
+            customHideElements(sfoptions.hide)
+          }
+          for (const key in options.redirects) {
+            const value = options.redirects[key]
+            // only one "redirect" should be "yes", this is set in the form.io form
+            if (submission.data[key] === 'yes') {
+              measure('redirect', {
+                reason: 'sfoptions.redirects',
+                url: value
+              })
+              window.location = value
+              break
+            }
+          }
+        }
+
+        // we want to navigate to the confirmation page only on final submission.
+        // saving a draft also triggers the submitDone event, but we want to keep
+        // the user on the current page in that case.
+        if (confirmationURL && submission.state !== 'draft') {
+          const formLanguageMap = {
+            zh: 'zh-hant',
+            'zh-TW': 'zh-hant'
+          }
+          // see: <https://github.com/formio/formio.js/pull/3592> for more details
+          let lang = form.language
+          lang = formLanguageMap[lang] || lang
+          const actualUrl = lang && lang !== 'en'
+            ? confirmationURL.replace('{lang}', lang)
+            : confirmationURL.replace('{lang}/', '')
+          measure('redirect', {
+            reason: 'confirmation',
+            url: actualUrl
+          })
+          window.location = actualUrl
+        }
+      })
+
+      form.onAny((type, error) => {
+        if (type.match(/error/i)) {
+          measure('error', {
+            errorType: type,
+            message: getErrorMessage(error)
+          })
+        }
+      })
+    })
+    .catch(error => {
+      measure('error', {
+        message: error.message,
+        stack: error.stack
+      })
+    })
+
+  // add an event and/or measurement variables to the GA data layer
+  function measure (event, vars) {
+    if (typeof event === 'object') {
+      vars = event
+    } else if (typeof event === 'string') {
+      vars = Object.assign(
+        { event: `form.${event}` },
+        vars
+      )
+    }
+    console.debug('measure', vars)
+    window.dataLayer.push(vars)
+  }
+
+  function getErrorMessage (error) {
+    return typeof error === 'string'
+      ? error
+      : Array.isArray(error)
+        ? `${error.length} error${(error.length === 1 ? '' : 's')}`
+        : error instanceof Object ? error.message : null
+  }
+
+  function customAddCssClassById (classes) {
+    for (const key in classes) {
+      const el = document.getElementById(key)
+      if (el) {
+        el.classList.add(classes[key])
+      }
+    }
+  }
+
+  function customHideElements (elements) {
+    elements.forEach((klass, index) => {
+      const hide = document.getElementsByClassName(klass)
+      for (let i = 0; i < hide.length; i++) {
+        hide[i].style.display = 'none'
+      }
+    })
+  }
+
+  function setCookie (name, value) {
+    // now + plus 90 days
+    // eslint-disable-next-line no-magic-numbers
+    const expires = 90 * 24 * 3600 * 1000
+    document.cookie = [
+      `${name}=${encodeURIComponent(value)}`,
+      'path=/',
+      `expires=${new Date(Date.now() + expires).toGMTString()}`
+    ].join('; ')
+  }
+
+  function getCookie (name) {
+    const match = document.cookie.match(new RegExp(name + '=([^;]+)'))
+    return match ? decodeURIComponent(match[1]) : null
+  }
+
+  function manageFormCookies (cookies, form, populateAll) {
+    cookies.forEach((item, index) => {
+      let field = document.querySelector(`input[name*="${item}"]`)
+      if (!field) {
+        return
+      }
+      const fieldtype = field.type
+
+      // special type: select, because formio renders select as divs
+      const selectField = document.querySelector(`select[name*="${item}"]`)
+      if (selectField) {
+        field = selectField
+      }
+      if (field || populateAll) {
+        const cookieval = getCookie(item)
+        if (cookieval) {
+          // set submission data, form validation needs this
+          form._submission.data[item] = cookieval
+        }
+
+        if (field) { // populate fields with cookie values
+          if (fieldtype === 'radio' || fieldtype === 'checkbox') {
+            if (cookieval?.includes(field.value)) {
+              field.checked = true
+            }
+          } else {
+            field.value = cookieval
+          }
+        }
+        // XXX: this condition never hits
+        // else if (field) {
+        //   // set cookie for first time
+        //   if (fieldtype === 'radio' || fieldtype === 'checkbox') {
+        //     setCookie(item, field.checked)
+        //   }
+        //   else {
+        //     setCookie(item, field.value)
+        //   }
+        // }
+        // updates cookie if value changed
+        field.addEventListener('change', function () {
+          // console.log(`setting cookie for ${item} with value ${this.value}`)
+          setCookie(item, this.value)
+        })
+      }
+    })
+  }
+
+  function safeJSONParse (str) {
+    try {
+      return JSON.parse(str)
+    } catch (error) {
+      return str
+    }
+  }
+})()

--- a/web/themes/custom/sfgovpl/src/js/formio-form-page.js
+++ b/web/themes/custom/sfgovpl/src/js/formio-form-page.js
@@ -146,6 +146,9 @@
         : error instanceof Object ? error.message : null
   }
 
+  /**
+   * @param {Map<string, string>} classes
+   */
   function customAddCssClassById (classes) {
     for (const key in classes) {
       const el = document.getElementById(key)
@@ -155,15 +158,22 @@
     }
   }
 
-  function customHideElements (elements) {
-    elements.forEach((klass, index) => {
+  /**
+   * @param {string[]} klasses
+   */
+  function customHideElements (klasses) {
+    for (const klass of klasses) {
       const hide = document.getElementsByClassName(klass)
       for (let i = 0; i < hide.length; i++) {
         hide[i].style.display = 'none'
       }
-    })
+    }
   }
 
+  /**
+   * @param {string} name
+   * @param {string} value
+   */
   function setCookie (name, value) {
     // now + plus 90 days
     // eslint-disable-next-line no-magic-numbers
@@ -175,13 +185,17 @@
     ].join('; ')
   }
 
+  /**
+   * @param {string} name
+   * @returns {string?}
+   */
   function getCookie (name) {
     const match = document.cookie.match(new RegExp(name + '=([^;]+)'))
     return match ? decodeURIComponent(match[1]) : null
   }
 
   function manageFormCookies (cookies, form, populateAll) {
-    cookies.forEach((item, index) => {
+    for (const item of cookies) {
       let field = document.querySelector(`input[name*="${item}"]`)
       if (!field) {
         return
@@ -202,14 +216,12 @@
 
         if (field) { // populate fields with cookie values
           if (fieldtype === 'radio' || fieldtype === 'checkbox') {
-            if (cookieval?.includes(field.value)) {
-              field.checked = true
-            }
+            field.checked = cookieval?.includes(field.value)
           } else {
             field.value = cookieval
           }
         }
-        // XXX: this condition never hits
+        /* XXX: this condition never hits */
         // else if (field) {
         //   // set cookie for first time
         //   if (fieldtype === 'radio' || fieldtype === 'checkbox') {
@@ -219,13 +231,14 @@
         //     setCookie(item, field.value)
         //   }
         // }
+
         // updates cookie if value changed
         field.addEventListener('change', function () {
           // console.log(`setting cookie for ${item} with value ${this.value}`)
           setCookie(item, this.value)
         })
       }
-    })
+    }
   }
 
   function safeJSONParse (str) {

--- a/web/themes/custom/sfgovpl/src/js/formio-form-page.js
+++ b/web/themes/custom/sfgovpl/src/js/formio-form-page.js
@@ -27,27 +27,9 @@
       })
       measure('load')
 
-      const sfoptions = options.sfoptions || {}
-      // perform sfoptions, hide certain elements
-      if (sfoptions.hide instanceof Object) {
-        customHideElements(sfoptions.hide)
-      }
-      // add css class to element(by id)
-      if (sfoptions.addClass) {
-        customAddCssClassById(sfoptions.addClass)
-      }
-      // if cookies are defined, populate the form field with cookie value.
-      if (sfoptions.cookies) {
-        manageFormCookies(sfoptions.cookies, form, true)
-      }
-
       // perform custom action on nextPage event
       form.on('nextPage', event => {
         measure('nextPage', { page: event.page })
-        // set form cookies, if there are any
-        if (sfoptions.cookies) {
-          manageFormCookies(sfoptions.cookies, form, false)
-        }
       })
 
       form.on('prevPage', event => {
@@ -67,25 +49,6 @@
       // What to do when the submit begins.
       form.on('submitDone', submission => {
         measure('submitDone')
-        // custom options defined in Form.io render options field
-        if (options.redirects instanceof Object) {
-          if (sfoptions.hide instanceof Object) {
-            customHideElements(sfoptions.hide)
-          }
-          for (const key in options.redirects) {
-            const value = options.redirects[key]
-            // only one "redirect" should be "yes", this is set in the form.io form
-            if (submission.data[key] === 'yes') {
-              measure('redirect', {
-                reason: 'sfoptions.redirects',
-                url: value
-              })
-              window.location = value
-              break
-            }
-          }
-        }
-
         // we want to navigate to the confirmation page only on final submission.
         // saving a draft also triggers the submitDone event, but we want to keep
         // the user on the current page in that case.
@@ -167,101 +130,6 @@
       : Array.isArray(error)
         ? `${error.length} validation error${(error.length === 1 ? '' : 's')}`
         : error instanceof Object ? error.message : null
-  }
-
-  /**
-   * @param {Map<string, string>} classes
-   */
-  function customAddCssClassById (classes) {
-    for (const key in classes) {
-      const el = document.getElementById(key)
-      if (el) {
-        el.classList.add(classes[key])
-      }
-    }
-  }
-
-  /**
-   * @param {string[]} klasses
-   */
-  function customHideElements (klasses) {
-    for (const klass of klasses) {
-      const hide = document.getElementsByClassName(klass)
-      for (let i = 0; i < hide.length; i++) {
-        hide[i].style.display = 'none'
-      }
-    }
-  }
-
-  /**
-   * @param {string} name
-   * @param {string} value
-   */
-  function setCookie (name, value) {
-    // now + plus 90 days
-    // eslint-disable-next-line no-magic-numbers
-    const expires = 90 * 24 * 3600 * 1000
-    document.cookie = [
-      `${name}=${encodeURIComponent(value)}`,
-      'path=/',
-      `expires=${new Date(Date.now() + expires).toGMTString()}`
-    ].join('; ')
-  }
-
-  /**
-   * @param {string} name
-   * @returns {string?}
-   */
-  function getCookie (name) {
-    const match = document.cookie.match(new RegExp(name + '=([^;]+)'))
-    return match ? decodeURIComponent(match[1]) : null
-  }
-
-  function manageFormCookies (cookies, form, populateAll) {
-    for (const item of cookies) {
-      let field = document.querySelector(`input[name*="${item}"]`)
-      if (!field) {
-        return
-      }
-      const fieldtype = field.type
-
-      // special type: select, because formio renders select as divs
-      const selectField = document.querySelector(`select[name*="${item}"]`)
-      if (selectField) {
-        field = selectField
-      }
-      if (field || populateAll) {
-        const cookieval = getCookie(item)
-        if (cookieval) {
-          // set submission data, form validation needs this
-          form._submission.data[item] = cookieval
-        }
-
-        if (field) { // populate fields with cookie values
-          if (fieldtype === 'radio' || fieldtype === 'checkbox') {
-            field.checked = cookieval?.includes(field.value)
-          } else {
-            field.value = cookieval
-          }
-        }
-        /* XXX: this condition never hits */
-        // else if (field) {
-        //   // set cookie for first time
-        //   if (fieldtype === 'radio' || fieldtype === 'checkbox') {
-        //     setCookie(item, field.checked)
-        //   }
-        //   else {
-        //     setCookie(item, field.value)
-        //   }
-        // }
-
-        // updates cookie if value changed
-        field.addEventListener('change', function () {
-          // console.log(`setting cookie for ${item} with value ${this.value}`)
-          setCookie(item, this.value)
-        })
-      }
-    }
   }
 
   function safeJSONParse (str) {

--- a/web/themes/custom/sfgovpl/src/js/formio-form-page.js
+++ b/web/themes/custom/sfgovpl/src/js/formio-form-page.js
@@ -1,6 +1,6 @@
 /* eslint brace-style: ['error', '1tbs'] */
 ;(function () { // eslint-disable-line no-extra-semi
-  const el = document.querySelector('[id^="formio-"]')
+  const el = document.getElementById('formio-form')
   const confirmationURL = el.getAttribute('data-confirmation-url')
   const options = safeJSONParse(el.getAttribute('data-options')) || {}
   options.i18n = safeJSONParse(el.getAttribute('data-translations')) || {}

--- a/web/themes/custom/sfgovpl/src/js/formio-form-page.js
+++ b/web/themes/custom/sfgovpl/src/js/formio-form-page.js
@@ -90,10 +90,14 @@
         if (IGNORE_ERROR_TYPES.includes(subtype)) {
           // do nothing
         } else if (subtype.match(/error/i)) {
-          measure('error', {
-            errorType: type,
-            message: getErrorMessage(event)
-          })
+          if (Array.isArray(event)) {
+            // console.debug('validation errors', event)
+          } else {
+            measure('error', {
+              errorType: type,
+              message: getErrorMessage(event)
+            })
+          }
         }
         /**
          * Uncomment this for local development to see messages for events that

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -39,7 +39,6 @@
  */
 #}
 {{ attach_library('sfgovpl/formio-form-page') }}
-{% set form_id = content.field_formio_data_source['#formio_id']|clean_id %}
 {% set classes = [
   'paragraph--formio',
   'paragraph--formio--view-mode--' ~ view_mode|clean_class,
@@ -48,7 +47,7 @@
 
 {% block paragraph %}
   <div{{ attributes.addClass(classes) }}>
-    <div id="formio-{{ form_id }}"
+    <div id="formio-form"
       data-source="{{ paragraph.field_formio_data_source.value|trim }}"
       data-options="{{ paragraph.field_formio_render_options.value|default('{}')|escape }}"
       data-translations="{{ content.formio_json_data }}"

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -38,10 +38,8 @@
  * @ingroup themeable
  */
 #}
-{% set endpoint = paragraph.field_formio_data_source.value|trim %}
+{{ attach_library('sfgovpl/formio-form-page') }}
 {% set form_id = content.field_formio_data_source['#formio_id']|clean_id %}
-{% set options = paragraph.field_formio_render_options.value|default('{}') %}
-
 {% set classes = [
   'paragraph--formio',
   'paragraph--formio--view-mode--' ~ view_mode|clean_class,
@@ -51,197 +49,14 @@
 {% block paragraph %}
   <div{{ attributes.addClass(classes) }}>
     <div id="formio-{{ form_id }}"
-      data-source="{{- endpoint -}}"
-      data-options="{{ options|escape }}"
+      data-source="{{ paragraph.field_formio_data_source.value|trim }}"
+      data-options="{{ paragraph.field_formio_render_options.value|default('{}')|escape }}"
       data-translations="{{ content.formio_json_data }}"
       data-confirmation-url="{{ paragraph.field_formio_confirmation_url.value|trim }}"
     ></div>
 
-{% block content %}
-<script>
-(function() {
+    {% block content %}
+    {% endblock content %}
 
-  var formLanguageMap = {
-    zh:       'zh-hant',
-    'zh-TW':  'zh-hant'
-  }
-
-  window.addEventListener('load', function() {
-    // keeping this as a DOM for patch.js
-    var el = document.getElementById('formio-{{ form_id }}')
-    var confirmationURL = el.getAttribute('data-confirmation-url')
-    var options = safeJSONParse(el.getAttribute('data-options'))
-    options.i18n = safeJSONParse(el.getAttribute('data-translations'))
-
-    var dataSource = el.getAttribute('data-source')
-    var params = new URL(location).searchParams
-    var submissionId = params.get('submission')
-    if (submissionId) {
-      dataSource += `/submission/${submissionId}`
-    }
-    Formio.createForm(el, dataSource, options)
-      .then(function(form) {
-        var sfoptions = options.sfoptions || {}
-        // perform sfoptions, hide certain elements
-        if (sfoptions.hide instanceof Object) {
-          customHideElements(options.sfoptions.hide)
-        }
-        // add css class to element(by id)
-        if (sfoptions.addClass) {
-          customAddCssClassById(options.sfoptions.addClass)
-        }
-        // if cookies are defined, populate the form field with cookie value.
-        if (sfoptions.cookies) {
-          manageFormCookies(options.sfoptions.cookies, form, true)
-        }
-
-        // perform custom action on nextPage event
-        form.on('nextPage', function() {
-          // set form cookies, if there are any
-          if (options.sfoptions instanceof Object && options.sfoptions.cookies) {
-            manageFormCookies(options.sfoptions.cookies, form, false)
-          }
-        })
-
-        // What to do when the submit begins.
-        form.on('submitDone', function(submission) {
-          // custom options defined in Form.io render options field
-          if (options.redirects instanceof Object) {
-            if (options.sfoptions && options.sfoptions.hide instanceof Object) {
-              customHideElements(options.sfoptions.hide)
-            }
-            for (var key in options.redirects) {
-              var value = options.redirects[key]
-              // only one "redirect" should be "yes", this is set in the form.io form
-              if (submission.data[key] === "yes") {
-                window.location = value
-                break
-              }
-            }
-          }
-
-          // we want to navigate to the confirmation page only on final submission.
-          // saving a draft also triggers the submitDone event, but we want to keep
-          // the user on the current page in that case.
-          if (confirmationURL && submission.state !== 'draft') {
-            // see: <https://github.com/formio/formio.js/pull/3592> for more details
-            var formLang = form.language || form.options.language
-            var lang = formLanguageMap[formLang] || formLang
-            window.location = lang && lang !== 'en'
-              ? confirmationURL.replace('{lang}', lang)
-              : confirmationURL.replace('{lang}/', '')
-          }
-        })
-      })
-      .catch(function(error) {
-        // FIXME: log error somewhere?
-        // amp('form.loadError', {
-        //   url: dataSource,
-        //   error: error
-        // })
-      })
-
-    function getPageTitle(data, form) {
-      if (!form || !form.pages || form.pages.length === 0) {
-        return undefined
-      }
-      var page = form.pages[data.page]
-      return page && page.component
-        ? page.component.title
-        : undefined
-    }
-
-    function customAddCssClassById(classes) {
-      for (var key in classes) {
-        var el = document.getElementById(key)
-        if (el != null) {
-          el.classList.add(classes[key])
-        }
-      }
-    }
-
-    function customHideElements(elements) {
-      elements.forEach(function(klass, index) {
-        var hide = document.getElementsByClassName(klass)
-        for (var i = 0; i < hide.length; i++) {
-          hide[i].style.display = "none"
-        }
-      })
-    }
-
-    function setCookie(name, value) {
-      var today = new Date()
-      var expiry = new Date(today.getTime() + 90 * 24 * 3600 * 1000); // plus 90 days
-      document.cookie=name + "=" + escape(value) + "; path=/; expires=" + expiry.toGMTString()
-    }
-
-    function getCookie(name) {
-      var re = new RegExp(name + "=([^;]+)")
-      var value = re.exec(document.cookie)
-      return (value != null) ? unescape(value[1]) : null
-    }
-
-    function setCheckboxRadioButton(field, cookieval, fieldtype) {
-      if (!cookieval) return
-
-      if (cookieval.includes(field.value)) {
-        field.prop('checked', true)
-      }
-    }
-
-    function manageFormCookies(cookies, form, populateAll) {
-      cookies.forEach(function(item, index) {
-        var field = $('input[name*="'+item+'"]') // use jquery to get dynamic field by name
-        var fieldtype = field.prop('type')
-
-        // special type: select, because formio renders select as divs
-        var selectField = $('select[name*="'+item+'"]')[0]
-        if (selectField) {
-          field = $(selectField) // convert to jQuery object
-        }
-        if (field || populateAll) {
-          var cookieval = getCookie(item)
-          if (cookieval) {
-            // set submission data, form validation needs this
-            form._submission.data[item] = cookieval
-          }
-
-          if (field) { // populate fields with cookie values
-            if (fieldtype !== undefined && (fieldtype === 'radio' || fieldtype === 'checkbox')) {
-              setCheckboxRadioButton(field, cookieval, fieldtype)
-            } else {
-              field.val(cookieval)
-            }
-          } else if (field) {
-            // set cookie for first time
-            if (fieldtype !== undefined && (fieldtype === 'radio' || fieldtype === 'checkbox')) {
-              setCookie(item, field.prop('checked'))
-            } else {
-              setCookie(item, field.val())
-            }
-          } // updates cookie if value changed
-          $(field).change(function() {
-            console.log("setting cookie for " + item + " with value " + this.value)
-            setCookie(item, this.value)
-          })
-        }
-      })
-    }
-
-    function safeJSONParse(str) {
-      var parsed = {}
-      try {
-        parsed = JSON.parse(str)
-      } catch (error) {
-        console.warn('Unable to parse form options:', str)
-      }
-      return parsed
-    }
-  })
-
-})()
-</script>
-{% endblock content %}
-
-</div>
+  </div>
 {% endblock paragraph %}

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -51,7 +51,7 @@
       data-source="{{ paragraph.field_formio_data_source.value|trim }}"
       data-options="{{ paragraph.field_formio_render_options.value|default('{}')|escape }}"
       data-translations="{{ content.formio_json_data }}"
-      data-confirmation-url="{{ paragraph.field_formio_confirmation_url.value|trim }}"
+      data-confirmation-url="{{ paragraph.field_formio_confirmation_url.value|default('')|trim }}"
     ></div>
 
     {% block content %}

--- a/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
+++ b/web/themes/custom/sfgovpl/templates/paragraphs/paragraph--form-io.html.twig
@@ -51,18 +51,15 @@
 {% block paragraph %}
   <div{{ attributes.addClass(classes) }}>
     <div id="formio-{{ form_id }}"
-      data-source="{{- endpoint -}}" data-options="{{ options|escape }}" data-translations="{{ content.formio_json_data }}">
-    </div>
+      data-source="{{- endpoint -}}"
+      data-options="{{ options|escape }}"
+      data-translations="{{ content.formio_json_data }}"
+      data-confirmation-url="{{ paragraph.field_formio_confirmation_url.value|trim }}"
+    ></div>
 
 {% block content %}
 <script>
 (function() {
-
-  var confirmationURL = {{
-    paragraph.field_formio_confirmation_url.value is empty
-      ? "null"
-      : paragraph.field_formio_confirmation_url.value|json_encode(constant('JSON_PRETTY_PRINT'))|raw
-  }}
 
   var formLanguageMap = {
     zh:       'zh-hant',
@@ -72,6 +69,7 @@
   window.addEventListener('load', function() {
     // keeping this as a DOM for patch.js
     var el = document.getElementById('formio-{{ form_id }}')
+    var confirmationURL = el.getAttribute('data-confirmation-url')
     var options = safeJSONParse(el.getAttribute('data-options'))
     options.i18n = safeJSONParse(el.getAttribute('data-translations'))
 


### PR DESCRIPTION
For EPR-1294, this updates the JavaScript on our form pages to send Google Analytics / Tag Manager events (honestly, I still  don't quite understand the distinction). To make this less painful, I've pulled the form initialization out of the page template and into a separate JS file. It's not very legible, but [here's the diff](https://gist.github.com/shawnbot/b49f937e57bffa049b4332ad2a0dbd41) between the JS portion of the template and the new file.

### `measure()`
The `measure()` function, which is local to the form initialization code, supports a couple of different call signatures:

1. `measure('foo')` just sends an event named `form.foo` (the first argument is a string, which gets a `form.` prefix)
2. `measure('foo', { some: 'value' })` sends the event with additional variables (specific to that event)
3. `measure({ other: 'value' })` sets one or more variables that will [persist](https://developers.google.com/tag-platform/tag-manager/datalayer#persist_data_layer_variables) for subsequent `measure()` calls

All of these just append an object to the GA [data layer](https://developers.google.com/tag-platform/tag-manager/datalayer) via `window.dataLayer.push(...)`.

### Variables
The following variables are set on all form measurement events:

* `form.url` is set to the URL of the form schema
* `form.language` is set to the language code of the form, used for translations

### Measurement events
We should start seeing the following events in GTM:

| Event | Trigger | Variables |
| :--- | :--- | :--- |
| <pre>form.create</pre> | Before form is created | |
| <pre>form.load</pre> | After form is loaded | |
| <pre>form.nextPage</pre> | User navigates to the next form page | `page`: the index of the page |
| <pre>form.prevPage</pre> | User navigates to the previous form page | `page`: the index of the page |
| <pre>form.fileUploadStart</pre> | File upload starts | |
| <pre>form.fileUploadEnd</pre> | File upload finishes | |
| <pre>form.submit</pre> | User submits the form | `state`: the submission state; `submission.saved`: boolean indicating if the submission was previously saved |
| <pre>form.submitDone</pre> | Submission finishes successfully | |
| <pre>form.redirect</pre> | Form redirects to another page | `url`: where it's redirecting; `reason`: `confirmation` or `sfoptions.redirects`
| <pre>form.error</pre> | Form fails to initialize | `message`: the error message; `stack`: the stack trace |

### Other changes
- I fixed up the theme's babel config so that it inherits the settings from the repo root, which gives us [babel-preset-env](https://babeljs.io/docs/babel-preset-env) magic ✨ 
- I updated the babel config in the theme to remove comments from the generated files
- I tweaked our `.browserslistrc` to expand our browser compatibility coverage from [84.9%](https://browsersl.ist/#q=last+2+versions%0A%3E+1%25%0Aie+11%0A) to [91.5%](https://browsersl.ist/#q=last+2+versions%0A%3E+0.2%25%0Aie+11%0A) globally

Changes to the root `package-lock.json` are the result of running `npm audit fix`.
