### PR TITLE
fix: set site "mail" setting to noreply@sfgov.org

### DIFF
--- a/config/system.site.yml
+++ b/config/system.site.yml
@@ -3,7 +3,7 @@ _core:
 langcode: en
 uuid: 3babad38-e3d2-427a-8263-5df1d347665a
 name: 'San Francisco'
-mail: joshua.chou@sfgov.org
+mail: noreply@sfgov.org
 slogan: ''
 page:
   403: ''


### PR DESCRIPTION
I noticed in the [site settings](https://www.sf.gov/admin/config/system/site-information) that the site's default "from" address is set to Josh's email. This changes it to `noreply@sfgov.org`. I've noticed that there are a couple of [other addresses](https://github.com/search?q=repo%3ASFDigitalServices%2Fsfgov%20%40sfgov.org&type=code) that we may want to look at, too (but not in this PR).

