### PR TITLE
bugfix(CMS-349): Add missing field to API and make API more resilliant

### DIFF
--- a/web/modules/custom/sfgov_api/src/Payload/PayloadBase.php
+++ b/web/modules/custom/sfgov_api/src/Payload/PayloadBase.php
@@ -143,7 +143,7 @@ abstract class PayloadBase {
         'title' => $entity->label(),
         'translations' => array_keys($entity->getTranslationLanguages()),
         'wag_bundle' => $this->wagBundle,
-        'published' => $entity->isPublished(),
+        'published' => method_exists($entity, 'isPublished') ? $entity->isPublished() : null,
         'created' => $this->convertTimestampToFormat($entity->getCreatedTime(), 'Y-m-d\TH:i:s'),
       ];
     }

--- a/web/modules/custom/sfgov_api/src/Plugin/SfgApi/Paragraph/Button.php
+++ b/web/modules/custom/sfgov_api/src/Plugin/SfgApi/Paragraph/Button.php
@@ -25,15 +25,24 @@ class Button extends SfgApiParagraphBase {
    * {@inheritDoc}
    */
   public function setCustomData($entity) {
+    $link_data = $entity->get('field_link')->getvalue();
+    $link_label = $link_data ? $link_data[0]['options']['attributes']['aria-label'] : '';
+
     // This is the shape wagtail expects when the button is empty.
-    $empty_button = [
+    $button_value = [
       'url' => '',
       'page' => NULL,
       'link_to' => '',
       'link_text' => '',
+      'screenreader_label' => '',
     ];
-    $button_data = $this->generateLinks($entity->get('field_link')->getvalue());
-    $button_value = $button_data ? $button_data[0] : $empty_button;
+    $button_data = $this->generateLinks($link_data);
+
+    if ($button_data) {
+      $button_value = $button_data[0];
+      $button_value['value']['screenreader_label'] = $link_label;
+    }
+
     return [
       'alter' => 'flatten_link',
       'link' => $button_value,


### PR DESCRIPTION
## Description

- Add in screen reader field for text buttons to API so the field can be migrated
- Add in a check for the isPublished flag as not all nodes seem to have that information

## Ticket

https://sfgovdt.jira.com/browse/CMS-349