### PR TITLE
CMS-697: Add direct and indirect path for media_image

### DIFF
--- a/web/modules/custom/sfgov_api/src/Plugin/SfgApi/Media/File.php
+++ b/web/modules/custom/sfgov_api/src/Plugin/SfgApi/Media/File.php
@@ -30,8 +30,8 @@ class File extends SfgApiMediaBase {
     $custom_data = [
       'description' => $entity->get('field_description')->value ?: '',
       'published_date' => $entity->get('field_published_date')->value ?: NULL,
-      'drupal_indirect_url' => $entity->toUrl()->toString(),
-      'drupal_direct_url' => $drupal_direct_url,
+      'drupal_indirect_path' => $entity->toUrl()->toString(),
+      'drupal_direct_path' => $drupal_direct_url,
     ];
     return $custom_data;
   }

--- a/web/modules/custom/sfgov_api/src/Plugin/SfgApi/Media/Image.php
+++ b/web/modules/custom/sfgov_api/src/Plugin/SfgApi/Media/Image.php
@@ -21,8 +21,12 @@ class Image extends SfgApiMediaBase {
    * {@inheritDoc}
    */
   public function setCustomData($entity) {
-
-    $custom_data = [];
+    $referenced_file = $entity->get('field_media_image')->referencedEntities()[0];
+    $drupal_direct_path = isset($referenced_file) ? $referenced_file->createFileUrl() : NULL;
+    $custom_data = [
+      'drupal_indirect_path' => $entity->toUrl()->toString(),
+      'drupal_direct_path' => $drupal_direct_path,
+    ];
     return $custom_data;
   }
 


### PR DESCRIPTION
## Description

Add `drupal_indirect_path` and `drupal_direct_path` properties for media image serialization, too. Also changed media file to be in line as well.

## Ticket

https://sfgovdt.jira.com/browse/CMS-697