### PR TITLE
CMS-697: Add the direct and indirect URL as a part of the payload for the Drupal API

### DIFF
--- a/web/modules/custom/sfgov_api/src/Plugin/SfgApi/Media/File.php
+++ b/web/modules/custom/sfgov_api/src/Plugin/SfgApi/Media/File.php
@@ -25,9 +25,13 @@ class File extends SfgApiMediaBase {
    * {@inheritDoc}
    */
   public function setCustomData($entity) {
+    $referenced_file = $entity->get('field_media_file')->referencedEntities()[0];
+    $drupal_direct_url = isset($referenced_file) ? $referenced_file->createFileUrl() : NULL;
     $custom_data = [
       'description' => $entity->get('field_description')->value ?: '',
       'published_date' => $entity->get('field_published_date')->value ?: NULL,
+      'drupal_indirect_url' => $entity->toUrl()->toString(),
+      'drupal_direct_url' => $drupal_direct_url,
     ];
     return $custom_data;
   }


### PR DESCRIPTION
## Description

Step 1:
Make two additional fields available for slurping up via the API: Direct URL to the file and Indirect (node file entity) URL to the file.

### Payload Before

https://www.sf.gov/sfgov-api-viewer/entity/mix/en/media/file/173

```json
{
    "title": "Social Distancing Flyer in English",
    "file": "/mnt/drupal-file/2020-03/3.11.20_Social_MultiLang_ENG.pdf",
    "fid": "243",
    "published": true,
    "alt_text": "",
    "description": "<p>Follow these recommendations from the San Francisco Department of Public Health to help reduce the spread of coronavirus (COVID-19) in the community.</p>\r\n",
    "published_date": "2020-03-13"
  },
```

### Payload After

```json
{
    "title": "Social Distancing Flyer in English",
    "file": "/app/web/sites/default/files/2020-03/3.11.20_Social_MultiLang_ENG.pdf",
    "fid": "243",
    "published": true,
    "alt_text": "",
    "description": "<p>Follow these recommendations from the San Francisco Department of Public Health to help reduce the spread of coronavirus (COVID-19) in the community.</p>\r\n",
    "published_date": "2020-03-13",
    "drupal_indirect_url": "/media/173",
    "drupal_direct_url": "/sites/default/files/2020-03/3.11.20_Social_MultiLang_ENG.pdf"
  },
```

## Ticket
* https://sfgovdt.jira.com/browse/CMS-697