### PR TITLE
fix: don't do our own front page thing

### DIFF
--- a/web/themes/custom/sfgovpl/templates/layout/html.html.twig
+++ b/web/themes/custom/sfgovpl/templates/layout/html.html.twig
@@ -24,7 +24,6 @@
  */
 #}
 {# Root path (used below) will not be true for revisions and inline diffs. #}
-{% set is_front = (node.id() == 2) ? true : false %}
 
 {%
   set body_classes = [


### PR DESCRIPTION
applies css classes to the front page, ignoring node id